### PR TITLE
Handle Scala 3 macro expressions

### DIFF
--- a/corpus/scala3.txt
+++ b/corpus/scala3.txt
@@ -1,0 +1,23 @@
+===================================
+Macro expressions
+===================================
+
+def string(arg: Int) = 
+  ${ '{ ${ yesh('arg) } } }
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (macro_splice_expression
+      (macro_quote_expression
+        (macro_splice_expression
+          (call_expression
+            (identifier)
+            (arguments
+              (symbol_literal))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -528,6 +528,8 @@ module.exports = grammar({
     // Expressions
 
     expression: $ => choice(
+      $.macro_splice_expression,
+      $.macro_quote_expression,
       $.if_expression,
       $.match_expression,
       $.try_expression,
@@ -554,6 +556,16 @@ module.exports = grammar({
       $.while_expression,
       $.do_while_expression,
       $.for_expression,
+    ),
+    macro_quote_expression: $=> seq(
+      "'{",
+        $.expression,
+      "}"
+    ),
+    macro_splice_expression: $=> seq(
+      "${",
+        $.expression,
+      "}"
     ),
 
     if_expression: $ => prec.right(seq(
@@ -770,10 +782,11 @@ module.exports = grammar({
       )),
       '\''
     )),
-
+    // https://www.scala-lang.org/files/archive/spec/2.13/01-lexical-syntax.html#symbol-literals
     symbol_literal: $ => token(seq(
       "'",
-      repeat1(/[^\\'\n]/)
+      /[^\{\'\n]/,
+      /[a-zA-Z_]*/
     )),
 
     interpolated_string_expression: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2759,6 +2759,14 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "macro_splice_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_quote_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "if_expression"
         },
         {
@@ -2860,6 +2868,40 @@
         {
           "type": "SYMBOL",
           "name": "for_expression"
+        }
+      ]
+    },
+    "macro_quote_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'{"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "macro_splice_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "${"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },
@@ -3963,11 +4005,12 @@
             "value": "'"
           },
           {
-            "type": "REPEAT1",
-            "content": {
-              "type": "PATTERN",
-              "value": "[^\\\\'\\n]"
-            }
+            "type": "PATTERN",
+            "value": "[^\\{\\'\\n]"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[a-zA-Z_]*"
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -208,6 +208,14 @@
         "named": true
       },
       {
+        "type": "macro_quote_expression",
+        "named": true
+      },
+      {
+        "type": "macro_splice_expression",
+        "named": true
+      },
+      {
         "type": "match_expression",
         "named": true
       },
@@ -2123,6 +2131,36 @@
     }
   },
   {
+    "type": "macro_quote_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "macro_splice_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "match_expression",
     "named": true,
     "fields": {
@@ -3580,6 +3618,14 @@
   },
   {
     "type": "$",
+    "named": false
+  },
+  {
+    "type": "${",
+    "named": false
+  },
+  {
+    "type": "'{",
     "named": false
   },
   {


### PR DESCRIPTION
At this third PR I'm starting to think I should've merged them all in one because of PR conflicts :-/

- This adds very basic support for `'{` and '${' quote/splice expressions
- Also fortify symbol literal definition to both avoid ambiguity with `'{` but also to follow the spec