### PR TITLE
Fixes annotation, sort of

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -399,6 +399,9 @@ Class definitions with parameters
 
 class Point(val x: Int, val y: Int)(implicit coord: Coord)
 
+// TODO: The last argument should become class_parameters
+class A @Inject()(x: Int, y: Int)
+
 ---
 
 (compilation_unit
@@ -408,7 +411,16 @@ class Point(val x: Int, val y: Int)(implicit coord: Coord)
       (class_parameter (identifier) (type_identifier))
       (class_parameter (identifier) (type_identifier)))
     (class_parameters
-      (class_parameter (identifier) (type_identifier)))))
+      (class_parameter (identifier) (type_identifier))))
+  (comment)
+  (class_definition
+    (identifier)
+    (annotation
+     (type_identifier)
+     (arguments)
+     (arguments
+       (ascription_expression (identifier) (type_identifier))
+       (ascription_expression (identifier) (type_identifier))))))
 
 =======================================
 Class definitions with parameters (Scala 3 syntax)
@@ -416,6 +428,15 @@ Class definitions with parameters (Scala 3 syntax)
 
 class Point(val x: Int, val y: Int)(using coord: Coord)
 
+// TODO: The last argument should become class_parameters
+class A @ann (x: Int, y: Int)
+
+// TODO: The last argument should become class_parameters
+class A @ann(1) (x: Int, y: Int)
+
+// TODO: The last argument should become class_parameters
+class A @ann(1)(1) (x: Int, y: Int)
+
 ---
 
 (compilation_unit
@@ -425,7 +446,35 @@ class Point(val x: Int, val y: Int)(using coord: Coord)
       (class_parameter (identifier) (type_identifier))
       (class_parameter (identifier) (type_identifier)))
     (class_parameters
-      (class_parameter (identifier) (type_identifier)))))
+      (class_parameter (identifier) (type_identifier))))
+  (comment)
+  (class_definition
+    (identifier)
+    (annotation
+     (type_identifier)
+     (arguments
+       (ascription_expression (identifier) (type_identifier))
+       (ascription_expression (identifier) (type_identifier)))))
+  (comment)
+  (class_definition
+    (identifier)
+    (annotation
+     (type_identifier)
+     (arguments (integer_literal))
+     (arguments
+       (ascription_expression (identifier) (type_identifier))
+       (ascription_expression (identifier) (type_identifier)))))
+  (comment)
+  (class_definition
+    (identifier)
+    (annotation
+     (type_identifier)
+     (arguments (integer_literal))
+     (arguments (integer_literal))
+     (arguments
+       (ascription_expression (identifier) (type_identifier))
+       (ascription_expression (identifier) (type_identifier)))))
+)
 
 =======================================
 Modifiers

--- a/grammar.js
+++ b/grammar.js
@@ -254,10 +254,12 @@ module.exports = grammar({
 
     /**
      * ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses
+     * ConstrMods        ::=  {Annotation} [AccessModifier]
      */
     _class_constructor: $ => prec.right(seq(
       field('name', $._identifier),
       field('type_parameters', optional($.type_parameters)),
+      optional($.annotation),
       optional($.access_modifier),
       field('class_parameters', repeat($.class_parameters)),
     )),


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/41

Problem
-------
1. class constructor should accept annotation, but it doesn't.
2. Apparently Scala 3 does allow zero, one, or multiple parameter list
   to an annotation, and differentiated between the class parameter by
   its lack of type ascription.

Solution
--------
1. Add optional annotation for constructor. At this point, we can at
   least parse the code with annotation on the ctor.
2. Unfortunatley, however, tree-sitter doesn't make enough lookahead to
   distinguish postfix expr or ascription expression `(x: Int)`,
   for now the class parameters will end up being parsed as arguments to
   the annotation.