### PR TITLE
Fix semicolon on package

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -127,6 +127,17 @@ package c {
       (object_definition (identifier)))))
 
 ================================
+Package with comma
+================================
+
+package a.b;
+
+---
+
+(compilation_unit
+  (package_clause (package_identifier (identifier) (identifier))))
+
+================================
 Package (Scala 3 syntax)
 ================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -164,6 +164,7 @@ module.exports = grammar({
     package_clause: $ => seq(
       'package',
       field('name', $.package_identifier),
+      optional($._semicolon),
       // This is slightly more permissive than the EBNF in that it allows any
       // kind of delcaration inside of the package blocks. As we're more
       // concerned with the structure rather than the validity of the program


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/178

Problem
-------
Package declaration with semicolon fails to parse.

Solution
--------
This adds an optional semicolon to fix that.