### PR TITLE
fix: Anonymous parameters in `using` clauses

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -963,15 +963,15 @@ class A {
     c: D,
     e: F,
   ) = 1
-  def g[H](i) {
-    j
-  }
+
   def h(x: T)(implicit ev: Reads[T])
 
   def l: Int =
     1
 
   def m = ()
+
+  def n(using a: A)(using B <:< B, C =:= C) = ()
 }
 
 --------------------------------------------------------------------------------
@@ -990,15 +990,6 @@ class A {
             (identifier)
             (type_identifier)))
         (integer_literal))
-      (function_definition
-        (identifier)
-        (type_parameters
-          (identifier))
-        (parameters
-          (parameter
-            (identifier)))
-        (block
-          (identifier)))
       (function_declaration
         (identifier)
         (parameters
@@ -1019,6 +1010,22 @@ class A {
           (integer_literal)))
       (function_definition
         (identifier)
+        (unit))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (parameters
+          (infix_type
+            (type_identifier)
+            (operator_identifier)
+            (type_identifier))
+          (infix_type
+            (type_identifier)
+            (operator_identifier)
+            (type_identifier)))
         (unit)))))
 
 ================================================================================

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2942,15 +2942,15 @@
       }
     },
     "parameters": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
             {
               "type": "CHOICE",
               "members": [
@@ -2959,15 +2959,82 @@
                   "value": "implicit"
                 },
                 {
-                  "type": "STRING",
-                  "value": "using"
+                  "type": "BLANK"
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "parameter"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "parameter"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_using_parameters_clause"
+        }
+      ]
+    },
+    "_using_parameters_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": "using"
         },
         {
           "type": "CHOICE",
@@ -3015,7 +3082,46 @@
               ]
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_param_type"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_param_type"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -3171,29 +3277,16 @@
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ":"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "type",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_param_type"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_param_type"
+          }
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4261,7 +4261,7 @@
       },
       "type": {
         "multiple": true,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "annotation",
@@ -4421,7 +4421,67 @@
       "required": false,
       "types": [
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "compound_type",
+          "named": true
+        },
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "generic_type",
+          "named": true
+        },
+        {
+          "type": "infix_type",
+          "named": true
+        },
+        {
+          "type": "lazy_parameter_type",
+          "named": true
+        },
+        {
+          "type": "literal_type",
+          "named": true
+        },
+        {
           "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "projected_type",
+          "named": true
+        },
+        {
+          "type": "repeated_parameter_type",
+          "named": true
+        },
+        {
+          "type": "singleton_type",
+          "named": true
+        },
+        {
+          "type": "stable_type_identifier",
+          "named": true
+        },
+        {
+          "type": "structural_type",
+          "named": true
+        },
+        {
+          "type": "tuple_type",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
+          "named": true
+        },
+        {
+          "type": "wildcard",
           "named": true
         }
       ]


### PR DESCRIPTION
Problem
-------
`$.parameters` required each param to have a name, so `using` clauses like `def x(using X =:= X)` failed to parse

Solution
-------
Introduce `$._using_parameters_clause`, which allows anonymous parameters


Resolves https://github.com/tree-sitter/tree-sitter-scala/issues/187