### PR TITLE
Fixes for expression

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -781,6 +781,11 @@ def f(): Unit =
   yield
     g(x, y)
 
+  for
+    annot <- annotations
+    if shouldEmitAnnotation(annot)
+  do
+    ()
 ---
 
 (compilation_unit
@@ -797,7 +802,13 @@ def f(): Unit =
          (enumerator (identifier) (identifier))
          (enumerator (identifier) (identifier)))
        (indented_block
-         (call_expression (identifier) (arguments (identifier) (identifier))))))))
+         (call_expression (identifier) (arguments (identifier) (identifier)))))
+
+     (for_expression
+       (enumerators
+         (enumerator (identifier) (identifier))
+         (enumerator (guard (call_expression (identifier) (arguments (identifier))))))
+       (indented_block (unit))))))
 
 ===============================
 Chained expressions

--- a/grammar.js
+++ b/grammar.js
@@ -1266,11 +1266,20 @@ module.exports = grammar({
       ),
     ),
 
-    enumerator: $ => seq(
-      $._pattern,
-      choice('<-', '='),
-      $.expression,
-      optional($.guard)
+    /**
+     *   Enumerator        ::=  Generator
+     *                       |  Guard {Guard}
+     *                       |  Pattern1 '=' Expr
+     */
+    enumerator: $ => choice(
+      seq(
+        optional('case'),
+        $._pattern,
+        choice('<-', '='),
+        $.expression,
+        optional($.guard)
+      ),
+      repeat1($.guard),
     ),
 
     comment: $ => token(choice(

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -3,8 +3,8 @@
 # This is an integration test to generally check the quality of parsing.
 
 SCALA_SCALA_LIBRARY_EXPECTED=100
-SCALA_SCALA_COMPILER_EXPECTED=64
-DOTTY_COMPILER_EXPECTED=71
+SCALA_SCALA_COMPILER_EXPECTED=66
+DOTTY_COMPILER_EXPECTED=73
 
 if [ ! -d "$SCALA_SCALA_DIR" ]; then
   echo "\$SCALA_SCALA_DIR must be set"


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/123

Problem
-------
Guard `if something` isn't supported in the for expression.

Solution
--------
This implements it.