### PR TITLE
chore: sync highlights back with nvim-treesitter

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,22 +1,22 @@
 ; CREDITS @stumash (stuart.mashaal@gmail.com)
 
 (class_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (enum_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (object_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (trait_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (full_enum_case
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 (simple_enum_case
-  name: (identifier) @type.definition)
+  name: (identifier) @type)
 
 ;; variables
 
@@ -96,8 +96,6 @@
 (generic_function
   function: (identifier) @function.call)
 
-;; I think this is broken
-
 ; function definitions
 
 (function_definition
@@ -110,7 +108,6 @@
   name: (identifier) @parameter)
 
 ; expressions
-
 
 (field_expression field: (identifier) @property)
 (field_expression value: (identifier) @type
@@ -161,6 +158,7 @@
   "var"
   "with"
   "given"
+  "using"
   "end"
   "implicit"
   "extension"
@@ -170,18 +168,13 @@
 [
   "abstract"
   "final"
-  "using"
   "lazy"
   "sealed"
+  "private"
+  "protected"
 ] @type.qualifier
 
 (inline_modifier) @storageclass
-
-[
-  "private"
-  "protected"
-] @storageclass
-
 
 (null_literal) @constant.builtin
 

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -1,6 +1,6 @@
 object Hello {
 // ^ keyword 
-//       ^ type.definition
+//       ^ type
   val x = if (true) (25 * 1.0) else "hello"  
 // ^keyword
 //    ^variable
@@ -17,7 +17,7 @@ object Hello {
 
   trait Test {
 // ^ keyword 
-//       ^ type.definition
+//       ^ type
      def meth(i: Int)(implicit x: Boolean) = ???
 //    ^keyword.function  
 //                       ^keyword    
@@ -27,7 +27,7 @@ object Hello {
   }
 
   protected abstract class Bla(test: String)
-//    ^storageclass
+//    ^type.qualifier
 //                    ^keyword
 //            ^type.qualifier 
 //                              ^parameter
@@ -40,7 +40,7 @@ object Hello {
 
   class A {
 // ^ keyword
-//      ^ type.definition
+//      ^ type
     self: X =>
 //  ^constant
 //        ^type

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -1,7 +1,7 @@
 // Optional braces syntax
 class C:
 // ^keyword
-//    ^type.definition
+//    ^type
 
   def test(aaaa: A): Int =
   //^keyword.function
@@ -17,7 +17,7 @@ class C:
 
 object O1:
 //^keyword
-//     ^type.definition
+//     ^type
 
   def test: Unit = ()
   //^keyword.function
@@ -63,16 +63,16 @@ enum Test(a: Int) derives Codec:
 //            ^type
 //                   ^keyword
 //                          ^type
-//    ^type.definition
+//    ^type
 //        ^parameter
   case Test(b: String)
   // ^keyword     
   //               ^type
-  //      ^type.definition
+  //      ^type
   //        ^parameter
   case Hello, Bla
-  //      ^type.definition
-  //          ^type.definition
+  //      ^type
+  //          ^type
   case Bla extends Test(256)
   //          ^keyword
 
@@ -98,7 +98,7 @@ inline given Test = new Test {
 
 object A:
 // ^ keyword
-//     ^type.definition
+//     ^type
 
   ::(123)
 //^function.call


### PR DESCRIPTION
NOTE that there are still out of sync a bit. The small change that was added in from the fewer braces support isn't yet in nvim-treesitter, but once we generate again after https://github.com/tree-sitter/tree-sitter-scala/pull/147, then I'll fully sync that back.