### PR TITLE
feat: `given` pattern

### DIFF
--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -1,30 +1,36 @@
-=========================
+================================================================================
 Alternative patterns
-=========================
+================================================================================
 
 val x = y match {
   case 1 | a => b
   case "c" | "d" | "e" => f
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (val_definition
     (identifier)
-    (match_expression (identifier) (case_block
-      (case_clause
-        (alternative_pattern (integer_literal) (identifier))
-        (identifier))
-      (case_clause
-        (alternative_pattern
-          (alternative_pattern (string) (string))
-          (string))
-        (identifier))))))
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (alternative_pattern
+            (integer_literal)
+            (identifier))
+          (identifier))
+        (case_clause
+          (alternative_pattern
+            (alternative_pattern
+              (string)
+              (string))
+            (string))
+          (identifier))))))
 
-=========================
+================================================================================
 Typed patterns
-=========================
+================================================================================
 
 val x = y match {
   case 1 : Int => 2
@@ -33,29 +39,44 @@ val x = y match {
   case Object.Constant => 3
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (val_definition
     (identifier)
-    (match_expression (identifier) (case_block
-      (case_clause
-        (typed_pattern (integer_literal) (type_identifier)) (integer_literal))
-      (case_clause
-        (typed_pattern (identifier) (compound_type (type_identifier) (type_identifier)))
-        (identifier))
-      (case_clause
-        (alternative_pattern
-          (typed_pattern (wildcard) (type_identifier))
-          (typed_pattern (wildcard) (type_identifier)))
-        (integer_literal))
-      (case_clause
-        (stable_identifier (identifier) (identifier))
-        (integer_literal))))))
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (typed_pattern
+            (integer_literal)
+            (type_identifier))
+          (integer_literal))
+        (case_clause
+          (typed_pattern
+            (identifier)
+            (compound_type
+              (type_identifier)
+              (type_identifier)))
+          (identifier))
+        (case_clause
+          (alternative_pattern
+            (typed_pattern
+              (wildcard)
+              (type_identifier))
+            (typed_pattern
+              (wildcard)
+              (type_identifier)))
+          (integer_literal))
+        (case_clause
+          (stable_identifier
+            (identifier)
+            (identifier))
+          (integer_literal))))))
 
-============================
+================================================================================
 Tuple patterns
-============================
+================================================================================
 
 val (a, b) = if (c) (d, e) else (f, g)
 
@@ -63,24 +84,36 @@ val x = y match {
   case (A, B) => X
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (val_definition
-    (tuple_pattern (identifier) (identifier))
+    (tuple_pattern
+      (identifier)
+      (identifier))
     (if_expression
-      (parenthesized_expression (identifier))
-      (tuple_expression (identifier) (identifier))
-      (tuple_expression (identifier) (identifier))))
-  (val_definition (identifier)
-    (match_expression (identifier)
+      (parenthesized_expression
+        (identifier))
+      (tuple_expression
+        (identifier)
+        (identifier))
+      (tuple_expression
+        (identifier)
+        (identifier))))
+  (val_definition
+    (identifier)
+    (match_expression
+      (identifier)
       (case_block
         (case_clause
-          (tuple_pattern (identifier) (identifier)) (identifier))))))
+          (tuple_pattern
+            (identifier)
+            (identifier))
+          (identifier))))))
 
-============================
+================================================================================
 Case class patterns
-============================
+================================================================================
 
 def showNotification(notification: Notification): String = {
   notification match {
@@ -93,49 +126,98 @@ def showNotification(notification: Notification): String = {
   }
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (function_definition
     (identifier)
-    (parameters (parameter (identifier) (type_identifier)))
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
     (type_identifier)
     (block
-      (match_expression (identifier) (case_block
-        (case_clause
-          (case_class_pattern (type_identifier) (identifier) (identifier) (wildcard))
-          (interpolated_string_expression (identifier) (interpolated_string (interpolation (identifier)) (interpolation (identifier)))))
-        (case_clause
-          (case_class_pattern (type_identifier) (identifier) (identifier))
-          (interpolated_string_expression (identifier) (interpolated_string (interpolation (identifier)) (interpolation (identifier)))))
-        (case_clause
-          (case_class_pattern (type_identifier) (identifier) (identifier))
-          (interpolated_string_expression (identifier) (interpolated_string (interpolation (identifier)) (interpolation (identifier))))))))))
+      (match_expression
+        (identifier)
+        (case_block
+          (case_clause
+            (case_class_pattern
+              (type_identifier)
+              (identifier)
+              (identifier)
+              (wildcard))
+            (interpolated_string_expression
+              (identifier)
+              (interpolated_string
+                (interpolation
+                  (identifier))
+                (interpolation
+                  (identifier)))))
+          (case_clause
+            (case_class_pattern
+              (type_identifier)
+              (identifier)
+              (identifier))
+            (interpolated_string_expression
+              (identifier)
+              (interpolated_string
+                (interpolation
+                  (identifier))
+                (interpolation
+                  (identifier)))))
+          (case_clause
+            (case_class_pattern
+              (type_identifier)
+              (identifier)
+              (identifier))
+            (interpolated_string_expression
+              (identifier)
+              (interpolated_string
+                (interpolation
+                  (identifier))
+                (interpolation
+                  (identifier))))))))))
 
