### PR TITLE
Optional braces, part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - run: npm install
-      - run: npm test
+      - shell: bash
+        run: |
+          gcc test/test-stack.c -o a.out
+          a.out
+          npm install
+          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
       - shell: bash
         run: |
           gcc test/test-stack.c -o a.out
-          a.out
+          ./a.out
           npm install
           npm test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 Cargo.lock
 .scalafmt.conf
 *worksheet.sc
+*.out

--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -16,6 +16,39 @@ package c {
       (object_definition (identifier)))))
 
 ================================
+Package (Scala 3 syntax)
+================================
+
+package a.b
+package c:
+  object A
+
+---
+
+(compilation_unit
+  (package_clause (package_identifier (identifier) (identifier)))
+  (package_clause (package_identifier (identifier))
+    (template_body
+      (object_definition (identifier)))))
+
+================================
+Package (Scala 3 syntax with end)
+================================
+
+package a.b
+package c:
+  object A
+end c
+
+---
+
+(compilation_unit
+  (package_clause (package_identifier (identifier) (identifier)))
+  (package_clause (package_identifier (identifier))
+    (template_body
+      (object_definition (identifier)))))
+
+================================
 Package object
 ================================
 
@@ -323,6 +356,23 @@ class A {
         (identifier)
         (identifier)
         (type_identifier))
+      (val_declaration
+        (identifier)
+        (type_identifier)))))
+
+=======================================
+Value declarations (Scala 3 syntax)
+=======================================
+
+class A:
+  val b: String
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
       (val_declaration
         (identifier)
         (type_identifier)))))

--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -23,27 +23,18 @@ package a.b
 package c:
   object A
 
+package d:
+  object A
+end d
+
 ---
 
 (compilation_unit
   (package_clause (package_identifier (identifier) (identifier)))
   (package_clause (package_identifier (identifier))
     (template_body
-      (object_definition (identifier)))))
+      (object_definition (identifier))))
 
-================================
-Package (Scala 3 syntax with end)
-================================
-
-package a.b
-package c:
-  object A
-end c
-
----
-
-(compilation_unit
-  (package_clause (package_identifier (identifier) (identifier)))
   (package_clause (package_identifier (identifier))
     (template_body
       (object_definition (identifier)))))
@@ -581,6 +572,32 @@ class A:
         (type_identifier)
         (indented_block
           (val_definition (identifier) (integer_literal)) (val_definition (identifier) (integer_literal)) (infix_expression (identifier) (operator_identifier) (identifier)))))))
+
+=======================================
+Top-level Definitions (Scala 3 syntax)
+=======================================
+
+class A:
+  def a() =
+    ()
+
+def a() = 1
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (parameters)
+        (indented_block
+          (unit)))))
+  (function_definition
+    (identifier)
+    (parameters)
+    (integer_literal)))
 
 =======================================
 Initialization expressions

--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -365,7 +365,8 @@ Value declarations (Scala 3 syntax)
 =======================================
 
 class A:
-  val b: String
+  val b, c : Int
+  val d : String
 
 ---
 
@@ -373,6 +374,10 @@ class A:
   (class_definition
     (identifier)
     (template_body
+      (val_declaration
+        (identifier)
+        (identifier)
+        (type_identifier))
       (val_declaration
         (identifier)
         (type_identifier)))))
@@ -441,6 +446,35 @@ class A {
         (identifier)
         (type_identifier)
         (integer_literal)))))
+
+=======================================
+Variable definitions (Scala 3 syntax)
+=======================================
+
+class A:
+  var b: Int = 1
+  var c: Int =
+    val d = 2
+    d
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (var_definition
+        (identifier)
+        (type_identifier)
+        (integer_literal))
+      (var_definition
+        (identifier)
+        (type_identifier)
+        (indented_block
+          (val_definition
+            (identifier)
+            (integer_literal))
+          (identifier))))))
 
 =======================================
 Type definitions
@@ -523,6 +557,30 @@ class A {
         (identifier)
         (parameters (parameter (identifier) (type_identifier)))
         (parameters (parameter (identifier) (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
+
+=======================================
+Function definitions (Scala 3 syntax)
+=======================================
+
+class A:
+  def foo(c: C): Int =
+    val x = 1
+    val y = 2
+    x + y
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter (identifier) (type_identifier)))
+        (type_identifier)
+        (indented_block
+          (val_definition (identifier) (integer_literal)) (val_definition (identifier) (integer_literal)) (infix_expression (identifier) (operator_identifier) (identifier)))))))
 
 =======================================
 Initialization expressions

--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -525,6 +525,11 @@ class A {
     j
   }
   def h(x: T)(implicit ev: Reads[T])
+
+  def l: Int =
+    1
+
+  def m = ()
 }
 
 ---
@@ -547,7 +552,9 @@ class A {
       (function_declaration
         (identifier)
         (parameters (parameter (identifier) (type_identifier)))
-        (parameters (parameter (identifier) (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
+        (parameters (parameter (identifier) (generic_type (type_identifier) (type_arguments (type_identifier))))))
+      (function_definition (identifier) (type_identifier) (indented_block (integer_literal)))
+      (function_definition (identifier) (unit)))))
 
 =======================================
 Function definitions (Scala 3 syntax)

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -156,6 +156,51 @@ def other() {
         (call_expression (identifier) (arguments))))))
 
 ===============================
