### PR TITLE
Top-level expressions

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1569,3 +1569,49 @@ def hello =
             (inline_modifier)
             (identifier)
             (case_block)))))))
+
+================================================================================
+Top-level expressions
+================================================================================
+
+var greeting = "Good bye"
+greeting = "Hello"
+val message = greeting + " from Scala script!"
+
+if true then
+  println(message)
+
+addSbtPlugin("foo" % "bar" % "0.1")
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (var_definition
+    (identifier)
+    (string))
+  (assignment_expression
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (string)))
+  (if_expression
+    (boolean_literal)
+    (indented_block
+      (call_expression
+        (identifier)
+        (arguments
+          (identifier)))))
+  (call_expression
+    (identifier)
+    (arguments
+      (infix_expression
+        (infix_expression
+          (string)
+          (operator_identifier)
+          (string))
+        (operator_identifier)
+        (string)))))

--- a/grammar.js
+++ b/grammar.js
@@ -103,6 +103,7 @@ module.exports = grammar({
       $.package_object,
       $._definition,
       $._end_marker,
+      $.expression,
     ),
 
     _definition: $ => choice(


### PR DESCRIPTION
Resolves https://github.com/tree-sitter/tree-sitter-scala/issues/198

Problem
-------
Top-level expressions are not supported. However, it's a valid case for Scala scripts or sbt configurations

Solution
-------
Now that AUTOMATIC_SEMICOLON tokens are handled at the top-level enabling top-level expressions is done by including `$.expression` into `$._top_level_definition`