### PR TITLE
Fix the diff change detection 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,15 @@ jobs:
           npm run build
           npm test
 
-      - name: Check parser (Linux)
+      - name: Check parser
         if: ${{ runner.os == 'macOS' && needs.changedfiles.outputs.c }}
         shell: bash
         run: |
           # `git diff --quiet` doesn't seem to work on Github Actions
           changes=$(git diff --name-only --diff-filter=ACMRT | xargs)
-          if [ ! "$changes" ]; then
-            echo "::error file=grammar.js::Generated parser differs from the checked in version"
+          if [ ! -z "$changes" ]; then
+            echo "::error file=grammar.js::Generated $changes differs from the checked in version"
+            git diff --exit-code
             exit 1
           fi
 


### PR DESCRIPTION
Ref https://github.com/tree-sitter/tree-sitter-scala/issues/85
Ref https://github.com/tree-sitter/tree-sitter-scala/pull/94

Problem
-------
Currently the diff change detection is broken because it fails
when the changes are empty.

Solution
--------
1. Fix the logic.
2. Include the file names in the error message.
3. Run diff