### PR TITLE
Allow quotes to be last characters of multi-line string

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1,6 +1,6 @@
-==========================
+================================================================================
 Simple strings
-==========================
+================================================================================
 
 val oneLineString = "I'm just on one line"
 
@@ -10,15 +10,24 @@ val multiLineString = """
   ${thisEither}
 """
 
----
+val multiLineString2 = """""""
+
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier) (string))
-  (val_definition (identifier) (string)))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string)))
 
-==========================
+================================================================================
 Interpolated strings
-==========================
+================================================================================
 
 val string1 = s"a $b ${c}"
 
@@ -29,35 +38,46 @@ val string3 = raw"Not a new line \n${ha}"
 val string4 = s"""
 works even in multiline strings, ${name}
 """
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (val_definition
     (identifier)
     (interpolated_string_expression
-      (identifier) (interpolated_string
-        (interpolation (identifier))
-        (interpolation (block (identifier))))))
+      (identifier)
+      (interpolated_string
+        (interpolation
+          (identifier))
+        (interpolation
+          (block
+            (identifier))))))
   (val_definition
     (identifier)
     (interpolated_string_expression
-      (identifier) (interpolated_string
-        (interpolation (identifier)))))
+      (identifier)
+      (interpolated_string
+        (interpolation
+          (identifier)))))
   (val_definition
     (identifier)
     (interpolated_string_expression
-      (identifier) (interpolated_string
-        (interpolation (block (identifier))))))
+      (identifier)
+      (interpolated_string
+        (interpolation
+          (block
+            (identifier))))))
   (val_definition
     (identifier)
     (interpolated_string_expression
-      (identifier) (interpolated_string
-        (interpolation (block (identifier)))))))
+      (identifier)
+      (interpolated_string
+        (interpolation
+          (block
+            (identifier)))))))
 
-
-==========================
+================================================================================
 Integer literals
-==========================
+================================================================================
 
 val i1 = 0
 val i2 = 1234
@@ -70,65 +90,94 @@ val l4 = 0XA03L
 val l5 = 150_000_000
 val l6 = 0xFF_FF_FF
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-  (val_definition (identifier) (integer_literal))
-)
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal)))
 
-==========================
+================================================================================
 Floating point literals
-==========================
+================================================================================
 
 val f1 = 3.14
 val f2 = -3f
 val f2 = 3E-1
 val d1 = .314D
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier) (floating_point_literal))
-  (val_definition (identifier) (floating_point_literal))
-  (val_definition (identifier) (floating_point_literal))
-  (val_definition (identifier) (floating_point_literal))
-  )
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal)))
 
-==========================
+================================================================================
 Boolean literals
-==========================
+================================================================================
 
 val myBool = true
 
 def foo(a: Boolean = false) = a && true
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier) (boolean_literal))
+  (val_definition
+    (identifier)
+    (boolean_literal))
   (function_definition
     (identifier)
-    (parameters (parameter
-      (identifier)
-      (type_identifier)
-      (boolean_literal)))
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)
+        (boolean_literal)))
     (infix_expression
       (identifier)
       (operator_identifier)
       (boolean_literal))))
 
-==========================
+================================================================================
 Character literals
-==========================
+================================================================================
 
 val myChar = 'c'
 
@@ -138,35 +187,48 @@ val anotherChar = '\n'
 
 def foo(a: Char = 'c') = a + 'd'
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier) (character_literal))
-  (val_definition (identifier) (character_literal))
-  (val_definition (identifier) (character_literal))
+  (val_definition
+    (identifier)
+    (character_literal))
+  (val_definition
+    (identifier)
+    (character_literal))
+  (val_definition
+    (identifier)
+    (character_literal))
   (function_definition
     (identifier)
-    (parameters (parameter
-      (identifier)
-      (type_identifier)
-      (character_literal)))
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)
+        (character_literal)))
     (infix_expression
       (identifier)
       (operator_identifier)
       (character_literal))))
 
-==========================
+================================================================================
 Null
-==========================
+================================================================================
 
 lazy val nullObject: String = null
 
----
-(compilation_unit (val_definition (modifiers) (identifier) (type_identifier) (null_literal)))
+--------------------------------------------------------------------------------
 
-==========================
+(compilation_unit
+  (val_definition
+    (modifiers)
+    (identifier)
+    (type_identifier)
+    (null_literal)))
+
+================================================================================
 Tuple literals
-==========================
+================================================================================
 
 val x = (
   1,
@@ -174,8 +236,12 @@ val x = (
   3,
 )
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (val_definition (identifier)
-  (tuple_expression (integer_literal) (integer_literal) (integer_literal))))
+  (val_definition
+    (identifier)
+    (tuple_expression
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -55,7 +55,7 @@ static bool scan_string_content(TSLexer *lexer, bool is_multiline, bool has_inte
         lexer->result_symbol = has_interpolation ? INTERPOLATED_STRING_END : SIMPLE_STRING;
         return true;
       }
-      if (closing_quote_count == 3) {
+      if (closing_quote_count >= 3 && lexer->lookahead != '"') {
         lexer->result_symbol = has_interpolation ? INTERPOLATED_MULTILINE_STRING_END : SIMPLE_MULTILINE_STRING;
         return true;
       }


### PR DESCRIPTION
Resolves https://github.com/tree-sitter/tree-sitter-scala/issues/225

Problem
-------
Strings like `"""""""` are valid in scala, but not in the grammar

Solution
-------
In `scanner.c` emit multi-line string only when at least 3 closing quotes found and the next lookahead is not a quote

Also, corpus/literals.txt was formatted with `tree-sitter test -u`