### PR TITLE
Fix `as` import renaming in Scala 3

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -263,26 +263,56 @@ Imports: Rename (Scala 3 Syntax)
 ================================
 
 import lang.System.{lineSeparator as EOL}
+import lang.System.lineSeparator as EOL
+import lang.System.lineSeparator as _
 
 ---
 
 (compilation_unit
   (import_declaration
-    (identifier) (identifier)
-    (namespace_selectors (renamed_identifier (identifier) (identifier)))))
+    (identifier)
+    (identifier)
+    (namespace_selectors
+      (as_renamed_identifier
+        (identifier)
+        (identifier))))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (as_renamed_identifier
+      (identifier)
+      (identifier)))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (as_renamed_identifier
+      (identifier)
+      (wildcard))))
 
 ================================
 Imports: Rename
 ================================
 
 import lang.System.{lineSeparator => EOL}
+import lang.System.{lineSeparator => _}
 
 ---
 
 (compilation_unit
   (import_declaration
-    (identifier) (identifier)
-    (namespace_selectors (renamed_identifier (identifier) (identifier)))))
+    (identifier)
+    (identifier)
+    (namespace_selectors
+      (arrow_renamed_identifier
+        (identifier)
+        (identifier))))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (namespace_selectors
+      (arrow_renamed_identifier
+        (identifier)
+        (wildcard)))))
 
 
 =================================
@@ -1190,6 +1220,8 @@ Exports (Scala 3)
 
 export scanUnit.scan
 export printUnit.{status as _, *}
+export printUnit.Test as Hello
+export printUnit.Test as _
 
 ---
 
@@ -1200,7 +1232,18 @@ export printUnit.{status as _, *}
   (export_declaration
     (identifier)
     (namespace_selectors
-      (renamed_identifier
+      (as_renamed_identifier
         (identifier)
         (wildcard))
-      (namespace_wildcard))))
+      (namespace_wildcard)))
+  (export_declaration
+    (identifier)
+      (as_renamed_identifier
+        (identifier)
+        (identifier)))
+  (export_declaration
+    (identifier)
+      (as_renamed_identifier
+        (identifier)
+        (wildcard)))
+)

--- a/grammar.js
+++ b/grammar.js
@@ -199,6 +199,10 @@ module.exports = grammar({
         choice(
           $.namespace_wildcard,
           $.namespace_selectors,
+          // Only allowed in Scala 3 
+          // ImportExpr        ::= 
+          //    SimpleRef {‘.’ id} ‘.’ ImportSpec |  SimpleRef ‘as’ id
+          $.as_renamed_identifier
         ),
       )),
     )),
@@ -215,7 +219,8 @@ module.exports = grammar({
           $._namespace_given_by_type,
           $.namespace_wildcard,
           $.identifier,
-          $.renamed_identifier
+          $.arrow_renamed_identifier,
+          $.as_renamed_identifier
         )),
       '}'
     ),
@@ -223,9 +228,15 @@ module.exports = grammar({
     // deprecated: Remove when highlight query is updated for Neovim
     _import_selectors: $ => alias($.namespace_selectors, $.import_selectors),
 
-    renamed_identifier: $ => seq(
+    arrow_renamed_identifier: $ => seq(
       field('name', $.identifier),
-      choice('=>', 'as'),
+      '=>',
+      field('alias', choice($.identifier, $.wildcard))
+    ),
+
+    as_renamed_identifier: $ => seq(
+      field('name', $.identifier),
+      'as',
       field('alias', choice($.identifier, $.wildcard))
     ),
 


### PR DESCRIPTION
In Scala 3, you can rename a single identifier without the curly braces if you use `as`
Doesn't work with `=>`