### PR TITLE
fix: make sure queries are copied to the right place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: copy nvim-treesitter queries
         if: ${{ runner.os == 'Linux' }}
         shell: bash
-        run: cp ./nvim_treesitter/queries/scala/*.scm ./queries/
+        run: cp ./nvim_treesitter/queries/scala/*.scm ./queries/scala/
 
       - name: Check if queries are out of sync with nvim-treesitter
         if: ${{ runner.os == 'Linux' }}

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -235,8 +235,13 @@
 
 "return" @keyword.return
 
-(comment) @comment @spell
-(block_comment) @comment @spell
+[
+  (comment)
+  (block_comment)
+] @comment @spell
+
+((block_comment) @comment.documentation
+  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
 ;; `case` is a conditional keyword in case_block
 

--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -1,29 +1,42 @@
-(template_body) @local.scope
-(lambda_expression) @local.scope
+; Scopes
 
+[
+  (template_body)
+  (lambda_expression)
+  (function_definition)
+  (block)
+] @scope
+
+; References
+
+(identifier) @reference
+
+; Definitions
 
 (function_declaration
-      name: (identifier) @local.definition) @local.scope
+  name: (identifier) @definition.function)
 
 (function_definition
-      name: (identifier) @local.definition)
+  name: (identifier) @definition.function)
 
 (parameter
-  name: (identifier) @local.definition)
+  name: (identifier) @definition.parameter)
+
+(class_parameter
+  name: (identifier) @definition.parameter)
 
 (binding
-  name: (identifier) @local.definition)
+  name: (identifier) @definition.var)
 
 (val_definition
-  pattern: (identifier) @local.definition)
+  pattern: (identifier) @definition.var)
 
 (var_definition
-  pattern: (identifier) @local.definition)
+  pattern: (identifier) @definition.var)
 
 (val_declaration
-  name: (identifier) @local.definition)
+  name: (identifier) @definition.var)
 
 (var_declaration
-  name: (identifier) @local.definition)
+  name: (identifier) @definition.var)
 
-(identifier) @local.reference


### PR DESCRIPTION
I noticed that the queries in nvim-treesitter and this repo have
diverged, but we never got an error here. I think this was a regression
introduced in
https://github.com/tree-sitter/tree-sitter-scala/commit/7d348f51e442563f4ab2b6c3e136dac658649f93.
