### PR TITLE
Handle backquoted identifiers

### DIFF
--- a/corpus/identifiers.txt
+++ b/corpus/identifiers.txt
@@ -1,0 +1,22 @@
+===================================
+ Backquoted identifiers
+ ===================================
+
+ object Main {
+   val `test-this` = 1
+
+   `my!object`.`method-call`(`test-this`)
+ }
+
+ ---
+
+ (compilation_unit
+   (object_definition (identifier) (template_body
+     (val_definition
+       (identifier) (integer_literal))
+     (call_expression 
+       (field_expression (identifier) (identifier))
+       (arguments (identifier))
+     )
+   )))
+

--- a/grammar.js
+++ b/grammar.js
@@ -59,7 +59,7 @@ module.exports = grammar({
     [$.binding, $.expression],
   ],
 
-  word: $ => $.identifier,
+  word: $ => $._plainid,
 
   rules: {
     compilation_unit: $ => repeat($._top_level_definition),
@@ -708,7 +708,9 @@ module.exports = grammar({
     ),
 
     // TODO: Include operators.
-    identifier: $ => /[a-zA-Z_]\w*/,
+    _plainid: $ => /[a-zA-Z_]\w*/,
+    _backquoted_id: $=> /`[^\n`]+`/,
+    identifier: $ => choice($._plainid, $._backquoted_id),
 
     wildcard: $ => '_',
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,6 @@
 {
   "name": "scala",
-  "word": "identifier",
+  "word": "_plainid",
   "rules": {
     "compilation_unit": {
       "type": "REPEAT",
@@ -3746,9 +3746,26 @@
         }
       ]
     },
-    "identifier": {
+    "_plainid": {
       "type": "PATTERN",
       "value": "[a-zA-Z_]\\w*"
+    },
+    "_backquoted_id": {
+      "type": "PATTERN",
+      "value": "`[^\\n`]+`"
+    },
+    "identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_plainid"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_backquoted_id"
+        }
+      ]
     },
     "wildcard": {
       "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1675,6 +1675,11 @@
     }
   },
   {
+    "type": "identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "if_expression",
     "named": true,
     "fields": {
@@ -3057,6 +3062,11 @@
     }
   },
   {
+    "type": "type_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "type_parameters",
     "named": true,
     "fields": {
@@ -3781,10 +3791,6 @@
     "named": false
   },
   {
-    "type": "identifier",
-    "named": true
-  },
-  {
     "type": "if",
     "named": false
   },
@@ -3871,10 +3877,6 @@
   {
     "type": "type",
     "named": false
-  },
-  {
-    "type": "type_identifier",
-    "named": true
   },
   {
     "type": "val",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Admittedly, this doesn't make the identifier grammar any more complete (according to EBNF), but it fixes the "infinite recursion of doom"

![image](https://user-images.githubusercontent.com/1052965/172361046-56fade9a-da20-4016-8a2e-6b7dcc4ec042.png)

(To see it for yourself, open this file: https://github.com/VirtusLab/scala-cli/blob/main/build.sc)

With this patch, all is great in the world again: 

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/1052965/172361282-9226348e-c0dc-4e07-a706-fc698045137c.png">

And the backquoted identifiers are highlighted beautifully.
