### PR TITLE
fix: Correctly handle _ separator in integer literals

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -67,10 +67,14 @@ val l1 = -0l
 val l2 = 1234L
 val l3 = 0xF23l
 val l4 = 0XA03L
+val l5 = 150_000_000
+val l6 = 0xFF_FF_FF
 
 ---
 
 (compilation_unit
+  (val_definition (identifier) (integer_literal))
+  (val_definition (identifier) (integer_literal))
   (val_definition (identifier) (integer_literal))
   (val_definition (identifier) (integer_literal))
   (val_definition (identifier) (integer_literal))

--- a/grammar.js
+++ b/grammar.js
@@ -1248,8 +1248,8 @@ module.exports = grammar({
       seq(
         optional(/[-]/),
         choice(
-          /[\d]+/,
-          /0[xX][\da-fA-F]+/
+          /[\d](_?\d)*/,
+          /0[xX][\da-fA-F](_?[\da-fA-F])*/
         ),
         optional(/[lL]/)
       )


### PR DESCRIPTION
I noticed that syntax highlighting breaks when `_` is present in integer literals. 
![image](https://user-images.githubusercontent.com/5662622/224551451-8447ea05-7852-4801-8ff8-338b577057a2.png)

This PR fixes that.