### PR TITLE
Scala 3 enums: fix simple case inheritance

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -785,6 +785,7 @@ Enums (Scala 3)
 enum Hello[Y] extends java.Enumeration derives Codec, Eq {
   case World, You
   case Test[A](bla: Int, yo: String) extends Hello[A]
+  case T extends Hello[String](25)
 }
 
 ---
@@ -812,7 +813,18 @@ enum Hello[Y] extends java.Enumeration derives Codec, Eq {
               (identifier)
               (type_identifier)))
           (extends_clause
-            (generic_type (type_identifier) (type_arguments (type_identifier))))))
+            (generic_type (type_identifier) (type_arguments (type_identifier)))))
+      )
+      (enum_case_definitions
+        (simple_enum_case
+          (identifier)
+          (extends_clause
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier)))
+            (arguments
+              (integer_literal)))))
       )
     )
   )

--- a/grammar.js
+++ b/grammar.js
@@ -141,11 +141,11 @@ module.exports = grammar({
       )
     ),
 
-    simple_enum_case: $ => field('name', $.identifier),
+    simple_enum_case: $ => seq(field('name', $.identifier), field('extend', optional($.extends_clause))),
 
-    full_enum_case: $ => seq(field('name', $.identifier), $._extended_enum_def),
+    full_enum_case: $ => seq(field('name', $.identifier), $._full_enum_def),
 
-    _extended_enum_def: $ => seq(
+    _full_enum_def: $ => seq(
       field('type_parameters', optional($.type_parameters)),
       field('class_parameters', repeat1($.class_parameters)),
       field('extend', optional($.extends_clause))

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -131,6 +131,7 @@
   "class"
   "enum"
   "extends"
+  "derives"
   "finally"
 ;; `forSome` existential types not implemented yet
 ;; `macro` not implemented yet

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -1,5 +1,8 @@
-enum Test(a: Int):
-// ^keyword   ^type
+enum Test(a: Int) derives Codec:
+// ^keyword   
+//            ^type
+//                   ^keyword
+//                          ^type
 //    ^type.definition
 //        ^parameter
   case Test(b: String)
@@ -9,6 +12,8 @@ enum Test(a: Int):
   case Hello, Bla
 //      ^type.definition
 //             ^type.definition
+  case Bla extends Test(256)
+//          ^keyword
 
 opaque type Blow <: Int = 25
 // ^type.qualifier


### PR DESCRIPTION
Seems like I missed it originally.

Now the reference enum looks _perfect_: 
![image](https://user-images.githubusercontent.com/1052965/211414333-5848d32c-f5c5-4540-a064-38886874a92b.png)
