### PR TITLE
Downgrade tree-sitter-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.14.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.7"
+    "tree-sitter-cli": "0.20.7"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",


### PR DESCRIPTION
**Problem**
CI is failing on Ubuntu 20.04.
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/211
See also https://github.com/tree-sitter/tree-sitter/issues/2272

**Solution**
Try downgrading tree-sitter-cli.