### PR TITLE
Export clauses

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -185,7 +185,7 @@ import reflect.io.{Directory, File, Path}
     (identifier) (identifier))
   (import_declaration
     (identifier) (identifier)
-    (import_selectors (identifier) (identifier) (identifier))))
+    (namespace_selectors (identifier) (identifier) (identifier))))
 
 ================================
 Imports: Wildcard
@@ -198,7 +198,7 @@ import tools.nsc.classpath._
 (compilation_unit
   (import_declaration
     (identifier) (identifier) (identifier)
-    (import_wildcard)))
+    (namespace_wildcard)))
 
 ================================
 Imports: Wildcard (Scala 3 syntax)
@@ -211,12 +211,12 @@ import a.b.*, b.c, c.*
 
 (compilation_unit
   (import_declaration
-    (identifier) (identifier) (identifier) (import_wildcard))
+    (identifier) (identifier) (identifier) (namespace_wildcard))
 
   (import_declaration
-    (identifier) (identifier) (import_wildcard)
+    (identifier) (identifier) (namespace_wildcard)
     (identifier) (identifier)
-    (identifier) (import_wildcard)))
+    (identifier) (namespace_wildcard)))
 
 ================================
 Imports: Wildcard and wildcard givens (Scala 3 syntax)
@@ -230,12 +230,12 @@ import tools.given
 (compilation_unit
   (import_declaration
     (identifier) (identifier) (identifier)
-    (import_selectors 
-      (import_wildcard)
-      (import_wildcard)))
+    (namespace_selectors 
+      (namespace_wildcard)
+      (namespace_wildcard)))
   (import_declaration
     (identifier)
-    (import_wildcard))) 
+    (namespace_wildcard))) 
 
 ================================
 Imports: Givens by type (Scala 3 syntax)
@@ -248,7 +248,7 @@ import tools.nsc.classpath.{given Test, given Test2, Test3}
 (compilation_unit
   (import_declaration
     (identifier) (identifier) (identifier)
-    (import_selectors 
+    (namespace_selectors 
       (type_identifier)
       (type_identifier)
       (identifier))))
@@ -264,7 +264,7 @@ import lang.System.{lineSeparator as EOL}
 (compilation_unit
   (import_declaration
     (identifier) (identifier)
-    (import_selectors (renamed_identifier (identifier) (identifier)))))
+    (namespace_selectors (renamed_identifier (identifier) (identifier)))))
 
 ================================
 Imports: Rename
@@ -277,7 +277,7 @@ import lang.System.{lineSeparator => EOL}
 (compilation_unit
   (import_declaration
     (identifier) (identifier)
-    (import_selectors (renamed_identifier (identifier) (identifier)))))
+    (namespace_selectors (renamed_identifier (identifier) (identifier)))))
 
 
 =================================
@@ -1101,3 +1101,26 @@ transparent trait Kind:
       (function_definition
         (identifier)
         (integer_literal)))))
+
+
+
+================================
+Exports (Scala 3)
+================================
+
+export scanUnit.scan
+export printUnit.{status as _, *}
+
+---
+
+(compilation_unit
+  (export_declaration
+    (identifier)
+    (identifier))
+  (export_declaration
+    (identifier)
+    (namespace_selectors
+      (renamed_identifier
+        (identifier)
+        (wildcard))
+      (namespace_wildcard))))

--- a/grammar.js
+++ b/grammar.js
@@ -89,6 +89,7 @@ module.exports = grammar({
       $.extension_definition,
       $.class_definition,
       $.import_declaration,
+      $.export_declaration,
       $.object_definition,
       $.enum_definition,
       $.trait_definition,
@@ -176,31 +177,37 @@ module.exports = grammar({
 
     import_declaration: $ => prec.left(seq(
       'import',
-      sep1(',', $._import_expression)
+      sep1(',', $._namespace_expression)
     )),
 
-    _import_expression: $ => prec.left(seq(
+    export_declaration: $ => prec.left(seq(
+      'export',
+      sep1(',', $._namespace_expression)
+    )),
+
+
+    _namespace_expression: $ => prec.left(seq(
       field('path', sep1('.', $.identifier)),
       optional(seq(
         '.',
         choice(
-          $.import_wildcard,
-          $.import_selectors,
+          $.namespace_wildcard,
+          $.namespace_selectors,
         ),
       )),
     )),
 
-    import_wildcard: $ => prec.left(1,
+    namespace_wildcard: $ => prec.left(1,
       choice('*', '_', 'given')
     ),
 
-    _import_given_by_type: $ => seq('given', $._type),
+    _namespace_given_by_type: $ => seq('given', $._type),
 
-    import_selectors: $ => seq(
+    namespace_selectors: $ => seq(
       '{',
         commaSep1(choice(
-          $._import_given_by_type,
-          $.import_wildcard,
+          $._namespace_given_by_type,
+          $.namespace_wildcard,
           $.identifier,
           $.renamed_identifier
         )),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -56,7 +56,7 @@
 (function_definition
       name: (identifier) @method)
 
-; imports
+; imports/exports
 
 (import_declaration
   path: (identifier) @namespace)
@@ -66,7 +66,15 @@
   path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
 ((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
-((import_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
+(export_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((export_declaration
+  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
+
+((namespace_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
 ; method invocation
 
@@ -213,7 +221,7 @@
  "@"
 ] @operator
 
-"import" @include
+["import" "export"] @include
 
 [
   "try"

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -37,7 +37,7 @@ run_tree_sitter () {
   echo $actual
   if (( $(echo "$actual >= $expected" |bc -l) )); then
     # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-creating-an-annotation-for-an-error
-    echo -e "::notice file=grammar.js,line=1::ok, ${source_dir}: ${actual}%"
+    echo -e "::notice file=grammar.js,line=1::ok, ${source_dir}: ${actual}%, expected at least $expected%"
   else
     echo -e "::error file=grammar.js,line=1::${source_dir}: expected ${expected}, but got ${actual} instead"
     failed=$((failed + 1))

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -67,3 +67,17 @@ given Test with
    def test = 1
 //  ^keyword.function
    val a = "hello"
+
+
+class Copier:
+  private val printUnit = new Printer { type PrinterType = InkJet }
+  private val scanUnit = new Scanner
+
+  export scanUnit.scan
+  // ^ include
+  //        ^namespace
+  export printUnit.{status as _, *}
+  // ^ include
+  //        ^namespace
+
+  def status: List[String] = printUnit.status ++ scanUnit.status


### PR DESCRIPTION
Closes #76 

### breaking highlighting

For consistency, I renamed import_selectors to namespace_selectors to share them with exports.
This will break with old queries.

That said, given how sensitive they are (any node/keyword not present in the grammar causes highlighting to break), we've broken them a while back.

We'll sync them to nvim-treesitter soon.