-============================
+================================================================================
 Infix patterns
-============================
+================================================================================
 
 def first(x: Seq[Int]) = x match {
   case e :+ _ => Some(e)
   case _ => None
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (function_definition (identifier)
-    (parameters (parameter (identifier) (generic_type (type_identifier) (type_arguments (type_identifier)))))
-    (match_expression (identifier)
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier)))))
+    (match_expression
+      (identifier)
       (case_block
-        (case_clause (infix_pattern (identifier) (operator_identifier) (wildcard))
-          (call_expression (identifier) (arguments (identifier))))
-        (case_clause (wildcard)
+        (case_clause
+          (infix_pattern
+            (identifier)
+            (operator_identifier)
+            (wildcard))
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))
+        (case_clause
+          (wildcard)
           (identifier))))))
 
-============================
+================================================================================
 Capture patterns
-============================
+================================================================================
 
 val x = y match {
   case a @ B(1) => a
@@ -144,7 +226,7 @@ val x = y match {
   case Array(a: Type, _@_*) => y
 }
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
   (val_definition
@@ -153,23 +235,41 @@ val x = y match {
       (identifier)
       (case_block
         (case_clause
-          (capture_pattern (identifier) (case_class_pattern (type_identifier) (integer_literal)))
+          (capture_pattern
+            (identifier)
+            (case_class_pattern
+              (type_identifier)
+              (integer_literal)))
           (identifier))
         (case_clause
-          (capture_pattern (identifier)
-            (case_class_pattern (type_identifier)
-              (capture_pattern (identifier)
+          (capture_pattern
+            (identifier)
+            (case_class_pattern
+              (type_identifier)
+              (capture_pattern
+                (identifier)
                 (tuple_pattern
-                  (capture_pattern (identifier) (identifier))
-                  (typed_pattern (wildcard) (type_identifier))))))
+                  (capture_pattern
+                    (identifier)
+                    (identifier))
+                  (typed_pattern
+                    (wildcard)
+                    (type_identifier))))))
           (identifier))
         (case_clause
           (infix_pattern
             (infix_pattern
-              (capture_pattern (identifier)
-                (tuple_pattern (alternative_pattern (identifier) (identifier))))
-              (operator_identifier) (identifier)) (operator_identifier) (string))
-              (integer_literal))
+              (capture_pattern
+                (identifier)
+                (tuple_pattern
+                  (alternative_pattern
+                    (identifier)
+                    (identifier))))
+              (operator_identifier)
+              (identifier))
+            (operator_identifier)
+            (string))
+          (integer_literal))
         (case_clause
           (case_class_pattern
             (type_identifier)
@@ -182,25 +282,53 @@ val x = y match {
                 (wildcard))))
           (identifier))))))
 
-============================
+================================================================================
 Quoted patterns (Scala 3 syntax)
-============================
+================================================================================
 
 def foo =
   x match
     case '{ $boolExpr } => Some(true)
     case _              => None
 
----
+--------------------------------------------------------------------------------
 
 (compilation_unit
-  (function_definition (identifier)
+  (function_definition
+    (identifier)
     (indented_block
-    (match_expression (identifier)
-      (indented_cases
-        (case_clause
-          (quote_expression (identifier))
-          (call_expression (identifier) (arguments (boolean_literal))))
-        (case_clause (wildcard)
-          (identifier)))))))
+      (match_expression
+        (identifier)
+        (indented_cases
+          (case_clause
+            (quote_expression
+              (identifier))
+            (call_expression
+              (identifier)
+              (arguments
+                (boolean_literal))))
+          (case_clause
+            (wildcard)
+            (identifier)))))))
 
+================================================================================
+Given pattern (Scala 3 syntax)
+================================================================================
+
+for  
+  given Int <- Some(1)
+yield ()
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (for_expression
+    (enumerators
+      (enumerator
+        (given_pattern
+          (type_identifier))
+        (call_expression
+          (identifier)
+          (arguments
+            (integer_literal)))))
+    (unit)))

--- a/grammar.js
+++ b/grammar.js
@@ -954,6 +954,7 @@ module.exports = grammar({
         $.infix_pattern,
         $.alternative_pattern,
         $.typed_pattern,
+        $.given_pattern,
         $.quote_expression,
         $.literal,
         $.wildcard,
@@ -994,6 +995,8 @@ module.exports = grammar({
       prec.right(
         seq(field("pattern", $._pattern), ":", field("type", $._type)),
       ),
+
+    given_pattern: $ => seq("given", field("type", $._type)),
 
     // TODO: Flatten this.
     alternative_pattern: $ => prec.left(-1, seq($._pattern, "|", $._pattern)),


### PR DESCRIPTION
Resolves #322

Summary
----
- `given_pattern` now handles cases like:
```scala
for
  given Int <- Some(1)
yield summon[Int]
```
- `corpus/patterns.txt` reformatted with `tree-sitter test -u`