### PR TITLE
Sync and improve highlighting queries, add Scala 3 specific constructs and tests

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -141,9 +141,9 @@ module.exports = grammar({
       )
     ),
 
-    simple_enum_case: $ => $.identifier,
+    simple_enum_case: $ => field('name', $.identifier),
 
-    full_enum_case: $ => seq($.identifier, $._extended_enum_def),
+    full_enum_case: $ => seq(field('name', $.identifier), $._extended_enum_def),
 
     _extended_enum_def: $ => seq(
       field('type_parameters', optional($.type_parameters)),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,76 +1,219 @@
-;; Annotations
+; CREDITS @stumash (stuart.mashaal@gmail.com)
 
-"@" @operator
-
-;; Types
-
-(class_definition
-  name: (identifier) @type)
-(trait_definition
-  name: (identifier) @type)
-(object_definition
-  name: (identifier) @type)
-
-(type_identifier) @type
-
-;; Variables
-
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
+;; variables
 
 (identifier) @variable
 
-;; Literals
+((identifier) @variable.builtin
+ (#lua-match? @variable.builtin "^this$"))
+
+(interpolation) @none
+
+; Assume other uppercase names constants.
+; NOTE: In order to distinguish constants we highlight
+; all the identifiers that are uppercased. But this solution
+; is not suitable for all occurrences e.g. it will highlight
+; an uppercased method as a constant if used with no params.
+; Introducing highlighting for those specific cases, is probably
+; best way to resolve the issue.
+((identifier) @constant (#lua-match? @constant "^[A-Z]"))
+
+;; types
+
+(type_identifier) @type
+
+(class_definition
+  name: (identifier) @type)
+
+(enum_definition
+  name: (identifier) @type)
+
+(object_definition
+  name: (identifier) @type)
+
+(trait_definition
+  name: (identifier) @type)
+
+(type_definition
+  name: (type_identifier) @type.definition)
+
+; method definition
+
+(class_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+(object_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+(trait_definition
+  body: (template_body
+    (function_definition
+      name: (identifier) @method)))
+
+; imports
+
+(import_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((import_declaration
+  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
+
+((import_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
+
+; method invocation
+
+
+(call_expression
+  function: (identifier) @function.call)
+
+(call_expression
+  function: (field_expression
+    field: (identifier) @method.call))
+
+((call_expression
+   function: (identifier) @constructor)
+ (#lua-match? @constructor "^[A-Z]"))
+
+(generic_function
+  function: (identifier) @function.call)
+
+(
+  (identifier) @function.builtin
+  (#lua-match? @function.builtin "^super$")
+)
+
+; function definitions
+
+(function_definition
+  name: (identifier) @function)
+
+(parameter
+  name: (identifier) @parameter)
+
+; expressions
+
+
+(field_expression field: (identifier) @property)
+(field_expression value: (identifier) @type
+ (#lua-match? @type "^[A-Z]"))
+
+(infix_expression operator: (identifier) @operator)
+(infix_expression operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+(infix_type operator: (operator_identifier) @operator)
+
+; literals
+
+(boolean_literal) @boolean
+(integer_literal) @number
+(floating_point_literal) @float
 
 [
-  (integer_literal)
-  (floating_point_literal)
-] @number
-
-[
-  (character_literal)
+  (symbol_literal)
   (string)
+  (character_literal)
+  (interpolated_string_expression)
 ] @string
 
-[
-  (boolean_literal)
-  (null_literal)
-] @constant.builtin
+(interpolation "$" @punctuation.special)
 
-(comment) @comment
+;; keywords
 
-(opaque_modifier) @keyword
-
-;; Keywords
+(opaque_modifier) @type.qualifier
 
 [
-  "abstract"
   "case"
-  "catch"
   "class"
-  "def"
-  "do"
-  "else"
+  "enum"
   "extends"
-  "final"
   "finally"
-  "for"
-  "if"
-  "implicit"
-  "import"
-  "lazy"
-  "match"
-  "new"
+;; `forSome` existential types not implemented yet
+;; `macro` not implemented yet
   "object"
   "override"
   "package"
+  "trait"
+  "type"
+  "val"
+  "var"
+  "with"
+  "given"
+  "end"
+] @keyword
+
+[
+  "abstract"
+  "final"
+  "implicit"
+  "using"
+  "lazy"
   "private"
   "protected"
-  "return"
   "sealed"
-  "throw"
-  "trait"
-  "try"
+] @type.qualifier
+
+(null_literal) @constant.builtin
+
+(wildcard) @parameter
+
+(annotation) @attribute
+
+;; special keywords
+
+"new" @keyword.operator
+
+[
+  "else"
+  "if"
+  "match"
+] @conditional
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+]  @punctuation.bracket
+
+[
+ "."
+ ","
+] @punctuation.delimiter
+
+[
+  "do"
+  "for"
   "while"
-  "with"
-] @keyword
+  "yield"
+] @repeat
+
+"def" @keyword.function
+
+[
+ "=>"
+ "<-"
+ "@"
+] @operator
+
+"import" @include
+
+[
+  "try"
+  "catch"
+  "throw"
+] @exception
+
+"return" @keyword.return
+
+(comment) @comment @spell
+
+;; `case` is a conditional keyword in case_block
+
+(case_block
+  (case_clause ("case") @conditional))

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,56 +1,60 @@
 ; CREDITS @stumash (stuart.mashaal@gmail.com)
 
+(class_definition
+  name: (identifier) @type.definition)
+
+(enum_definition
+  name: (identifier) @type.definition)
+
+(object_definition
+  name: (identifier) @type.definition)
+
+(trait_definition
+  name: (identifier) @type.definition)
+
+(full_enum_case
+  name: (identifier) @type.definition)
+
+(simple_enum_case
+  name: (identifier) @type.definition)
+
 ;; variables
 
-(identifier) @variable
+(class_parameter 
+  name: (identifier) @parameter)
 
-((identifier) @variable.builtin
- (#lua-match? @variable.builtin "^this$"))
 
 (interpolation) @none
 
-; Assume other uppercase names constants.
-; NOTE: In order to distinguish constants we highlight
-; all the identifiers that are uppercased. But this solution
-; is not suitable for all occurrences e.g. it will highlight
-; an uppercased method as a constant if used with no params.
-; Introducing highlighting for those specific cases, is probably
-; best way to resolve the issue.
-((identifier) @constant (#lua-match? @constant "^[A-Z]"))
-
 ;; types
-
-(type_identifier) @type
-
-(class_definition
-  name: (identifier) @type)
-
-(enum_definition
-  name: (identifier) @type)
-
-(object_definition
-  name: (identifier) @type)
-
-(trait_definition
-  name: (identifier) @type)
 
 (type_definition
   name: (type_identifier) @type.definition)
 
+(type_identifier) @type
+
+
+;; val/var definitions/declarations
+
+(val_definition
+  pattern: (identifier) @variable)
+
+(var_definition
+  pattern: (identifier) @variable)
+
+(val_declaration
+  name: (identifier) @variable)
+
+(var_declaration
+  name: (identifier) @variable)
+
 ; method definition
 
-(class_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
-(object_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
-(trait_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
+(function_declaration
+      name: (identifier) @method)
+
+(function_definition
+      name: (identifier) @method)
 
 ; imports
 
@@ -81,10 +85,11 @@
 (generic_function
   function: (identifier) @function.call)
 
-(
-  (identifier) @function.builtin
-  (#lua-match? @function.builtin "^super$")
-)
+;; I think this is broken
+; (
+;   (identifier) @function.builtin
+;   (#lua-match? @function.builtin "^super$")
+; )
 
 ; function definitions
 
@@ -143,12 +148,12 @@
   "with"
   "given"
   "end"
+  "implicit"
 ] @keyword
 
 [
   "abstract"
   "final"
-  "implicit"
   "using"
   "lazy"
   "private"
@@ -217,3 +222,8 @@
 
 (case_block
   (case_clause ("case") @conditional))
+
+((identifier) @constant (#lua-match? @constant "^[A-Z]"))
+((identifier) @variable.builtin
+ (#lua-match? @variable.builtin "^this$"))
+

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -1,0 +1,37 @@
+object Hello {
+// ^ keyword 
+//       ^ type.definition
+  val x = if (true) (25 * 1.0) else "hello"  
+// ^keyword
+//    ^variable
+//         ^conditional
+//             ^boolean
+//                   ^number
+//                        ^float    
+//                                    ^string
+//                              ^conditional 
+
+  trait Test {
+// ^ keyword 
+//       ^ type.definition
+     def meth(i: Int)(implicit x: Boolean) = ???
+//    ^keyword.function  
+//                       ^keyword    
+//                                  ^type    
+//        ^method
+//                             ^parameter 
+  }
+
+  protected abstract class Bla(test: String)
+//    ^type.qualifier  
+//                    ^keyword
+//            ^type.qualifier 
+//                              ^parameter
+//                                     ^type
+
+  type Hello = "25"
+  // ^keyword
+  //    ^type.definition 
+  //            ^string
+} 
+

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -1,0 +1,17 @@
+enum Test(a: Int):
+// ^keyword   ^type
+//    ^type.definition
+//        ^parameter
+  case Test(b: String)
+// ^keyword     ^type
+//      ^type.definition
+//          ^parameter
+  case Hello, Bla
+//      ^type.definition
+//             ^type.definition
+
+opaque type Blow <: Int = 25
+// ^type.qualifier
+//      ^keyword     
+//                   ^type     
+//            ^type.definition


### PR DESCRIPTION
closes #98 

The highlighting queries in this repo are out of date with the version in nvim-treesitter: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/scala/highlights.scm

That version has some issues, so I used it as the bases and moved/simplified/added rules.
In particular we are more precise about highlighting identifiers (before they would be aggressively highlighted as variable in lots of places)



### plans

I feel like we should grow the test coverage of highlighting queries, and once we're satisfied - upstream the changes

### using these queries

```
cp queries/* ~/.local/share/nvim/site/pack/packer/start/nvim-treesitter/queries/scala/
```

The difference are subtle (and some identifiers have the correct highlighting only because they're capitalised), but in particular class/enum parameters and trait/class/object/enum names are treated correctly.

nvim-treesitter version 
![image](https://user-images.githubusercontent.com/1052965/211199597-352abea8-121f-4927-a2e4-1922f84c4537.png)

this version
![image](https://user-images.githubusercontent.com/1052965/211199624-bf0580bf-912d-47dc-a3fb-e8e52539a17f.png)
