### PR TITLE
refactor(queries): change uppercase from constant to type

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -241,7 +241,7 @@
 
 (operator_identifier) @operator
 
-((identifier) @constant (#lua-match? @constant "^[A-Z]"))
+((identifier) @type (#lua-match? @type "^[A-Z]"))
 ((identifier) @variable.builtin
  (#lua-match? @variable.builtin "^this$"))
 

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -1,3 +1,7 @@
+import java.time.Instant
+//^include
+//     ^namespace
+//               ^type
 object Hello {
 // ^ keyword 
 //       ^ type
@@ -53,7 +57,7 @@ object Hello {
 // ^ keyword
 //      ^ type
     self: X =>
-//  ^constant
+//  ^type
 //        ^type
   }
 

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -51,7 +51,7 @@ class C:
   // This is SIP-44
   val y = x:
     Int
-    //^constant
+    //^type
 
 // Ascription expression
 class C:


### PR DESCRIPTION
This is in reference to the conversation that was in
https://github.com/tree-sitter/tree-sitter-scala/discussions/168 around
imports and the coloring of the final part. Taken from Eugene's comment,
which made a lot of sense to message

> In Scala we have namespace for terms and types, and they can each
> define the same name, often encouraged as "companion object", so at the
> point of import statement it's ambiguous.

This is relevant in the import case, but I also think I agree with it
most of the time when you have an uppercase identifier. While there may
be times this isn't the case, I think it's a safe default.

If we agree on this, I'll open a pr in nvim-treesitter so that test passes.
