### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 build
+/.build
 target
 *.log
 test.scala

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterScala",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [.library(name: "TreeSitterScala", targets: ["TreeSitterScala"])],
+    targets: [
+        .target(
+            name: "TreeSitterScala",
+            path: ".",
+            exclude: [
+            ],
+            sources: [
+                "src/parser.c",
+                "src/scanner.c",
+            ],
+            resources: [
+                .copy("queries"),
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+    ]
+)

--- a/bindings/swift/TreeSitterScala/scala.h
+++ b/bindings/swift/TreeSitterScala/scala.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_SCALA_H_
+#define TREE_SITTER_SCALA_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_scala();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_SCALA_H_


### PR DESCRIPTION
Hi friends! Me again :)

This adds Swift bindings and Swift Package Manager (SPM) support. This should require no maintenance on your part, and should not impact the actual parsers in any way. Other similar changes were made here:

https://github.com/tree-sitter/tree-sitter-go
https://github.com/tree-sitter/tree-sitter-c
https://github.com/tree-sitter/tree-sitter-haskell