### PR TITLE
Using clauses

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -263,6 +263,23 @@ class Point(val x: Int, val y: Int)(implicit coord: Coord)
       (class_parameter (identifier) (type_identifier)))))
 
 =======================================
+Class definitions with parameters (Scala 3 syntax)
+=======================================
+
+class Point(val x: Int, val y: Int)(using coord: Coord)
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter (identifier) (type_identifier))
+      (class_parameter (identifier) (type_identifier)))
+    (class_parameters
+      (class_parameter (identifier) (type_identifier)))))
+
+=======================================
 Modifiers
 =======================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -376,18 +376,16 @@ module.exports = grammar({
       optional($.arguments)
     )),
 
-    // TODO: Allow only the last parameter list to be implicit.
     class_parameters: $ => prec(1, seq(
       '(',
-      optional('implicit'),
+      optional(choice('implicit', 'using')),
       commaSep($.class_parameter),
       ')'
     )),
 
-    // TODO: Allow only the last parameter list to be implicit.
     parameters: $ => seq(
       '(',
-      optional('implicit'),
+      optional(choice('implicit', 'using')),
       commaSep($.parameter),
       ')'
     ),


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/71

### Problem
Scala 3 syntax uses `using` to denote implicit parameters.

### Solution
Allow both `implicit` and `using`.

### Note
This improves Dotty parsing success% (tested using https://github.com/tree-sitter/tree-sitter-scala/pull/81) from 35.68% to 56.81%