### PR TITLE
Transparent, open, infix

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -1008,3 +1008,67 @@ inline given Test =
                 (operator_identifier)
                 (type_identifier))))))
       (integer_literal))))
+
+
+=======================================
+Infix methods (Scala 3)
+=======================================
+
+object Test:
+  infix private def hello = 25
+
+---
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (modifiers
+          (infix_modifier)
+          (access_modifier))
+        (identifier)
+        (integer_literal)))))
+
+=======================================
+Open classes (Scala 3)
+=======================================
+
+open class Test(a: Int):
+  def test = 25
+end Test
+
+---
+
+(compilation_unit
+  (class_definition
+    (modifiers
+      (open_modifier))
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier)))
+    (template_body
+      (function_definition
+        (identifier)
+        (integer_literal)))))
+
+=======================================
+Transparent traits (Scala 3)
+=======================================
+
+transparent trait Kind:
+  def test = 1
+
+---
+
+(compilation_unit
+  (trait_definition
+    (modifiers
+      (transparent_modifier))
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (integer_literal)))))

--- a/grammar.js
+++ b/grammar.js
@@ -512,6 +512,9 @@ module.exports = grammar({
       'override',
       $.access_modifier,
       $.inline_modifier,
+      $.infix_modifier,
+      $.open_modifier,
+      $.transparent_modifier
     )),
 
     access_modifier: $ => prec.left(seq(
@@ -526,6 +529,9 @@ module.exports = grammar({
     ),
 
     inline_modifier: $ => 'inline',
+    infix_modifier: $ => 'infix',
+    open_modifier: $ => 'open',
+    transparent_modifier: $ => 'transparent',
 
     extends_clause: $ => prec.left(seq(
       'extends',

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -129,6 +129,9 @@
 
 (opaque_modifier) @type.qualifier
 (inline_modifier) @keyword
+(infix_modifier) @keyword
+(transparent_modifier) @type.qualifier
+(open_modifier) @type.qualifier
 
 [
   "case"

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -44,3 +44,10 @@ object A:
 //^function.call
 //   ^number
 
+object bla:
+  open class Hello(A: Int)
+// ^ type.qualifier
+  transparent trait Hello
+//   ^ type.qualifier
+  infix def hello = 25
+//  ^ keyword


### PR DESCRIPTION
Closes #78
Closes #79 
Closes #75 

Low hanging fruit.

Getting those modifiers consistent with the spec would be good, but for the purposes of highlighting IMO it's not worth splitting them out (I tried - it causes tons of conflicts, so needs thought)

![image](https://user-images.githubusercontent.com/1052965/211506651-18a0322b-9789-421c-b452-17c5b138e24d.png)