+If expressions (Scala 3 syntax)
+===============================
+
+class C:
+  def main() =
+    if a then b()
+    end if
+
+    if
+      val c = false
+      c
+    then
+      d()
+      1
+    else if f then
+      g()
+    else
+      h()
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (parameters)
+        (indented_block
+          (if_expression
+            (identifier)
+            (call_expression (identifier) (arguments)))
+          (if_expression
+            (indented_block
+              (val_definition (identifier) (boolean_literal))
+              (identifier))
+            (indented_block
+              (call_expression (identifier) (arguments))
+              (integer_literal))
+            (if_expression
+              (identifier)
+              (indented_block (call_expression (identifier) (arguments)))
+              (indented_block (call_expression (identifier) (arguments))))))))))
+
+===============================
 Try expressions
 ===============================
 
@@ -436,7 +481,8 @@ object O {
 
 (compilation_unit
   (object_definition (identifier)
-    (template_body (val_definition
+    (template_body
+      (val_definition
         (identifier) (lambda_expression
           (identifier) (infix_expression
             (identifier) (operator_identifier) (integer_literal))))
@@ -447,7 +493,7 @@ object O {
           (block (infix_expression
               (identifier) (operator_identifier) (identifier)))))
       (val_definition (identifier)
-        (lambda_expression (identifier) (integer_literal)))
+        (lambda_expression (wildcard) (integer_literal)))
       (lambda_expression
         (bindings
           (binding (identifier))
@@ -623,9 +669,9 @@ def main() {
       (call_expression
         (field_expression (identifier) (identifier))
         (arguments (infix_expression
-          (identifier) (operator_identifier) (integer_literal))))
+          (wildcard) (operator_identifier) (integer_literal))))
       (call_expression
         (field_expression (identifier) (identifier))
         (arguments (infix_expression
-          (identifier) (operator_identifier) (integer_literal))))
+          (wildcard) (operator_identifier) (integer_literal))))
       (field_expression (identifier) (identifier)))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -648,8 +648,8 @@ While loops
 ===============================
 
 def f = {
-  while(a) g()
-  while(b < c) {
+  while (a) g()
+  while (b < c) {
     d
   }
 }
@@ -666,6 +666,36 @@ def f = {
       (while_expression
         (parenthesized_expression (infix_expression (identifier) (operator_identifier) (identifier)))
         (block (identifier))))))
+
+===============================
+While loops (Scala 3 syntax)
+===============================
+
+def f: Unit =
+  while a do g()
+
+  while
+    val x = 1
+    b < x
+  do
+    ()
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (type_identifier)
+    (indented_block
+      (while_expression
+        (identifier)
+        (call_expression (identifier) (arguments)))
+      (while_expression
+        (indented_block
+          (val_definition (identifier) (integer_literal))
+          (infix_expression (identifier) (operator_identifier) (identifier)))
+        (indented_block
+          (unit))))))
 
 ===============================
 Do-while loops

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -766,6 +766,37 @@ def f() = {
        (block (call_expression (identifier) (arguments (identifier) (identifier))))))))
 
 ===============================
+For comprehensions (Scala 3 syntax)
+===============================
+
+def f(): Unit =
+  for n <- nums yield n + 1
+
+  for
+    x <- xs
+    y <- ys
+  yield
+    g(x, y)
+
+---
+
+(compilation_unit
+ (function_definition
+   (identifier)
+   (parameters)
+   (type_identifier)
+   (indented_block
+     (for_expression
+       (enumerators (enumerator (identifier) (identifier)))
+       (infix_expression (identifier) (operator_identifier) (integer_literal)))
+     (for_expression
+       (enumerators
+         (enumerator (identifier) (identifier))
+         (enumerator (identifier) (identifier)))
+       (indented_block
+         (call_expression (identifier) (arguments (identifier) (identifier))))))))
+
+===============================
 Chained expressions
 ===============================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -356,6 +356,43 @@ def matchTest(x: Int): String = x match {
       (case_clause (wildcard) (val_definition (identifier) (string)) (string))))))
 
 ===============================
+Match expressions (Scala 3 syntax)
+===============================
+
+def matchTest(x: Int): String =
+  x match
+    case 0 =>
+    case 1 => "one"; "uno"
+    case 2 => "two"
+    case x if x == 3 =>
+      val x = "3"
+      x
+    case ((i, _)) => i
+    case _ =>
+      val x = "many"
+      "more"
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters (parameter (identifier) (type_identifier)))
+    (type_identifier)
+    (indented_block
+      (match_expression (identifier) (indented_cases
+        (case_clause (integer_literal))
+        (case_clause (integer_literal) (string) (string))
+        (case_clause (integer_literal) (string))
+        (case_clause
+          (identifier)
+          (guard (infix_expression (identifier) (operator_identifier) (integer_literal)))
+          (val_definition (identifier) (string))
+          (identifier))
+        (case_clause (tuple_pattern (tuple_pattern (identifier) (wildcard))) (identifier))
+        (case_clause (wildcard) (val_definition (identifier) (string)) (string)))))))
+
+===============================
 Field expressions
 ===============================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -266,6 +266,64 @@ def main() {
         (finally_clause (call_expression (identifier) (arguments)))))))
 
 ===============================
