### PR TITLE
Optimize codegen memory usage

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -219,25 +219,31 @@ module.exports = grammar({
       field('body', optional($.template_body)),
     )),
 
-    class_definition: $ => prec.right(seq(
+    class_definition: $ => prec.left(seq(
       repeat($.annotation),
       optional($.modifiers),
       optional('case'),
       'class',
+      $._class_constructor,
+      field('extend', optional($.extends_clause)),
+      field('body', optional($.template_body))
+    )),
+
+    /**
+     * ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses
+     */
+    _class_constructor: $ => prec.right(seq(
       field('name', $.identifier),
       field('type_parameters', optional($.type_parameters)),
       optional($.access_modifier),
       field('class_parameters', repeat($.class_parameters)),
-      field('extend', optional($.extends_clause)),
-      field('body', optional($.template_body))
     )),
 
     trait_definition: $ => prec.left(seq(
       repeat($.annotation),
        optional($.modifiers),
       'trait',
-      field('name', $.identifier),
-      field('type_parameters', optional($.type_parameters)),
+      $._class_constructor,
       field('extend', optional($.extends_clause)),
       field('body', optional($.template_body))
     )),


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/97

Problem
-------
Currently codegen uses 34GB, which is more than my desktop can handle. ahlinc kindly let us know about `--report-states-for-rule` flag to try to identify some choke points.
To my surprise `class_definition` uses 3728 states - https://gist.github.com/eed3si9n/009b1e5f11f5a80ea2c98d030bd25e13

Solution
--------
This adds intermediate node called `_class_constructor`, which is right associated to deal with the modifiers, but now `class_definition` can be left associated.

After this change:
```
$ /usr/bin/time -f "%M" node_modules/.bin/tree-sitter generate
11723152
```
This brings down memory usage to 11GB.