### PR TITLE
SIP-44 Fewer braces support

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -1025,7 +1025,6 @@ inline given Test =
     (type_identifier)
       (instance_expression (type_identifier))))
 
-
 =======================================
 Infix methods (Scala 3)
 =======================================

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -60,6 +60,9 @@ class C:
     val x = 1
     List(x)
 
+  xs.map:
+    case x => x
+
   // This is ascription
   xs: Int
   // This is call_expression
@@ -76,35 +79,42 @@ class C:
         (field_expression (identifier) (identifier))
         (colon_argument
          (identifier)
-         (infix_expression (identifier) (operator_identifier) (integer_literal))))
+         (indented_block (infix_expression (identifier) (operator_identifier) (integer_literal)))))
 
       (call_expression
         (field_expression (identifier) (identifier))
         (colon_argument
-         (lambda_expression (identifier) 
-           (infix_expression (identifier) (operator_identifier) (integer_literal)))))
+         (indented_block (lambda_expression (identifier)
+           (infix_expression (identifier) (operator_identifier) (integer_literal))))))
 
       (call_expression
         (identifier)
         (colon_argument
-          (call_expression
+          (indented_block (call_expression
             (identifier)
-            (arguments (string)))))
+            (arguments (string))))))
 
       (infix_expression
         (identifier)
         (identifier)
-        (colon_argument
+        (colon_argument (indented_block
           (val_definition
             (identifier)
             (integer_literal))
-          (call_expression (identifier) (arguments (identifier)))))
+          (call_expression (identifier) (arguments (identifier))))))
+
+      (call_expression
+        (field_expression (identifier) (identifier))
+        (colon_argument
+          (indented_cases (case_clause
+            (identifier)
+            (identifier)))))
 
       (comment)
       (ascription_expression (identifier) (type_identifier))
 
       (comment)
-      (call_expression (identifier) (colon_argument (identifier))))))
+      (call_expression (identifier) (colon_argument (indented_block (identifier)))))))
 
 ===============================
 Generic functions

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -60,6 +60,12 @@ class C:
     val x = 1
     List(x)
 
+  // This is ascription
+  xs: Int
+  // This is call_expression
+  xs:
+    Int
+
 ---
 
 (compilation_unit
@@ -92,7 +98,13 @@ class C:
           (val_definition
             (identifier)
             (integer_literal))
-          (call_expression (identifier) (arguments (identifier))))))))
+          (call_expression (identifier) (arguments (identifier)))))
+
+      (comment)
+      (ascription_expression (identifier) (type_identifier))
+
+      (comment)
+      (call_expression (identifier) (colon_argument (identifier))))))
 
 ===============================
 Generic functions

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -42,6 +42,59 @@ class C {
             (tuple_pattern (tuple_pattern (identifier) (wildcard))) (identifier)))))))))
 
 ===============================
+SIP-44 Fewer braces (Scala 3 syntax)
+===============================
+
+class C:
+  xs.map: x =>
+    x + 1
+
+  xs.map:
+    x =>
+      x + 1
+
+  xs:
+    println("")
+
+  xs `++`:
+    val x = 1
+    List(x)
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (call_expression
+        (field_expression (identifier) (identifier))
+        (colon_argument
+         (identifier)
+         (infix_expression (identifier) (operator_identifier) (integer_literal))))
+
+      (call_expression
+        (field_expression (identifier) (identifier))
+        (colon_argument
+         (lambda_expression (identifier) 
+           (infix_expression (identifier) (operator_identifier) (integer_literal)))))
+
+      (call_expression
+        (identifier)
+        (colon_argument
+          (call_expression
+            (identifier)
+            (arguments (string)))))
+
+      (infix_expression
+        (identifier)
+        (identifier)
+        (colon_argument
+          (val_definition
+            (identifier)
+            (integer_literal))
+          (call_expression (identifier) (arguments (identifier))))))))
+
+===============================
 Generic functions
 ===============================
 
@@ -589,7 +642,7 @@ object O {
         (generic_type (type_identifier)
           (type_arguments (type_identifier))))
       (ascription_expression (integer_literal)
-        (repeated_parameter_type (type_identifier)))
+        (repeated_parameter_type (wildcard)))
       (ascription_expression (identifier)
         (annotation (type_identifier))))))
 

--- a/grammar.js
+++ b/grammar.js
@@ -973,6 +973,10 @@ module.exports = grammar({
       )),
     ),
 
+    /**
+     *   ColonArgument     ::=  colon [LambdaStart]
+     *                          (CaseClauses | Block)
+     */
     colon_argument: $ => prec.left(PREC.colon_call, seq(
       optional(field('lambda_start', seq(
         choice(
@@ -982,13 +986,10 @@ module.exports = grammar({
         ),
         '=>',
       ))),
-      $._colon_argument_block,
-    )),
-
-    _colon_argument_block: $ => prec.left(seq(
-      $._indent,
-      field('body', $._block),
-      $._outdent,
+      choice(
+        $.indented_block,
+        $.indented_cases,
+      ),
     )),
 
     field_expression: $ => prec.left(PREC.field, seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -106,6 +106,9 @@
 (parameter
   name: (identifier) @parameter)
 
+(binding
+  name: (identifier) @parameter)
+
 ; expressions
 
 

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -1,3 +1,29 @@
+// SIP-44
+class C:
+// ^keyword
+  fooooo.map: x =>
+  // ^type
+  //     ^method.call
+    x + 1
+
+  xs.map:
+    param1 =>
+      param1 + 1
+
+  foooo:
+  // ^function.call
+    println("")
+
+  foooo `++`:
+  //    ^operator
+    val x = 1
+    List(x)
+
+// Ascription expression
+class C:
+  foooo: Int
+  //     ^type
+
 enum Test(a: Int) derives Codec:
 // ^keyword   
 //            ^type
@@ -6,15 +32,15 @@ enum Test(a: Int) derives Codec:
 //    ^type.definition
 //        ^parameter
   case Test(b: String)
-// ^keyword     
-//               ^type
-//      ^type.definition
-//          ^parameter
+  // ^keyword     
+  //               ^type
+  //      ^type.definition
+  //        ^parameter
   case Hello, Bla
-//      ^type.definition
-//             ^type.definition
+  //      ^type.definition
+  //          ^type.definition
   case Bla extends Test(256)
-//          ^keyword
+  //          ^keyword
 
 opaque type Blow <: Int = 25
 // ^type.qualifier

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -19,6 +19,15 @@ class C:
     val x = 1
     List(x)
 
+  // This is an ascription
+  val y = x: Int
+  //         ^type
+
+  // This is SIP-44
+  val y = x:
+    Int
+    //^constant
+
 // Ascription expression
 class C:
   foooo: Int


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/127

This is on top of https://github.com/tree-sitter/tree-sitter-scala/pull/131

<img width="660" alt="sip-44" src="https://user-images.githubusercontent.com/184683/211686349-91124d09-73f7-438a-b361-b3a1bf5c3760.png">

Problem
-------
Currently our grammar does not support the fewer braces syntax, which basically lets us pass the last argument as a block after `:`.

Solution
--------
This implements fewer braces support for call_expression, infix_expression, with and without the lambda start.
