### PR TITLE
Added block comments to the comment highlighting query

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -236,6 +236,7 @@
 "return" @keyword.return
 
 (comment) @comment @spell
+(block_comment) @comment @spell
 
 ;; `case` is a conditional keyword in case_block
 

--- a/test/highlight/comments.scala
+++ b/test/highlight/comments.scala
@@ -2,3 +2,11 @@
 //  ^keyword
 //        ^parameter
 //              ^string
+
+/*
+ * Beep boop
+ */
+// <- comment
+
+// Single line comment
+// <- comment


### PR DESCRIPTION
As per a quick conversation on nvim-metals discord channel - block comments didn't get highlighting query added to them when they were split into their own thing, as per @keynmol :

> I also found the commit where it slipped through the cracks - the comment node got split but the highlighting query wasn't added: https://github.com/tree-sitter/tree-sitter-scala/commit/693c651b509e2654c237a68e52080f0211b4f5bf

This PR rectifies that and adds tests.

Let me know if there's anything else needed here!