### PR TITLE
Fixes extends clause

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -333,6 +333,8 @@ object C {
         with C[T]
 }
 
+class D(c: String) extends E(c) with F
+
 ---
 
 (compilation_unit
@@ -358,9 +360,31 @@ object C {
     (identifier)
     (template_body
         (class_definition (identifier) (extends_clause
-          (compound_type
-            (generic_type (type_identifier) (type_arguments (type_identifier)))
-            (generic_type (type_identifier) (type_arguments (type_identifier)))))))))
+          (generic_type (type_identifier) (type_arguments (type_identifier)))
+          (generic_type (type_identifier) (type_arguments (type_identifier)))))))
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter (identifier) (type_identifier)))
+    (extends_clause
+       (type_identifier) (arguments (identifier))
+       (type_identifier))))
+
+=======================================
+Subclass definitions (Scala 3 syntax)
+=======================================
+
+class A extends B, C:
+ 1
+end A
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (extends_clause (type_identifier) (type_identifier))
+    (template_body (integer_literal))))
 
 =======================================
 Class definitions with parameters
@@ -449,7 +473,7 @@ trait T[U] extends V.W[U] {
     (extends_clause (type_identifier)))
   (trait_definition
     (identifier)
-    (extends_clause (compound_type (type_identifier) (type_identifier))))
+    (extends_clause (type_identifier) (type_identifier)))
   (trait_definition
     (identifier)
     (type_parameters (identifier))

--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -335,6 +335,8 @@ object C {
 
 class D(c: String) extends E(c) with F
 
+class MyClass extends Potato() with Tomato
+
 ---
 
 (compilation_unit
@@ -368,6 +370,11 @@ class D(c: String) extends E(c) with F
       (class_parameter (identifier) (type_identifier)))
     (extends_clause
        (type_identifier) (arguments (identifier))
+       (type_identifier)))
+  (class_definition
+    (identifier)
+    (extends_clause
+       (type_identifier) (arguments)
        (type_identifier))))
 
 =======================================

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -114,7 +114,7 @@ class F extends Cloneable with Resetable with Serializable {}
     (type_identifier) (block))
   (class_definition (identifier)
     (extends_clause
-      (compound_type (type_identifier) (type_identifier) (type_identifier)))
+      (type_identifier) (type_identifier) (type_identifier))
     (template_body)))
 
 ==================================

--- a/grammar.js
+++ b/grammar.js
@@ -515,11 +515,11 @@ module.exports = grammar({
     /**
      * StructuralInstance ::=  ConstrApp {'with' ConstrApp} ['with' WithTemplateBody]
      */
-    _structural_instance: $ => seq(
+    _structural_instance: $ => prec.left(PREC.compound, seq(
       $._constructor_application,
       'with',
       field('body', $.with_template_body),
-    ),
+    )),
 
     /**
      * ConstrApp         ::=  SimpleType1 {Annotation} {ParArgumentExprs}
@@ -543,6 +543,11 @@ module.exports = grammar({
         $.compound_type,
         field('arguments', $.arguments),
       ),
+    )),
+
+    _constructor_applications: $ => prec.left(choice(
+      commaSep1($._constructor_application),
+      sep1('with', $._constructor_application),
     )),
 
     modifiers: $ => repeat1(choice(
@@ -575,9 +580,12 @@ module.exports = grammar({
     open_modifier: $ => 'open',
     transparent_modifier: $ => 'transparent',
 
+    /**
+     * InheritClauses    ::=  ['extends' ConstrApps] ['derives' QualId {',' QualId}]
+     */
     extends_clause: $ => prec.left(seq(
       'extends',
-      field('type', $._type),
+      field('type', $._constructor_applications),
       optional($.arguments)
     )),
 

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -3,7 +3,7 @@
 # This is an integration test to generally check the quality of parsing.
 
 SCALA_SCALA_LIBRARY_EXPECTED=100
-SCALA_SCALA_COMPILER_EXPECTED=66
+SCALA_SCALA_COMPILER_EXPECTED=67
 DOTTY_COMPILER_EXPECTED=66
 
 if [ ! -d "$SCALA_SCALA_DIR" ]; then


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/53
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/56

Problem
-------
1. In Scala 3, extends clause can be comma separated.
2. In Scala 2 or 3 extends clause can ctor with parameters:
   `class D with E(x) with F(y)`.

Solution
--------
`extends` is now followed by *constructor applications* separated by
either `with` or `,` as opposed to treating them as a compound type.