+Try expressions (Scala 3 syntax)
+===============================
+
+def main(): Unit =
+  try a() finally depth -= 1
+
+  try
+    a()
+    b()
+  catch
+    case e: SomeException => prinlnt(e.message)
+    case NonFatal(ex)     => throw new SomeException(ex)
+  finally
+    tryAnotherThing()
+    tryAnotherThing2()
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters)
+    (type_identifier)
+    (indented_block
+      (try_expression
+        (call_expression (identifier) (arguments))
+        (finally_clause (infix_expression (identifier) (operator_identifier) (integer_literal))))
+      (try_expression
+        (indented_block
+          (call_expression (identifier) (arguments))
+          (call_expression (identifier) (arguments)))
+        (catch_clause
+          (indented_cases
+            (case_clause
+              (typed_pattern
+                (identifier)
+                (type_identifier))
+              (call_expression
+                (identifier)
+                (arguments (field_expression
+                  (identifier)
+                  (identifier)))))
+            (case_clause
+              (case_class_pattern
+                (type_identifier)
+                (identifier))
+              (throw_expression (instance_expression (call_expression (identifier) (arguments (identifier))))
+              )
+            )
+          )
+        )
+        (finally_clause
+          (indented_block
+            (call_expression (identifier) (arguments))
+            (call_expression (identifier) (arguments)))))
+    )))
+
+===============================
 Match expressions
 ===============================
 

--- a/grammar.js
+++ b/grammar.js
@@ -3,6 +3,7 @@ const PREC = {
   stable_type_id: 2,
   lambda: 2,
   binding_decl: 2,
+  while: 2,
   binding_def: 3,
   assign: 3,
   stable_id: 4,
@@ -62,6 +63,7 @@ module.exports = grammar({
     [$.tuple_type, $.parameter_types],
     [$.binding, $.expression],
     [$.if_expression, $.expression],
+    [$.while_expression, $.expression],
   ],
 
   word: $ => $.identifier,
@@ -905,10 +907,21 @@ module.exports = grammar({
 
     throw_expression: $ => prec.left(seq('throw', $.expression)),
 
-    while_expression: $ => prec.right(seq(
-      'while',
-      field('condition', $.parenthesized_expression),
-      field('body', $.expression)
+    /*
+     *   Expr1             ::=  'while' '(' Expr ')' {nl} Expr
+     *                       |  'while' Expr 'do' Expr
+     */
+    while_expression: $ => prec(PREC.while, choice(
+      prec.right(seq(
+        'while',
+        field('condition', $.parenthesized_expression),
+        field('body', $.expression)
+      )),
+      prec.right(seq(
+        'while',
+        field('condition', seq($._indentable_expression, 'do')),
+        field('body', $._indentable_expression)
+      )),
     )),
 
     do_while_expression: $ => prec.right(seq(

--- a/grammar.js
+++ b/grammar.js
@@ -647,10 +647,13 @@ module.exports = grammar({
       )),
     )),
 
+    /*
+     *   MatchClause       ::=  'match' <<< CaseClauses >>>
+     */
     match_expression: $ => prec.left(PREC.postfix, seq(
       field('value', $.expression),
       'match',
-      field('body', $.case_block)
+      field('body', choice($.case_block, $.indented_cases))
     )),
 
     try_expression: $ => prec.right(PREC.control, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -73,6 +73,7 @@ module.exports = grammar({
       $.package_clause,
       $.package_object,
       $._definition,
+      $._end_marker,
     ),
 
     _definition: $ => choice(
@@ -236,7 +237,6 @@ module.exports = grammar({
         $._indent,
         $._block,
         $._outdent,
-        optional($._end_marker),
       )),
       seq(
         '{',
@@ -248,7 +248,19 @@ module.exports = grammar({
 
     _end_marker: $ => prec.left(PREC.end_marker, seq(
       'end',
-      alias($.identifier, '_end_ident'),
+      choice(
+        'if',
+        'while',
+        'for',
+        'match',
+        'try',
+        'new',
+        'this',
+        'given',
+        'extension',
+        'val',
+        alias($.identifier, '_end_ident'),
+      ),
     )),
 
     annotation: $ => prec.right(seq(
@@ -626,7 +638,6 @@ module.exports = grammar({
         'else',
         field('alternative', $._indentable_expression),
       )),
-      optional(seq('end', 'if')),
     )),
 
     match_expression: $ => prec.left(PREC.postfix, seq(

--- a/grammar.js
+++ b/grammar.js
@@ -33,12 +33,14 @@ module.exports = grammar({
 
   externals: $ => [
     $._automatic_semicolon,
-    $._simple_string,
-    $._simple_multiline_string,
+    $._indent,
     $._interpolated_string_middle,
     $._interpolated_string_end,
     $._interpolated_multiline_string_middle,
     $._interpolated_multiline_string_end,
+    $._outdent,
+    $._simple_multiline_string,
+    $._simple_string,
     'else',
     'catch',
     'finally',

--- a/grammar.js
+++ b/grammar.js
@@ -415,6 +415,7 @@ module.exports = grammar({
 
     _indentable_expression: $ => choice(
       $.indented_block,
+      $.indented_cases,
       $.expression,
     ),
 
@@ -429,6 +430,12 @@ module.exports = grammar({
       $._block,
       $._outdent,
       optional($._end_marker),
+    )),
+
+    indented_cases: $ => prec.left(PREC.end_marker, seq(
+      $._indent,
+      repeat1($.case_clause),
+      $._outdent,
     )),
 
     // ---------------------------------------------------------------
@@ -648,14 +655,17 @@ module.exports = grammar({
 
     try_expression: $ => prec.right(PREC.control, seq(
       'try',
-      field('body', $.expression),
+      field('body', $._indentable_expression),
       optional($.catch_clause),
       optional($.finally_clause)
     )),
 
-    catch_clause: $ => prec.right(seq('catch', $.case_block)),
+    /*
+     *   Catches           ::=  'catch' (Expr | ExprCaseClause)
+     */
+    catch_clause: $ => prec.right(seq('catch', $._indentable_expression)),
 
-    finally_clause: $ => prec.right(seq('finally', $.expression)),
+    finally_clause: $ => prec.right(seq('finally', $._indentable_expression)),
 
     binding: $ => prec.dynamic(PREC.binding_decl, seq(
       field('name', $.identifier),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -23,6 +23,10 @@
         {
           "type": "SYMBOL",
           "name": "_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_marker"
         }
       ]
     },
@@ -361,8 +365,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "=>"
+              "type": "SYMBOL",
+              "name": "_arrow"
             },
             {
               "type": "STRING",
@@ -963,29 +967,126 @@
       ]
     },
     "template_body": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "{"
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ":"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_indent"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_block"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_outdent"
+              }
+            ]
+          }
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_block"
+              "type": "STRING",
+              "value": "{"
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
         }
       ]
+    },
+    "_end_marker": {
+      "type": "PREC_LEFT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "end"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "if"
+              },
+              {
+                "type": "STRING",
+                "value": "while"
+              },
+              {
+                "type": "STRING",
+                "value": "for"
+              },
+              {
+                "type": "STRING",
+                "value": "match"
+              },
+              {
+                "type": "STRING",
+                "value": "try"
+              },
+              {
+                "type": "STRING",
+                "value": "new"
+              },
+              {
+                "type": "STRING",
+                "value": "this"
+              },
+              {
+                "type": "STRING",
+                "value": "given"
+              },
+              {
+                "type": "STRING",
+                "value": "extension"
+              },
+              {
+                "type": "STRING",
+                "value": "val"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                "named": false,
+                "value": "_end_ident"
+              }
+            ]
+          }
+        ]
+      }
     },
     "annotation": {
       "type": "PREC_RIGHT",
@@ -1021,7 +1122,7 @@
     },
     "val_definition": {
       "type": "PREC",
-      "value": 2,
+      "value": 3,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1071,7 +1172,7 @@
             "name": "value",
             "content": {
               "type": "SYMBOL",
-              "name": "expression"
+              "name": "_indentable_expression"
             }
           }
         ]
@@ -1079,7 +1180,7 @@
     },
     "val_declaration": {
       "type": "PREC",
-      "value": 1,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1165,7 +1266,7 @@
     },
     "var_declaration": {
       "type": "PREC",
-      "value": 1,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1223,7 +1324,7 @@
     },
     "var_definition": {
       "type": "PREC",
-      "value": 2,
+      "value": 3,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1273,7 +1374,7 @@
             "name": "value",
             "content": {
               "type": "SYMBOL",
-              "name": "expression"
+              "name": "_indentable_expression"
             }
           }
         ]
@@ -1481,7 +1582,7 @@
                   "name": "body",
                   "content": {
                     "type": "SYMBOL",
-                    "name": "expression"
+                    "name": "_indentable_expression"
                   }
                 }
               ]
@@ -2031,6 +2132,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "_definition"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_end_marker"
                   }
                 ]
               },
