### PR TITLE
fix: Incorrect string interpolation highlighting group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: copy nvim-treesitter queries
         if: ${{ runner.os == 'Linux' }}
         shell: bash
-        run: cp ./nvim_treesitter/queries/scala/*.scm ./queries/scala/
+        run: cp ./nvim_treesitter/queries/scala/*.scm ./queries/
 
       - name: Check if queries are out of sync with nvim-treesitter
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,22 +98,22 @@ jobs:
           DOTTY_DIR: dotty
         run: script/smoke_test.sh
 
-      - name: copy nvim-treesitter highlight queries
+      - name: copy nvim-treesitter queries
         if: ${{ runner.os == 'Linux' }}
         shell: bash
-        run: cp ./nvim_treesitter/queries/scala/highlights.scm ./queries/scala/highlights.scm
+        run: cp ./nvim_treesitter/queries/scala/*.scm ./queries/scala/
 
-      - name: Check if highlight queries are out of sync with nvim-treesitter
+      - name: Check if queries are out of sync with nvim-treesitter
         if: ${{ runner.os == 'Linux' }}
         uses: tj-actions/verify-changed-files@v13
         id: verify-changed-files
         with:
           files: |
-            queries/scala/highlights.scm
+            queries/scala/*.scm
 
       - name: Test quries if out of sync with nvim-treesitter
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
-          echo "::warning file=queries/scala/highlights.scm::Queries in this repo are out of sync with nvim-treesitter"
-          git diff queries/scala/highlights.scm
+          echo "::warning Queries in ${{ steps.verify-changed-files.outputs.changed_files }} in this repo are out of sync with nvim-treesitter"
+          git diff queries/scala/
           npm run test

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -37,7 +37,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/scala/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+pub const LOCALS_QUERY: &'static str = include_str!("../../queries/scala/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
       "file-types": [
         "scala"
       ],
-      "highlights": "queries/scala/highlights.scm"
+      "highlights": "queries/scala/highlights.scm",
+      "locals": "queries/scala/locals.scm"
     }
   ]
 }

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -23,7 +23,10 @@
 (class_parameter 
   name: (identifier) @parameter)
 
-(interpolation) @none
+(self_type (identifier) @parameter)
+
+(interpolation (identifier) @none)
+(interpolation (block) @none)
 
 ;; types
 

--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -1,0 +1,29 @@
+(template_body) @local.scope
+(lambda_expression) @local.scope
+
+
+(function_declaration
+      name: (identifier) @local.definition) @local.scope
+
+(function_definition
+      name: (identifier) @local.definition)
+
+(parameter
+  name: (identifier) @local.definition)
+
+(binding
+  name: (identifier) @local.definition)
+
+(val_definition
+  pattern: (identifier) @local.definition)
+
+(var_definition
+  pattern: (identifier) @local.definition)
+
+(val_declaration
+  name: (identifier) @local.definition)
+
+(var_declaration
+  name: (identifier) @local.definition)
+
+(identifier) @local.reference

--- a/test/highlight/basics.scala
+++ b/test/highlight/basics.scala
@@ -57,7 +57,7 @@ object Hello {
 // ^ keyword
 //      ^ type
     self: X =>
-//  ^type
+//  ^parameter
 //        ^type
   }
 
@@ -70,8 +70,14 @@ object Hello {
 //               ^keyword
 //                   ^type.definition
 
-  val hello = c"some $stuff"
+  val hello = c"some $mutation ${1}"
 //            ^function.call
 //                   ^punctuation.special
+//                     ^variable
+//                               ^number
+  def meth = ???
+//     ^method
+  val hello2 = c"some $meth"
+//                      ^method
 }
 

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -141,9 +141,9 @@ class Copier:
 
   export scanUnit.scan
   // ^ include
-  //        ^namespace
+  //        ^variable
   export printUnit.{status as _, *}
   // ^ include
-  //        ^namespace
+  //        ^variable
 
   def status: List[String] = printUnit.status ++ scanUnit.status


### PR DESCRIPTION
I noticed that values from interpolated strings are not highlighted correctly:

![Screenshot from 2023-03-12 22-11-18](https://user-images.githubusercontent.com/5662622/224574460-60340b29-bf98-4047-a352-cabe2b34f052.png)
 
In order to have correct hl (highlight) group assigned I had to introduce scope tracking feature from the treesitter. After that some hl tests started failing. 

Since some of the changes might be controversial I breakdown them here:
1. in `self: X =>` `self` had a `type` hl group previously. I dunno why. I changed it to `parameter`
2. in `export scanUnit.scan` `scanUnit` was a `namespace` but it is declared few lines above as a variable hence it should has the same hl group as its definition. 

   According to the treesitter documentation:
   > Good syntax highlighting helps the reader to quickly distinguish between the different types of entities in their code. Ideally, if a given entity appears in multiple places, it should be colored the same in each place. 
3. `(interpolation) @none` was too wide and I couldn't get it to work with the rest of the changes, so I narrowed it. 
