### PR TITLE
Literal types

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -250,3 +250,41 @@ type A = B with B1 with B2 ! C with C1
       (compound_type (type_identifier) (type_identifier) (type_identifier))
       (operator_identifier)
       (compound_type (type_identifier) (type_identifier)))))
+
+==================================
+Literal type aliases (Scala 2.13+)
+==================================
+
+type A = "hello"
+type B = 25
+type C = false
+type D = 0.5f
+
+class Test(d: "hello", b: 25)
+
+---
+
+(compilation_unit
+  (type_definition 
+    (type_identifier) (literal_type (string)))
+
+  (type_definition 
+    (type_identifier) (literal_type (integer_literal)))
+
+  (type_definition 
+    (type_identifier) (literal_type (boolean_literal)))
+
+  (type_definition 
+    (type_identifier) (literal_type (floating_point_literal)))
+
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (literal_type
+          (string)))
+      (class_parameter
+        (identifier)
+        (literal_type
+          (integer_literal))))))

--- a/grammar.js
+++ b/grammar.js
@@ -450,6 +450,7 @@ module.exports = grammar({
       $.compound_type,
       $.infix_type,
       $._annotated_type,
+      $.literal_type
     ),
 
     // TODO: Make this a visible type, so that _type can be a supertype.
@@ -791,13 +792,20 @@ module.exports = grammar({
 
     operator_identifier: $ => /[^\s\w\(\)\[\]\{\}'"`\.;,]+/,
 
+    _non_null_literal: $ => 
+      choice(
+        $.integer_literal,
+        $.floating_point_literal,
+        $.boolean_literal,
+        $.character_literal,
+        $.symbol_literal,
+        $.string
+      ),
+
+    literal_type: $ => $._non_null_literal,
+
     literal: $ => choice(
-      $.integer_literal,
-      $.floating_point_literal,
-      $.boolean_literal,
-      $.character_literal,
-      $.symbol_literal,
-      $.string,
+      $._non_null_literal,
       $.null_literal
     ),
 


### PR DESCRIPTION
I had to separate null and non null because the former cannot be a literal type 
<img width="538" alt="image" src="https://user-images.githubusercontent.com/1052965/211094950-d97183a6-37b6-4b82-a8e6-4ffd3d81bd43.png">

Closes #84 
