### PR TITLE
Scala 2 macros

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1523,6 +1523,30 @@ def main() {
         (identifier)))))
 
 ================================================================================
+Macros (Scala 2 syntax)
+================================================================================
+
+class Foo {
+  def a: A =
+    macro B.b
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (indented_block
+          (macro_body
+            (field_expression
+              (identifier)
+              (identifier))))))))
+
+================================================================================
 Macros (Scala 3 syntax)
 ================================================================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -1019,6 +1019,7 @@ module.exports = grammar({
         $.while_expression,
         $.do_while_expression,
         $.for_expression,
+        $.macro_body,
         $._simple_expression,
       ),
 
@@ -1304,6 +1305,15 @@ module.exports = grammar({
           $.prefix_expression,
           $._simple_expression,
         ),
+      ),
+
+    macro_body: $ =>
+      prec.left(
+        PREC.macro,
+        seq(
+          "macro",
+          choice($.infix_expression, $.prefix_expression, $._simple_expression),
+        )
       ),
 
     /**


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/302

Problem
-------
Scala 2 macro definition is not supported.

Solution
--------
This adds macro_body as an expression.