### PR TITLE
Use match? instead of lua-match? for queries

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -64,18 +64,18 @@
 ((stable_identifier (identifier) @namespace))
 
 ((import_declaration
-  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
-((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
 
 (export_declaration
   path: (identifier) @namespace)
 ((stable_identifier (identifier) @namespace))
 
 ((export_declaration
-  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
-((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
+  path: (identifier) @type) (#match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
 
-((namespace_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
+((namespace_selectors (identifier) @type) (#match? @type "^[A-Z]"))
 
 ; method invocation
 
@@ -91,7 +91,7 @@
 
 ((call_expression
    function: (identifier) @constructor)
- (#lua-match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 (generic_function
   function: (identifier) @function.call)
@@ -114,7 +114,7 @@
 
 (field_expression field: (identifier) @property)
 (field_expression value: (identifier) @type
- (#lua-match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 (infix_expression operator: (identifier) @operator)
 (infix_expression operator: (operator_identifier) @operator)
@@ -245,13 +245,13 @@
 
 (operator_identifier) @operator
 
-((identifier) @type (#lua-match? @type "^[A-Z]"))
+((identifier) @type (#match? @type "^[A-Z]"))
 ((identifier) @variable.builtin
- (#lua-match? @variable.builtin "^this$"))
+ (#match? @variable.builtin "^this$"))
 
 (
   (identifier) @function.builtin
-  (#lua-match? @function.builtin "^super$")
+  (#match? @function.builtin "^super$")
 )
 
 ;; Scala CLI using directives

--- a/test/highlight/scala3.scala
+++ b/test/highlight/scala3.scala
@@ -36,8 +36,8 @@ object O2:
 // SIP-44
 class C:
 // ^keyword
+  //  ^type
   fooooo.map: x =>
-  // ^type
   //     ^method.call
     x + 1
 


### PR DESCRIPTION
Improves compatibility with non-`nvim` tree-sitter implementations.
Since we only have very simple patterns, just switching to `match` should be fine.
