### PR TITLE
Use storageclass

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -136,7 +136,6 @@
 ;; keywords
 
 (opaque_modifier) @type.qualifier
-(inline_modifier) @keyword
 (infix_modifier) @keyword
 (transparent_modifier) @type.qualifier
 (open_modifier) @type.qualifier
@@ -170,10 +169,16 @@
   "final"
   "using"
   "lazy"
-  "private"
-  "protected"
   "sealed"
 ] @type.qualifier
+
+(inline_modifier) @storageclass
+
+[
+  "private"
+  "protected"
+] @storageclass
+
 
 (null_literal) @constant.builtin
 

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -27,7 +27,7 @@ object Hello {
   }
 
   protected abstract class Bla(test: String)
-//    ^type.qualifier  
+//    ^storageclass
 //                    ^keyword
 //            ^type.qualifier 
 //                              ^parameter

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -23,15 +23,15 @@ opaque type Blow <: Int = 25
 //            ^type.definition
 
 inline given Test = new Test {
-// ^ keyword
+// ^ storageclass
   inline def hello(inline x: Boolean) = 
-// ^ keyword
-//                   ^ keyword
+// ^ storageclass
+//                   ^ storageclass
     inline if x then "hi" else "bye" 
-    // ^keyword
+    // ^storageclass
     //            ^conditional
     inline x match 
-    // ^keyword
+    // ^storageclass
       case true => 25 
       case false => 26 
 }


### PR DESCRIPTION
Problem
-------
Currently storage related modifiers use keyword.

Solution
--------
We should use `storageclass` for `private`, `protected`, and `inline`. See also https://www.sublimetext.com/docs/scope_naming.html#storage

> Keywords that affect the storage of a variable, function or data structure should use the following scope. Examples include static, inline, const, public and private.