### PR TITLE
Fixes buffer overrun

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,25 @@
+name: Fuzz parser
+
+# Run this workflow on changes to the external scanner
+on:
+  workflow_dispatch:
+  #push:
+  #  paths:
+  #  - src/scanner.c
+  #  - src/stack.h
+  #pull_request:
+  #  paths:
+  #  - src/scanner.c
+  #  - src/stack.h
+
+jobs:
+  test:
+    name: Parser fuzzing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: eed3si9n/tree-sitter-fuzz-action@v1
+        with:
+          language: scala
+          external-scanner: src/scanner.c
+          time: 60

--- a/src/stack.h
+++ b/src/stack.h
@@ -10,10 +10,11 @@
 #define LOG(...)
 #endif
 
-#define STACK_SIZE 1024
+// Total payload size is 1024 bytes max
+#define STACK_SIZE 100
 
 typedef struct ScannerStack {
-  unsigned int stack[STACK_SIZE];
+  int stack[STACK_SIZE];
   int top;
   int last_indentation_size;
   int last_newline_count;
@@ -63,7 +64,10 @@ void printStack(ScannerStack *stack, char *msg) {
 }
 
 unsigned serialiseStack(ScannerStack *stack, char *buf) {
-  unsigned elements = isEmptyStack(stack) ? 0 : stack->top;
+  int elements = isEmptyStack(stack) ? 0 : stack->top;
+  if (elements < 0) {
+    elements = 0;
+  }
   unsigned result_length = (elements + 3) * sizeof(int);
   int *placement = (int *)buf;
   memcpy(placement, stack->stack, elements * sizeof(int));

--- a/test/test-stack.c
+++ b/test/test-stack.c
@@ -26,19 +26,19 @@ int main() {
   assert(peekStack(stack) == -1);
   assert(isEmptyStack(stack));
 
-  char *buf = malloc(2048);
+  char *buf = malloc(1024);
 
-  for (int i = 0; i < 250; i++) {
+  for (int i = 0; i < 100; i++) {
     pushStack(stack, i);
   }
 
-  assert(serialiseStack(stack, buf) == sizeof(int) * 253);
+  assert(serialiseStack(stack, buf) == sizeof(int) * 103);
 
   ScannerStack *newStack = createStack();
 
-  deserialiseStack(newStack, buf, sizeof(int) * 253);
-  assert(newStack -> top == 250);
-  assert(popStack(newStack) == 249);
+  deserialiseStack(newStack, buf, sizeof(int) * 103);
+  assert(newStack -> top == 100);
+  assert(popStack(newStack) == 99);
 
   resetStack(newStack);
 


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/159
Ref https://github.com/nvim-treesitter/nvim-treesitter/issues/4170

Problem
-------
The buffer given for payload serialization is 1024, but we are currently using (1024 + 3) * sizeof(int)

Solution
--------
Reduce it way down.