### PR TITLE
chore: Update nixpkgs to 22.11 and add python3 to devshell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 let
   nixpkgs = fetchTarball {
     name = "nixpkgs";
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.05.tar.gz";
-    sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.11.tar.gz";
+    sha256 = "11w3wn2yjhaa5pv20gbfbirvjq6i3m7pqrq2msf0g7cv44vijwgw";
   };
   pkgs = import nixpkgs { };
 in
@@ -13,6 +13,7 @@ pkgs.mkShell {
     gcc
     clang
     libiconv
+    python3
   ];
   shellHook = ''
     PATH=./node_modules/.bin:$PATH

--- a/default.nix
+++ b/default.nix
@@ -10,15 +10,8 @@ pkgs.mkShell {
   name = "env";
   buildInputs = with pkgs; [
     nodejs
-    gcc
-    clang
-    libiconv
-    python3
+    tree-sitter
   ];
-  shellHook = ''
-    PATH=./node_modules/.bin:$PATH
-    command -v tree-sitter >/dev/null 2>&1 || npm install 
-  '';
 }
 
 


### PR DESCRIPTION
21.05 is already 2 years old. Switching to 22.11 will make sure that binaries are still in the public cache. 

~In addition I added python3 which seems to by needed internally by npm. I didn't notice that before because I had python globally installed.~

I also found out that on the nixos that is more strict regarding the globabl packages tree-sitter installed via npm no longer works. I switched to use tree-sitter from the upstream. 

