### PR TITLE
Self-types in braceless trait definitions

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -1584,10 +1584,11 @@ end Test
         (integer_literal)))))
 
 ================================================================================
-Transparent traits (Scala 3)
+Traits (Scala 3)
 ================================================================================
 
 transparent trait Kind:
+  this: A =>
   def test = 1
 
 --------------------------------------------------------------------------------
@@ -1598,6 +1599,9 @@ transparent trait Kind:
       (transparent_modifier))
     (identifier)
     (template_body
+      (self_type
+        (identifier)
+        (type_identifier))
       (function_definition
         (identifier)
         (integer_literal)))))

--- a/grammar.js
+++ b/grammar.js
@@ -80,6 +80,10 @@ module.exports = grammar({
     // In case of: 'extension'  _indent  '{'  'case'  operator_identifier  'if'  operator_identifier  •  '=>'  …
     // we treat `operator_identifier` as `simple_expression`
     [$._simple_expression, $.lambda_expression],
+    // 'package'  package_identifier  '{'  operator_identifier  •  ':'  …
+    [$.self_type, $._simple_expression],
+    // 'package'  package_identifier  '{'  operator_identifier  '=>'  •  'enum'  …
+    [$.self_type, $.lambda_expression],
   ],
 
   word: $ => $._alpha_identifier,
@@ -350,8 +354,8 @@ module.exports = grammar({
     template_body: $ => choice(
       prec.left(PREC.control, seq(
         ':',
-        optional($.self_type),
         $._indent,
+        optional($.self_type),
         $._block,
         $._outdent,
       )),
@@ -403,7 +407,8 @@ module.exports = grammar({
       ),
     )),
 
-    self_type: $ => prec(4, seq(
+    // Dynamic precedences added here to win over $.call_expression
+    self_type: $ => prec.dynamic(1, seq(
       $._identifier, optional($._self_type_ascription), '=>'
     )),
 


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/230

Problem
-------
Self-types are not parsed in braceless trait definitions:
```scala
trait A:
  this: B =>
````

Solution
-------
Move existing `$.self_type` rule in trait definition into indented scope.
Rebalance `$.self_type` precedence.
Without explicit precedence it looses to `$.call_expression` in
```scala
trait A {
  self: B =>
  def f = ""
}
```
With static precedence instead of dynamic it leads to errors in
definitions like:
```scala
class A
  x: Int // this should be $.ascription_expression
enum B:
  case C
```
