### PR TITLE
Repeat pattern

### DIFF
--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -141,6 +141,7 @@ val x = y match {
   case a @ B(1) => a
   case b @ C(d @ (e @ X, _: Y)) => e
   case req @ (POST | GET) -> Root / "test" => 5
+  case Array(a: Type, _@_*) => y
 }
 
 ---
@@ -168,7 +169,18 @@ val x = y match {
               (capture_pattern (identifier)
                 (tuple_pattern (alternative_pattern (identifier) (identifier))))
               (operator_identifier) (identifier)) (operator_identifier) (string))
-              (integer_literal))))))
+              (integer_literal))
+        (case_clause
+          (case_class_pattern
+            (type_identifier)
+            (typed_pattern
+              (identifier)
+              (type_identifier))
+            (repeat_pattern
+              (capture_pattern
+                (wildcard)
+                (wildcard))))
+          (identifier))))))
 
 ============================
 Quoted patterns (Scala 3 syntax)

--- a/grammar.js
+++ b/grammar.js
@@ -913,7 +913,8 @@ module.exports = grammar({
       $.typed_pattern,
       $.quote_expression,
       $.literal,
-      $.wildcard
+      $.wildcard,
+      $.repeat_pattern,
     ),
 
     case_class_pattern: $ => seq(
@@ -929,10 +930,15 @@ module.exports = grammar({
       field('right', $._pattern),
     )),
 
-    capture_pattern: $ => prec(PREC.field, seq(
-      field('name', $._identifier),
+    capture_pattern: $ => prec.right(PREC.field, seq(
+      field('name', choice($._identifier, $.wildcard)),
       '@',
-      field('pattern', $._pattern)
+      field('pattern', $._pattern),
+    )),
+
+    repeat_pattern: $ => prec.right(seq(
+      field('pattern', $._pattern),
+      '*',
     )),
 
     typed_pattern: $ => prec.right(seq(


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/262

Problem
-------
1. Repeat pattern with `*` doesn't parse.
2. Capture pattern `@` doesn't capture wildcard.

Solution
--------
1. This implements support for `*` in pattern.
2. This also allows using `_@`.