### PR TITLE
Add support for structural types

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -320,3 +320,61 @@ opaque type B <: Test >: Help = String
     (lower_bound (type_identifier))
     (type_identifier))
 )
+
+==================================
+Structural type
+==================================
+
+type A = { def fly(): Unit }
+
+---
+
+(compilation_unit
+  (type_definition (type_identifier)
+    (structural_type
+      (function_declaration 
+        (identifier)
+        (parameters)
+        (type_identifier)
+      )
+    )
+  )
+)
+
+=========================================
+Anonymous structural type with projection
+=========================================
+
+type A = B[({ type f[x] = M[S, x] })#f]
+
+---
+
+(compilation_unit
+  (type_definition (type_identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (projected_type
+          (tuple_type
+            (structural_type
+              (type_definition
+                (type_identifier)
+                (type_parameters
+                  (identifier)
+                )
+                (generic_type
+                  (type_identifier)
+                    (type_arguments
+                      (type_identifier)
+                      (type_identifier)
+                    )
+                )
+              )
+            )
+          )
+          (type_identifier)
+        )
+      )
+    )
+  )
+)

--- a/grammar.js
+++ b/grammar.js
@@ -634,7 +634,8 @@ module.exports = grammar({
       $.compound_type,
       $.infix_type,
       $._annotated_type,
-      $.literal_type
+      $.literal_type,
+      alias($.template_body, $.structural_type)
     ),
 
     // TODO: Make this a visible type, so that _type can be a supertype.

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -41,5 +41,14 @@ object Hello {
 //  ^constant
 //        ^type
   }
+
+  type A = { def fly(): Unit }
+//            ^keyword.function
+//                ^method
+//                       ^type
+
+  type A = B[({ type f[x] = M[S, x] })#f]
+//               ^keyword
+//                   ^type.definition
 }
 


### PR DESCRIPTION
I hope that it isn't too late to join the tree-sitter party :)

This PR adds supports for structural types which allows for using type projections on anonymous structural types that are usually used when working with a higher-kinded types without kind projector.