### PR TITLE
Optional braces, part 1

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -16,6 +16,39 @@ package c {
       (object_definition (identifier)))))
 
 ================================
+Package (Scala 3 syntax)
+================================
+
+package a.b
+package c:
+  object A
+
+---
+
+(compilation_unit
+  (package_clause (package_identifier (identifier) (identifier)))
+  (package_clause (package_identifier (identifier))
+    (template_body
+      (object_definition (identifier)))))
+
+================================
+Package (Scala 3 syntax with end)
+================================
+
+package a.b
+package c:
+  object A
+end c
+
+---
+
+(compilation_unit
+  (package_clause (package_identifier (identifier) (identifier)))
+  (package_clause (package_identifier (identifier))
+    (template_body
+      (object_definition (identifier)))))
+
+================================
 Package object
 ================================
 
@@ -323,6 +356,23 @@ class A {
         (identifier)
         (identifier)
         (type_identifier))
+      (val_declaration
+        (identifier)
+        (type_identifier)))))
+
+=======================================
+Value declarations (Scala 3 syntax)
+=======================================
+
+class A:
+  val b: String
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
       (val_declaration
         (identifier)
         (type_identifier)))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -963,29 +963,80 @@
       ]
     },
     "template_body": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "{"
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ":"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_block"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_end_signifier"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_block"
+              "type": "STRING",
+              "value": "{"
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
         }
       ]
+    },
+    "_end_signifier": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "end"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_end_identifier"
+          }
+        ]
+      }
     },
     "annotation": {
       "type": "PREC_RIGHT",
@@ -3749,6 +3800,10 @@
     "identifier": {
       "type": "PATTERN",
       "value": "[a-zA-Z_]\\w*"
+    },
+    "_end_identifier": {
+      "type": "PATTERN",
+      "value": "(end)?[a-zA-Z_]\\w*"
     },
     "wildcard": {
       "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3753,6 +3753,10 @@
     "named": false
   },
   {
+    "type": "end",
+    "named": false
+  },
+  {
     "type": "extends",
     "named": false
   },


### PR DESCRIPTION
Problem
-------
Currently Scala 3 optional braces syntax does not work.

Solution
--------
This implements initial attempt on dealing with colon instead of braces.
Note that this does not implement any indent/outdent tracking so the second `val` onwards will not be added in `template_body` but it should improve the highlighting a bit.

Demo
------
Here's a demonstration of before and after using Sonokai. The theme is a bit too color happy, but it's good for checking what changed:

## Before
<img width="814" alt="sonokai_main_before" src="https://user-images.githubusercontent.com/184683/207691436-93e7af86-b8db-4435-adde-2f3e5fcf1033.png">

**Note**: `def run` is not recognized as a method.

## After
<img width="812" alt="sonokai_main_after" src="https://user-images.githubusercontent.com/184683/207691466-8b603350-99b4-4139-b730-87263114883b.png">
