### PR TITLE
Support Scala CLI using directives

### DIFF
--- a/corpus/comments.txt
+++ b/corpus/comments.txt
@@ -31,3 +31,34 @@ Block comments
     (block_comment
       (block_comment)
       (comment))))
+
+================================================================================
+Using directives
+================================================================================
+
+//> using jvm graalvm:21
+//> using scala 3.3.0
+//> using dep foo:bar:1,2,3,url=https://github.com
+//> using exclude "examples/*" "*/resources/*" 
+// > just a comment
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (comment
+    (using_directive
+      (using_directive_key)
+      (using_directive_value)))
+  (comment
+    (using_directive
+      (using_directive_key)
+      (using_directive_value)))
+  (comment
+    (using_directive
+      (using_directive_key)
+      (using_directive_value)))
+  (comment
+    (using_directive
+      (using_directive_key)
+      (using_directive_value)))
+  (comment))

--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,6 @@
 const PREC = {
+  comment: 0,
+  using_directive: 1,
   control: 1,
   stable_type_id: 2,
   binding_decl: 2,
@@ -1580,7 +1582,21 @@ module.exports = grammar({
       repeat1($.guard),
     ),
 
-    comment: $ => token(seq('//', /.*/)),
+    comment: $ => seq(token('//'), choice(
+      $.using_directive,
+      $._comment_text,
+    )),
+
+    _comment_text: $ => token(prec(PREC.comment, /.*/)),
+
+    using_directive: $ => seq(
+      token.immediate(prec(PREC.using_directive, '>')),
+      token('using'),
+      $.using_directive_key,
+      $.using_directive_value,
+    ),
+    using_directive_key: $ => token(/[^\s]+/),
+    using_directive_value: $ => token(/.*/),
 
     block_comment: $ => seq(
       token('/*'),

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -252,3 +252,7 @@
   (identifier) @function.builtin
   (#lua-match? @function.builtin "^super$")
 )
+
+;; Scala CLI using directives
+(using_directive_key) @parameter
+(using_directive_value) @string

--- a/test/highlight/comments.scala
+++ b/test/highlight/comments.scala
@@ -1,0 +1,4 @@
+//> using scala 3.1.0
+//  ^keyword
+//        ^parameter
+//              ^string


### PR DESCRIPTION
Implements https://github.com/tree-sitter/tree-sitter-scala/issues/189

Summary
-------
Single line `$.comment` is split into a choice of `$._comment_text` and `$.using_directive` to parse a structure of comments like
```
//> using scala 3.3.0
```

Highlighted example:

![image](https://github.com/tree-sitter/tree-sitter-scala/assets/15569000/d3434fa2-f9d3-40a3-972e-fd5d05cd579d)
with highlight queries:
```
(using_directive_key) @parameter
(using_directive_value) @string
```