@@ -2053,6 +2158,10 @@
                         {
                           "type": "SYMBOL",
                           "name": "_definition"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_end_marker"
                         }
                       ]
                     }
@@ -2075,6 +2184,23 @@
           }
         ]
       }
+    },
+    "_indentable_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "indented_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "indented_cases"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        }
+      ]
     },
     "block": {
       "type": "SEQ",
@@ -2100,6 +2226,63 @@
           "value": "}"
         }
       ]
+    },
+    "indented_block": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_indent"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_block"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_outdent"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_end_marker"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "indented_cases": {
+      "type": "PREC_LEFT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_indent"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "case_clause"
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_outdent"
+          }
+        ]
+      }
     },
     "_type": {
       "type": "CHOICE",
@@ -2169,7 +2352,7 @@
     },
     "compound_type": {
       "type": "PREC",
-      "value": 6,
+      "value": 7,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2206,7 +2389,7 @@
     },
     "infix_type": {
       "type": "PREC_LEFT",
-      "value": 5,
+      "value": 6,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2312,7 +2495,7 @@
     },
     "stable_type_identifier": {
       "type": "PREC_LEFT",
-      "value": 1,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2342,7 +2525,7 @@
     },
     "stable_identifier": {
       "type": "PREC_LEFT",
-      "value": 3,
+      "value": 4,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2431,8 +2614,8 @@
             }
           },
           {
-            "type": "STRING",
-            "value": "=>"
+            "type": "SYMBOL",
+            "name": "_arrow"
           },
           {
             "type": "FIELD",
@@ -2537,8 +2720,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "=>"
+          "type": "SYMBOL",
+          "name": "_arrow"
         },
         {
           "type": "FIELD",
@@ -2690,7 +2873,7 @@
     },
     "infix_pattern": {
       "type": "PREC_LEFT",
-      "value": 5,
+      "value": 6,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2732,7 +2915,7 @@
     },
     "capture_pattern": {
       "type": "PREC",
-      "value": 7,
+      "value": 8,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2863,31 +3046,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "generic_function"
-        },
-        {
-          "type": "SYMBOL",
           "name": "assignment_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "parenthesized_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interpolated_string_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "lambda_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "field_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "instance_expression"
         },
         {
           "type": "SYMBOL",
@@ -2915,22 +3078,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "block"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "unit"
-        },
-        {
-          "type": "SYMBOL",
           "name": "return_expression"
         },
         {
@@ -2948,12 +3095,86 @@
         {
           "type": "SYMBOL",
           "name": "for_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unit"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolated_string_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instance_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "wildcard"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generic_function"
         }
       ]
     },
