### PR TITLE
Fixes pattern match with guard

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -417,6 +417,8 @@ def matchTest(x: Int): String = x match {
   case 3 => {
     "3"
   }
+  case A if a == 1 =>
+  case A if a == 2 => 2
   case ((i, _)) => i
   case _ =>
     val x = "many"
@@ -435,6 +437,8 @@ def matchTest(x: Int): String = x match {
       (case_clause (integer_literal) (string) (string))
       (case_clause (integer_literal) (string))
       (case_clause (integer_literal) (block (string)))
+      (case_clause (identifier) (guard (infix_expression (identifier) (operator_identifier) (integer_literal))))
+      (case_clause (identifier) (guard (infix_expression (identifier) (operator_identifier) (integer_literal))) (integer_literal))
       (case_clause (tuple_pattern (tuple_pattern (identifier) (wildcard))) (identifier))
       (case_clause (wildcard) (val_definition (identifier) (string)) (string))))))
 

--- a/grammar.js
+++ b/grammar.js
@@ -6,6 +6,7 @@ const PREC = {
   while: 2,
   binding_def: 3,
   assign: 3,
+  case: 3,
   stable_id: 4,
   unit: 4,
   ascription: 4,
@@ -948,18 +949,23 @@ module.exports = grammar({
       seq('{', repeat1($.case_clause), '}'),
     ),
 
-    case_clause: $ => prec.left(seq(
+    case_clause: $ => prec.left(PREC.control, seq(
       'case',
-      field('pattern', $._pattern),
-      optional($.guard),
-      '=>',
+      $._case_pattern,
       field('body', optional($._block)),
     )),
 
-    guard: $ => seq(
+    // This is created to capture guard from the right
+    _case_pattern: $ => prec.right(10, seq(
+      field('pattern', $._pattern),
+      optional($.guard),
+      '=>',
+    )),
+
+    guard: $ => prec.left(PREC.control, seq(
       'if',
       field('condition', $._postfix_expression_choice)
-    ),
+    )),
 
     assignment_expression: $ => prec.right(PREC.assign, seq(
       field('left', choice(


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/132

Problem
-------
Currently pattern match with guard doesn't parse.

Solution
--------
This implements it by creating an intermediate node called `_case_pattern` with right associativity.

Note
-----

```
$ diff -U 0 main-reports/report-scala2-compiler.txt report-scala2-compiler.txt | rg '^[+-]\w+'
4:-scala/tools/nsc/ast/DocComments.scala                                        (ERROR [314, 32] - [567, 0])
5:+scala/tools/nsc/ast/DocComments.scala                                        (ERROR [314, 32] - [319, 2])
7:-scala/tools/nsc/ast/parser/TreeBuilder.scala                                 (ERROR [143, 60] - [143, 61])
10:+scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala                     (ERROR [560, 6] - [627, 4])
13:+scala/tools/nsc/tasty/TreeUnpickler.scala                                   (ERROR [368, 10] - [378, 8])
16:+scala/tools/nsc/typechecker/Checkable.scala                                 (ERROR [320, 16] - [326, 13])
20:+scala/tools/nsc/typechecker/splain/SplainFormatting.scala                   (ERROR [360, 4] - [367, 2])
$ diff -U 0 main-reports/report-dotty-compiler.txt report-dotty-compiler.txt | rg '^[+-]\w+'
4:+src/dotty/tools/backend/sjs/JSCodeGen.scala                                                  (ERROR [805, 11] - [805, 12])
7:+src/dotty/tools/dotc/semanticdb/Scala3.scala                                                 (ERROR [163, 4] - [163, 36])
10:+src/dotty/tools/dotc/transform/ExtensionMethods.scala                                       (ERROR [117, 8] - [125, 6])
13:+src/dotty/tools/MainGenericCompiler.scala                                                   (ERROR [175, 21] - [175, 22])
16:+src/dotty/tools/repl/ParseResult.scala                                                      (ERROR [156, 44] - [156, 45])
19:+test-coursier/dotty/tools/coursier/CoursierScalaTests.scala                                 (ERROR [168, 175] - [168, 178])
23:+test/dotty/tools/dotc/SettingsTests.scala                                                   (ERROR [181, 98] - [181, 99])
```
