### PR TITLE
By-name class parameters

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -259,12 +259,12 @@ import a.{ :: }
     (namespace_selectors
       (identifier)))
   (import_declaration
-      (identifier)
-      (operator_identifier))
+    (identifier)
+    (operator_identifier))
   (import_declaration
-      (identifier)
-      (namespace_selectors
-        (operator_identifier))))
+    (identifier)
+    (namespace_selectors
+      (operator_identifier))))
 
 ================================================================================
 Imports: Wildcard
@@ -453,7 +453,7 @@ Class definitions
 class C[
   T,
   U,
-] {
+](a: => A, b: B, c: C*) {
 }
 --------------------------------------------------------------------------------
 
@@ -463,6 +463,18 @@ class C[
     (type_parameters
       (identifier)
       (identifier))
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (lazy_parameter_type
+          (type_identifier)))
+      (class_parameter
+        (identifier)
+        (type_identifier))
+      (class_parameter
+        (identifier)
+        (repeated_parameter_type
+          (type_identifier))))
     (template_body)))
 
 ================================================================================

--- a/grammar.js
+++ b/grammar.js
@@ -663,8 +663,7 @@ module.exports = grammar({
       optional($.modifiers),
       optional(choice('val', 'var')),
       field('name', $._identifier),
-      optional(seq(':', field('type', $._type))),
-      optional('*'),
+      optional(seq(':', field('type', $._param_type))),
       optional(seq('=', field('default_value', $.expression)))
     ),
 


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/228

Problem
-------
By-name parameters in class definitions were not supported:
```scala
class A(a: => B)
```

Solution
-------
Support by-name parameters by changing the rule describing class parameter type from `$._type` to `$._param_type`