+    "lambda_expression": {
+      "type": "PREC_RIGHT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "bindings"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "wildcard"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_arrow"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_block"
+          }
+        ]
+      }
+    },
     "if_expression": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2965,8 +3186,26 @@
             "type": "FIELD",
             "name": "condition",
             "content": {
-              "type": "SYMBOL",
-              "name": "parenthesized_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "parenthesized_expression"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_indentable_expression"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "then"
+                    }
+                  ]
+                }
+              ]
             }
           },
           {
@@ -2974,7 +3213,7 @@
             "name": "consequence",
             "content": {
               "type": "SYMBOL",
-              "name": "expression"
+              "name": "_indentable_expression"
             }
           },
           {
@@ -2992,7 +3231,7 @@
                     "name": "alternative",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "expression"
+                      "name": "_indentable_expression"
                     }
                   }
                 ]
@@ -3007,7 +3246,7 @@
     },
     "match_expression": {
       "type": "PREC_LEFT",
-      "value": 4,
+      "value": 5,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3027,8 +3266,17 @@
             "type": "FIELD",
             "name": "body",
             "content": {
-              "type": "SYMBOL",
-              "name": "case_block"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "case_block"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "indented_cases"
+                }
+              ]
             }
           }
         ]
@@ -3036,7 +3284,7 @@
     },
     "try_expression": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3049,7 +3297,7 @@
             "name": "body",
             "content": {
               "type": "SYMBOL",
-              "name": "expression"
+              "name": "_indentable_expression"
             }
           },
           {
@@ -3091,7 +3339,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "case_block"
+            "name": "_indentable_expression"
           }
         ]
       }
@@ -3108,14 +3356,14 @@
           },
           {
             "type": "SYMBOL",
-            "name": "expression"
+            "name": "_indentable_expression"
           }
         ]
       }
     },
     "binding": {
       "type": "PREC_DYNAMIC",
-      "value": 1,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3201,44 +3449,6 @@
         }
       ]
     },
-    "lambda_expression": {
-      "type": "PREC_RIGHT",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "bindings"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "=>"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_block"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
     "case_block": {
       "type": "CHOICE",
       "members": [
@@ -3312,8 +3522,8 @@
             ]
           },
           {
-            "type": "STRING",
-            "value": "=>"
+            "type": "SYMBOL",
+            "name": "_arrow"
           },
           {
             "type": "FIELD",
@@ -3382,7 +3592,7 @@
     },
     "generic_function": {
       "type": "PREC",
-      "value": 7,
+      "value": 8,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3407,7 +3617,7 @@
     },
     "call_expression": {
       "type": "PREC",
-      "value": 7,
+      "value": 8,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3445,7 +3655,7 @@
     },
     "field_expression": {
       "type": "PREC",
-      "value": 7,
+      "value": 8,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3474,7 +3684,7 @@
     },
     "instance_expression": {
       "type": "PREC",
-      "value": 6,
+      "value": 7,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3491,7 +3701,7 @@
     },
     "ascription_expression": {
       "type": "PREC_RIGHT",
-      "value": 3,
+      "value": 4,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3512,7 +3722,7 @@
     },
     "infix_expression": {
       "type": "PREC_LEFT",
-      "value": 5,
+      "value": 6,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3554,7 +3764,7 @@
     },
     "postfix_expression": {
       "type": "PREC_LEFT",
-      "value": 4,
+      "value": 5,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3580,7 +3790,7 @@
     },
     "prefix_expression": {
       "type": "PREC",
-      "value": 6,
+      "value": 7,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3753,6 +3963,10 @@
     "wildcard": {
       "type": "STRING",
       "value": "_"
+    },
+    "_arrow": {
+      "type": "STRING",
+      "value": "=>"
     },
     "operator_identifier": {
       "type": "PATTERN",
@@ -4210,7 +4424,7 @@
     },
     "unit": {
       "type": "PREC",
-      "value": 3,
+      "value": 4,
       "content": {
         "type": "SEQ",
         "members": [
@@ -4268,29 +4482,76 @@
       }
     },
     "while_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
+      "type": "PREC",
+      "value": 2,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "STRING",
-            "value": "while"
-          },
-          {
-            "type": "FIELD",
-            "name": "condition",
+            "type": "PREC_RIGHT",
+            "value": 0,
             "content": {
-              "type": "SYMBOL",
-              "name": "parenthesized_expression"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "while"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "condition",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "parenthesized_expression"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                }
+              ]
             }
           },
           {
-            "type": "FIELD",
-            "name": "body",
+            "type": "PREC_RIGHT",
+            "value": 0,
             "content": {
-              "type": "SYMBOL",
-              "name": "expression"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "while"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "condition",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_indentable_expression"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "do"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_indentable_expression"
+                  }
+                }
+              ]
             }
           }
         ]
