### PR TITLE
Singleton type

### DIFF
--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -294,6 +294,23 @@ class Test(d: "hello", b: 25)
           (integer_literal))))))
 
 ==================================
+Singleton Types
+==================================
+
+class A:
+  def foobar: this.type = this
+  type X = A.B.type
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition (identifier) (singleton_type (identifier)) (identifier))
+      (type_definition (type_identifier) (singleton_type (stable_identifier (identifier) (identifier)))))))
+
+==================================
 Opaque type aliases (Scala 3)
 ==================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -682,6 +682,7 @@ module.exports = grammar({
       $.generic_type,
       $.projected_type,
       $.tuple_type,
+      $.singleton_type,
       $.stable_type_identifier,
       $._type_identifier,
       $.wildcard,
@@ -704,6 +705,12 @@ module.exports = grammar({
       commaSep1($._type),
       ')',
     ),
+
+    singleton_type: $ => prec.left(PREC.stable_type_id, seq(
+      choice($._identifier, $.stable_identifier),
+      '.',
+      'type',
+    )),
 
     stable_type_identifier: $ => prec.left(PREC.stable_type_id, seq(
       choice($._identifier, $.stable_identifier),


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/3

Problem
-------
Currently singleton types are treated as `stable_type_identifier`.

Solution
--------
This adds `singleton_type`.