### PR TITLE
Derives clause for classes and objects

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -421,6 +421,22 @@ object O3 extends A {
     (template_body)))
 
 ================================================================================
+Object definitions
+================================================================================
+case object A extends B derives C, D {}
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (extends_clause
+      (type_identifier))
+    (derives_clause
+      (type_identifier)
+      (type_identifier))
+    (template_body)))
+
+================================================================================
 Class definitions
 ================================================================================
 
@@ -438,6 +454,23 @@ class C[
       (identifier)
       (identifier))
     (template_body)))
+
+================================================================================
+Class definitions (Scala 3)
+================================================================================
+final case class C() extends A derives B, C
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (modifiers)
+    (identifier)
+    (class_parameters)
+    (extends_clause
+      (type_identifier))
+    (derives_clause
+      (type_identifier)
+      (type_identifier))))
 
 ================================================================================
 Subclass definitions

--- a/grammar.js
+++ b/grammar.js
@@ -255,6 +255,7 @@ module.exports = grammar({
     _object_definition: $ => prec.left(seq(
       field('name', $._identifier),
       field('extend', optional($.extends_clause)),
+      field('derive', optional($.derives_clause)),
       field('body', optional($.template_body)),
     )),
 
@@ -265,6 +266,7 @@ module.exports = grammar({
       'class',
       $._class_constructor,
       field('extend', optional($.extends_clause)),
+      field('derive', optional($.derives_clause)),
       field('body', optional($.template_body))
     )),
 
@@ -610,10 +612,10 @@ module.exports = grammar({
       optional($.arguments)
     )),
 
-    derives_clause: $ => seq(
+    derives_clause: $ => prec.left(seq(
       'derives',
       commaSep1(field('type', $._type_identifier))
-    ),
+    )),
 
     class_parameters: $ => prec(1, seq(
       '(',

--- a/grammar.js
+++ b/grammar.js
@@ -264,11 +264,15 @@ module.exports = grammar({
       optional($.modifiers),
       optional('case'),
       'class',
+      $._class_definition,
+    )),
+
+    _class_definition: $ => seq(
       $._class_constructor,
       field('extend', optional($.extends_clause)),
       field('derive', optional($.derives_clause)),
       field('body', optional($.template_body))
-    )),
+    ),
 
     /**
      * ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1011,58 +1011,67 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_class_constructor"
-          },
-          {
-            "type": "FIELD",
-            "name": "extend",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "extends_clause"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "derive",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "derives_clause"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "body",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "template_body"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
+            "name": "_class_definition"
           }
         ]
       }
+    },
+    "_class_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_class_constructor"
+        },
+        {
+          "type": "FIELD",
+          "name": "extend",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "extends_clause"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "derive",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "derives_clause"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "template_body"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        }
+      ]
     },
     "_class_constructor": {
       "type": "PREC_RIGHT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -935,6 +935,22 @@
           },
           {
             "type": "FIELD",
+            "name": "derive",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "derives_clause"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
             "name": "body",
             "content": {
               "type": "CHOICE",
@@ -1006,6 +1022,22 @@
                 {
                   "type": "SYMBOL",
                   "name": "extends_clause"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "derive",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "derives_clause"
                 },
                 {
                   "type": "BLANK"
@@ -2812,46 +2844,50 @@
       }
     },
     "derives_clause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "derives"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "type",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
-              }
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "type",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_type_identifier"
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "derives"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "type",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_type_identifier"
+                }
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "type",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_type_identifier"
+                      }
                     }
-                  }
-                ]
+                  ]
+                }
               }
-            }
-          ]
-        }
-      ]
+            ]
+          }
+        ]
+      }
     },
     "class_parameters": {
       "type": "PREC",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1209,6 +1209,16 @@
           }
         ]
       },
+      "derive": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "derives_clause",
+            "named": true
+          }
+        ]
+      },
       "extend": {
         "multiple": false,
         "required": false,
@@ -4106,6 +4116,16 @@
           }
         ]
       },
+      "derive": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "derives_clause",
+            "named": true
+          }
+        ]
+      },
       "extend": {
         "multiple": false,
         "required": false,
@@ -4201,6 +4221,16 @@
         "types": [
           {
             "type": "template_body",
+            "named": true
+          }
+        ]
+      },
+      "derive": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "derives_clause",
             "named": true
           }
         ]


### PR DESCRIPTION
Closes https://github.com/tree-sitter/tree-sitter-scala/issues/202

Problem
-------
Derives clause is only defined for enums, but not for classes and objects

Solution
-------
Include optional `$.derives_clause` in class and object definitions

Concerns
-------
This change increases `tree-sitter gen` execution time by ~50 percent (while not growing the size of  `parser.c` significantly). This slowdown is similar to to the one from optional branches of  else-clause in `if_expression`, catch-clause of in `try_expression`, etc.

I've opened a discussion on this topic some time ago, but no progress there https://github.com/tree-sitter/tree-sitter/discussions/1948