### PR TITLE
feat: add an explicit interpolator field

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1281,7 +1281,7 @@ module.exports = grammar({
     )),
 
     interpolated_string_expression: $ => seq(
-      $.identifier,
+      field('interpolator', $.identifier),
       $.interpolated_string
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -23,7 +23,6 @@
 (class_parameter 
   name: (identifier) @parameter)
 
-
 (interpolation) @none
 
 ;; types
@@ -32,7 +31,6 @@
   name: (type_identifier) @type.definition)
 
 (type_identifier) @type
-
 
 ;; val/var definitions/declarations
 
@@ -78,7 +76,6 @@
 
 ; method invocation
 
-
 (call_expression
   function: (identifier) @function.call)
 
@@ -95,6 +92,9 @@
 
 (generic_function
   function: (identifier) @function.call)
+
+(interpolated_string_expression
+  interpolator: (identifier) @function.call)
 
 ; function definitions
 

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -54,5 +54,9 @@ object Hello {
   type A = B[({ type f[x] = M[S, x] })#f]
 //               ^keyword
 //                   ^type.definition
+
+  val hello = c"some $stuff"
+//            ^function.call
+//                   ^punctuation.special
 }
 


### PR DESCRIPTION
_The problem_

Currently when you come across string interpolation you don't get any
special highlighting for the actual interpolator meaning:

```scala
ivy"com.lihaoyi::os-lib:0.9.0"
```

Is all colored the same.

_The Solution_

The pr makes 2 changes.

- The `identifier` we use for the interpolator now becomes a field for
  no reason other than I thought it'd be nice to just give it a name
- A hightlight query that captures it and assigns it to `function.call`.