@@ -4330,118 +4591,253 @@
       }
     },
     "for_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "for"
-          },
-          {
-            "type": "FIELD",
-            "name": "enumerators",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "("
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "enumerators"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ")"
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "{"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "enumerators"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "}"
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "type": "CHOICE",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_RIGHT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
                 "type": "STRING",
-                "value": "yield"
+                "value": "for"
               },
               {
-                "type": "BLANK"
+                "type": "FIELD",
+                "name": "enumerators",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "enumerators"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "{"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "enumerators"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "body",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "expression"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "yield"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "body",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_indentable_expression"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
-          },
-          {
-            "type": "FIELD",
-            "name": "body",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
           }
-        ]
-      }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "for"
+              },
+              {
+                "type": "FIELD",
+                "name": "enumerators",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "enumerators"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "do"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "body",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_indentable_expression"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "yield"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "body",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_indentable_expression"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
     },
     "enumerators": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "enumerator"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "enumerator"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_semicolon"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "enumerator"
+                      }
+                    ]
+                  }
+                }
+              ]
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_semicolon"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "enumerator"
-                  }
-                ]
-              }
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_automatic_semicolon"
+              "name": "_indent"
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "enumerator"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_semicolon"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "enumerator"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_automatic_semicolon"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_outdent"
             }
           ]
         }
@@ -4542,6 +4938,22 @@
     [
       "binding",
       "expression"
+    ],
+    [
+      "if_expression",
+      "expression"
+    ],
+    [
+      "while_expression",
+      "expression"
+    ],
+    [
+      "for_expression",
+      "infix_expression"
+    ],
+    [
+      "_indentable_expression",
+      "do_while_expression"
     ]
   ],
   "precedences": [],
@@ -4552,11 +4964,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_string"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_simple_multiline_string"
+      "name": "_indent"
     },
     {
       "type": "SYMBOL",
@@ -4573,6 +4981,18 @@
     {
       "type": "SYMBOL",
       "name": "_interpolated_multiline_string_end"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_outdent"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_multiline_string"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_string"
     },
     {
       "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -250,6 +250,10 @@
       {
         "type": "while_expression",
         "named": true
+      },
+      {
+        "type": "wildcard",
+        "named": true
       }
     ]
   },
@@ -671,8 +675,56 @@
             "named": true
           },
           {
+            "type": "_end_ident",
+            "named": false
+          },
+          {
+            "type": "end",
+            "named": false
+          },
+          {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "extension",
+            "named": false
+          },
+          {
+            "type": "for",
+            "named": false
+          },
+          {
+            "type": "given",
+            "named": false
+          },
+          {
+            "type": "if",
+            "named": false
+          },
+          {
+            "type": "match",
+            "named": false
+          },
+          {
+            "type": "new",
+            "named": false
+          },
+          {
+            "type": "this",
+            "named": false
+          },
+          {
+            "type": "try",
+            "named": false
+          },
+          {
+            "type": "val",
+            "named": false
+          },
+          {
+            "type": "while",
+            "named": false
           }
         ]
       },
@@ -707,7 +759,15 @@
       "required": true,
       "types": [
         {
-          "type": "case_block",
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "indented_block",
+          "named": true
+        },
+        {
+          "type": "indented_cases",
           "named": true
         }
       ]
@@ -1284,6 +1344,14 @@
         {
           "type": "expression",
           "named": true
+        },
+        {
+          "type": "indented_block",
+          "named": true
+        },
+        {
+          "type": "indented_cases",
+          "named": true
         }
       ]
     }
@@ -1298,6 +1366,14 @@
         "types": [
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
             "named": true
           }
         ]
@@ -1436,6 +1512,14 @@
         "types": [
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
             "named": true
           }
         ]
@@ -1685,16 +1769,36 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
           }
         ]
       },
       "condition": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
-            "type": "parenthesized_expression",
+            "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
+          },
+          {
+            "type": "then",
+            "named": false
           }
         ]
       },
@@ -1704,6 +1808,14 @@
         "types": [
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
             "named": true
           }
         ]
@@ -1807,6 +1919,40 @@
     "type": "import_wildcard",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "indented_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_definition",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "indented_cases",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "case_clause",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "infix_expression",
@@ -2181,6 +2327,10 @@
         "types": [
           {
             "type": "case_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
             "named": true
           }
         ]
@@ -2831,6 +2981,14 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
           }
         ]
       }
@@ -3372,6 +3530,14 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
           }
         ]
       }
@@ -3526,6 +3692,14 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
           }
         ]
       }
@@ -3604,15 +3778,35 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
+            "named": true
           }
         ]
       },
       "condition": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
