### PR TITLE
fix: remove hidden arrow node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -144,7 +144,7 @@ module.exports = grammar({
 
     renamed_identifier: $ => seq(
       field('name', $.identifier),
-      choice($._arrow, 'as'),
+      choice('=>', 'as'),
       field('alias', choice($.identifier, $.wildcard))
     ),
 
@@ -508,7 +508,7 @@ module.exports = grammar({
 
     function_type: $ => prec.right(seq(
       field('parameter_types', $.parameter_types),
-      $._arrow,
+      '=>',
       field('return_type', $._type)
     )),
 
@@ -528,7 +528,7 @@ module.exports = grammar({
     ),
 
     lazy_parameter_type: $ => seq(
-      $._arrow,
+      '=>',
       field('type', $._type)
     ),
 
@@ -633,7 +633,7 @@ module.exports = grammar({
           $.identifier,
           $.wildcard,
       ),
-      $._arrow,
+      '=>',
       $._block,
     )),
 
@@ -693,7 +693,7 @@ module.exports = grammar({
       'case',
       field('pattern', $._pattern),
       optional($.guard),
-      $._arrow,
+      '=>',
       field('body', optional($._block)),
     )),
 
@@ -785,8 +785,6 @@ module.exports = grammar({
     ),
 
     wildcard: $ => '_',
-
-    _arrow: $ => '=>',
 
     operator_identifier: $ => /[^\s\w\(\)\[\]\{\}'"`\.;,]+/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -365,8 +365,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_arrow"
+              "type": "STRING",
+              "value": "=>"
             },
             {
               "type": "STRING",
@@ -1834,8 +1834,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "implicit"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "implicit"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "using"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -1893,8 +1902,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "implicit"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "implicit"
+                },
+                {
+                  "type": "STRING",
+                  "value": "using"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -2302,6 +2320,10 @@
         {
           "type": "SYMBOL",
           "name": "_annotated_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "literal_type"
         }
       ]
     },
@@ -2614,8 +2636,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "_arrow"
+            "type": "STRING",
+            "value": "=>"
           },
           {
             "type": "FIELD",
@@ -2720,8 +2742,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_arrow"
+          "type": "STRING",
+          "value": "=>"
         },
         {
           "type": "FIELD",
@@ -3162,8 +3184,8 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "_arrow"
+            "type": "STRING",
+            "value": "=>"
           },
           {
             "type": "SYMBOL",
@@ -3522,8 +3544,8 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "_arrow"
+            "type": "STRING",
+            "value": "=>"
           },
           {
             "type": "FIELD",
@@ -3981,15 +4003,11 @@
       "type": "STRING",
       "value": "_"
     },
-    "_arrow": {
-      "type": "STRING",
-      "value": "=>"
-    },
     "operator_identifier": {
       "type": "PATTERN",
       "value": "[^\\s\\w\\(\\)\\[\\]\\{\\}'\"`\\.;,]+"
     },
-    "literal": {
+    "_non_null_literal": {
       "type": "CHOICE",
       "members": [
         {
@@ -4015,6 +4033,19 @@
         {
           "type": "SYMBOL",
           "name": "string"
+        }
+      ]
+    },
+    "literal_type": {
+      "type": "SYMBOL",
+      "name": "_non_null_literal"
+    },
+    "literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_non_null_literal"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -401,6 +401,10 @@
           "named": true
         },
         {
+          "type": "literal_type",
+          "named": true
+        },
+        {
           "type": "projected_type",
           "named": true
         },
@@ -489,6 +493,10 @@
           },
           {
             "type": "lazy_parameter_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -901,6 +909,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -1064,6 +1076,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -1283,6 +1299,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -1464,6 +1484,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -1578,6 +1602,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -1657,6 +1685,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -1900,6 +1932,10 @@
         },
         {
           "type": "infix_type",
+          "named": true
+        },
+        {
+          "type": "literal_type",
           "named": true
         },
         {
@@ -2260,6 +2296,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -2277,6 +2317,41 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "literal_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "floating_point_literal",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol_literal",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -2305,6 +2380,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -2552,6 +2631,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -2615,6 +2698,10 @@
         },
         {
           "type": "lazy_parameter_type",
+          "named": true
+        },
+        {
+          "type": "literal_type",
           "named": true
         },
         {
@@ -2802,6 +2889,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3077,6 +3168,10 @@
           "named": true
         },
         {
+          "type": "literal_type",
+          "named": true
+        },
+        {
           "type": "projected_type",
           "named": true
         },
@@ -3121,6 +3216,10 @@
         },
         {
           "type": "infix_type",
+          "named": true
+        },
+        {
+          "type": "literal_type",
           "named": true
         },
         {
@@ -3178,6 +3277,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3338,6 +3441,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -3388,6 +3495,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3446,6 +3557,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3518,6 +3633,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3611,6 +3730,10 @@
             "named": true
           },
           {
+            "type": "literal_type",
+            "named": true
+          },
+          {
             "type": "projected_type",
             "named": true
           },
@@ -3680,6 +3803,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3760,6 +3887,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
             "named": true
           },
           {
@@ -3895,6 +4026,10 @@
   },
   {
     "type": "=",
+    "named": false
+  },
+  {
+    "type": "=>",
     "named": false
   },
   {
@@ -4087,6 +4222,10 @@
   },
   {
     "type": "type",
+    "named": false
+  },
+  {
+    "type": "using",
     "named": false
   },
   {


### PR DESCRIPTION
This reverts a change made in
https://github.com/tree-sitter/tree-sitter-scala/commit/fa8d64b77ed9a53067317eb69725b61bf2c634b1#diff-919ac210accac9ecc55a76d10a7590e3d85ca3f0e165b52d30f08faee486d0cbL140-R142
where we introduced `_arrow`. This change will break the current neovim
highlights and we don't need it to be a named node.

refs: https://github.com/nvim-treesitter/nvim-treesitter/pull/4113
