### PR TITLE
Fixes crash, take 2

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,14 +3,14 @@ name: Fuzz parser
 # Run this workflow on changes to the external scanner
 on:
   workflow_dispatch:
-  #push:
-  #  paths:
-  #  - src/scanner.c
-  #  - src/stack.h
-  #pull_request:
-  #  paths:
-  #  - src/scanner.c
-  #  - src/stack.h
+  push:
+    paths:
+    - src/scanner.c
+    - src/stack.h
+  pull_request:
+    paths:
+    - src/scanner.c
+    - src/stack.h
 
 jobs:
   test:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: eed3si9n/tree-sitter-fuzz-action@v1
+      - uses: vigoux/tree-sitter-fuzz-action@v1
         with:
           language: scala
           external-scanner: src/scanner.c

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -144,13 +144,18 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
     lexer->result_symbol = OUTDENT;
     stack->last_indentation_size = indentation_size;
     stack->last_newline_count = newline_count;
-    stack->last_column = lexer->get_column(lexer);
+    if (lexer->eof(lexer)) {
+      stack->last_column = -1;
+    } else {
+      stack->last_column = lexer->get_column(lexer);
+    }
     return true;
   }
 
   // Recover newline_count from the outdent reset
   if (stack->last_newline_count > 0 &&
-    lexer->get_column(lexer) == stack->last_column) {
+    ((lexer->eof(lexer) && stack->last_column == -1)
+      || lexer->get_column(lexer) == stack->last_column)) {
     newline_count += stack->last_newline_count;
   }
   stack->last_newline_count = 0;


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/159

Problem
-------
tree-sitter-scala crashes under mysterious conditions. gdb seems to indicate that it happens around `get_column`.

Solution
--------
Avoid calling `get_column` when it's at the end of file. That seems to satisfy fuzz.