-            "type": "parenthesized_expression",
+            "type": "do",
+            "named": false
+          },
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
+          },
+          {
+            "type": "indented_cases",
             "named": true
           }
         ]
@@ -3689,10 +3883,6 @@
     "named": false
   },
   {
-    "type": "=>",
-    "named": false
-  },
-  {
     "type": ">:",
     "named": false
   },
@@ -3710,6 +3900,10 @@
   },
   {
     "type": "_",
+    "named": false
+  },
+  {
+    "type": "_end_ident",
     "named": false
   },
   {
@@ -3753,7 +3947,15 @@
     "named": false
   },
   {
+    "type": "end",
+    "named": false
+  },
+  {
     "type": "extends",
+    "named": false
+  },
+  {
+    "type": "extension",
     "named": false
   },
   {
@@ -3851,6 +4053,14 @@
   {
     "type": "symbol_literal",
     "named": true
+  },
+  {
+    "type": "then",
+    "named": false
+  },
+  {
+    "type": "this",
+    "named": false
   },
   {
     "type": "throw",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -113,8 +113,9 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
     lexer->result_symbol = INDENT;
     return true;
   }
-  if (valid_symbols[OUTDENT] && newline_count > 0 && prev != -1 &&
-      indentation_size < prev) {
+  if (valid_symbols[OUTDENT] &&
+      (lexer->lookahead == 0 || (
+        newline_count > 0 && prev != -1 && indentation_size < prev))) {
     popStack(stack);
     LOG("pop\n");
     lexer->result_symbol = OUTDENT;

--- a/src/stack.h
+++ b/src/stack.h
@@ -16,6 +16,8 @@ typedef struct ScannerStack {
   unsigned int stack[STACK_SIZE];
   int top;
   int last_indentation_size;
+  int last_newline_count;
+  int last_column;
 } ScannerStack;
 
 ScannerStack* createStack() {
@@ -23,6 +25,8 @@ ScannerStack* createStack() {
 
   ptr -> top = 0;
   ptr -> last_indentation_size = -1;
+  ptr -> last_newline_count = 0;
+  ptr -> last_column = -1;
   memset(ptr -> stack, STACK_SIZE, (0));
 
   return ptr;
@@ -60,10 +64,12 @@ void printStack(ScannerStack *stack, char *msg) {
 
 unsigned serialiseStack(ScannerStack *stack, char *buf) {
   unsigned elements = isEmptyStack(stack) ? 0 : stack->top;
-  unsigned result_length = (elements + 1) * sizeof(int);
+  unsigned result_length = (elements + 3) * sizeof(int);
   int *placement = (int *)buf;
   memcpy(placement, stack->stack, elements * sizeof(int));
   placement[elements] = stack->last_indentation_size;
+  placement[elements + 1] = stack->last_newline_count;
+  placement[elements + 2] = stack->last_column;
 
   return result_length;
 }
@@ -72,14 +78,18 @@ void deserialiseStack(ScannerStack* stack, const char* buf, unsigned n) {
   if (n != 0) {
     int *intBuf = (int *)buf;
 
-    unsigned elements = n / sizeof(int) - 1;
+    unsigned elements = n / sizeof(int) - 3;
     stack->top = elements;
     memcpy(stack->stack, intBuf, elements * sizeof(int));
     stack->last_indentation_size = intBuf[elements];
+    stack->last_newline_count = intBuf[elements + 1];
+    stack->last_column = intBuf[elements + 2];
   }
 }
 
 void resetStack(ScannerStack *p) {
   p->top = 0;
   p->last_indentation_size = -1;
+  p->last_newline_count = 0;
+  p->last_column = -1;
 }

--- a/src/stack.h
+++ b/src/stack.h
@@ -1,0 +1,78 @@
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef DEBUG
+    #define LOG(args...) fprintf(stderr, args);
+#else
+    #define LOG(args...)
+#endif
+
+#define STACK_SIZE 1024
+
+typedef struct ScannerStack {
+  unsigned int stack[STACK_SIZE];
+  int top;
+} ScannerStack;
+
+ScannerStack* createStack() {
+  ScannerStack* ptr = (ScannerStack*) malloc(sizeof(ScannerStack));
+
+  ptr -> top = 0;
+  memset(ptr -> stack, STACK_SIZE, (0));
+
+  return ptr;
+}
+
+bool isEmptyStack(ScannerStack *stack) { return stack->top == 0; }
+
+int peekStack(ScannerStack *stack) {
+  return isEmptyStack(stack) ? -1 : stack->stack[stack->top - 1];
+}
+
+void pushStack(ScannerStack *stack, unsigned int value) {
+  stack->top++;
+  stack->stack[stack->top - 1] = value;
+}
+
+int popStack(ScannerStack *stack) {
+  if (isEmptyStack(stack))
+    return -1;
+  else {
+    int result = peekStack(stack);
+    stack->top--;
+
+    return result;
+  }
+}
+
+void printStack(ScannerStack *stack, char *msg) {
+  LOG("%s Stack[top = %d; ", msg, stack->top);
+  for (int i = 0; i < stack->top; i++) {
+    LOG("%d | ", stack->stack[i]);
+  }
+  LOG("]\n");
+}
+
+unsigned serialiseStack(ScannerStack *stack, char *buf) {
+  unsigned elements = isEmptyStack(stack) ? 0 : stack->top;
+  unsigned result_length = elements * sizeof(int);
+  int *placement = (int *)buf;
+  memcpy(placement, stack->stack, elements * sizeof(int));
+
+  return result_length;
+}
+
+void deserialiseStack(ScannerStack* stack, const char* buf, unsigned n) {
+  if (n != 0) {
+    int *intBuf = (int *)buf;
+
+    int elements = n / sizeof(int);
+    stack->top = elements;
+    memcpy(stack->stack, intBuf, elements * sizeof(int));
+  }
+}
+
+void resetStack(ScannerStack *p) { p->top = 0; }

--- a/test/test-stack.c
+++ b/test/test-stack.c
@@ -32,11 +32,11 @@ int main() {
     pushStack(stack, i);
   }
 
-  assert(serialiseStack(stack, buf) == sizeof(int) * 250);
+  assert(serialiseStack(stack, buf) == sizeof(int) * 251);
 
   ScannerStack *newStack = createStack();
 
-  deserialiseStack(newStack, buf, sizeof(int) * 250);
+  deserialiseStack(newStack, buf, sizeof(int) * 251);
   assert(newStack -> top == 250);
   assert(popStack(newStack) == 249);
 

--- a/test/test-stack.c
+++ b/test/test-stack.c
@@ -32,11 +32,11 @@ int main() {
     pushStack(stack, i);
   }
 
-  assert(serialiseStack(stack, buf) == sizeof(int) * 251);
+  assert(serialiseStack(stack, buf) == sizeof(int) * 253);
 
   ScannerStack *newStack = createStack();
 
-  deserialiseStack(newStack, buf, sizeof(int) * 251);
+  deserialiseStack(newStack, buf, sizeof(int) * 253);
   assert(newStack -> top == 250);
   assert(popStack(newStack) == 249);
 

--- a/test/test-stack.c
+++ b/test/test-stack.c
@@ -1,0 +1,50 @@
+#define DEBUG
+#include "../src/stack.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  ScannerStack *stack = createStack();
+
+  printStack(stack, "hello");
+
+  assert(isEmptyStack(stack));
+
+  pushStack(stack, 27);
+  assert(!isEmptyStack(stack));
+  assert(peekStack(stack) == 27);
+
+  pushStack(stack, 42);
+  assert(!isEmptyStack(stack));
+  assert(peekStack(stack) == 42);
+
+  assert(popStack(stack) == 42);
+  assert(peekStack(stack) == 27);
+
+  assert(popStack(stack) == 27);
+  assert(peekStack(stack) == -1);
+  assert(isEmptyStack(stack));
+
+  char *buf = malloc(2048);
+
+  for (int i = 0; i < 250; i++) {
+    pushStack(stack, i);
+  }
+
+  assert(serialiseStack(stack, buf) == sizeof(int) * 250);
+
+  ScannerStack *newStack = createStack();
+
+  deserialiseStack(newStack, buf, sizeof(int) * 250);
+  assert(newStack -> top == 250);
+  assert(popStack(newStack) == 249);
+
+  resetStack(newStack);
+
+  assert(isEmptyStack(newStack));
+
+  printStack(stack, "hello");
+  printStack(newStack, "hello");
+  return 0;
+}


### PR DESCRIPTION
Ref https://github.com/tree-sitter/tree-sitter-scala/issues/43

Problem
-------
Currently Scala 3 optional braces syntax does not work.
Specifically, in this PR I want to address decls/defns not properly grouped under the right owner in part 1 (#61).

Solution
--------
1. This brings in indent/outdent impl by @keynmol
2. Introduce `_indentable_expression`.
   This allows us to limit where indent/outdent shows up without
   confusing tree-sitter too much.
   Internally I've made a change to track `last_indentation_size` in the payload to indicate last
    outdent (default: -1). If it's not -1 that means there was an outdent.
    This then checks if the last_indentation_size qualified for another outdent.
2. Add support for control strctures:
    - [x] if expression
    - [x] try-catch expression
    - [x] match expression
    - [x] while expression
    - [x] for expression    

The test cases for these are:

```lisp
=======================================
Top-level Definitions (Scala 3 syntax)
=======================================

class A:
  def a() =
    ()

def a() = 1

---

(compilation_unit
  (class_definition
    (identifier)
    (template_body
      (function_definition
        (identifier)
        (parameters)
        (indented_block
          (unit)))))
  (function_definition
    (identifier)
    (parameters)
    (integer_literal)))
```

```diff
  =======================================
  Value declarations (Scala 3 syntax)
  =======================================
  
  class A:
-   val b: String
+   val b, c : Int
+   val d : String
```

Demo
------
Here's a demonstration of before and after using Sonokai. The theme is a bit too color happy, but it's good for checking what changed:

## Before #61
<img width="814" alt="sonokai_main_before" src="https://user-images.githubusercontent.com/184683/207691436-93e7af86-b8db-4435-adde-2f3e5fcf1033.png">

**Note**: `def run` is not recognized as a method.

## After this PR

<img width="804" alt="sonokai_main_after2" src="https://user-images.githubusercontent.com/184683/207772121-a5f53c30-511f-4854-bcee-451f2c60765a.png">

`def run`  is highlighted as a method. The body of `def dealiasBaseDirectory` improved as well, since `val` is now acceptable without `{ ... }`.