### PR TITLE
Allow `$.stable_type_identifier` in `derives_clause`

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -502,7 +502,7 @@ class A
 ================================================================================
 Class definitions (Scala 3)
 ================================================================================
-final case class C() extends A derives B, C
+final case class C() extends A derives B, C.D
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -514,7 +514,9 @@ final case class C() extends A derives B, C
       (type_identifier))
     (derives_clause
       (type_identifier)
-      (type_identifier))))
+      (stable_type_identifier
+        (identifier)
+        (type_identifier)))))
 
 ================================================================================
 Subclass definitions

--- a/grammar.js
+++ b/grammar.js
@@ -681,7 +681,7 @@ module.exports = grammar({
       ),
 
     derives_clause: $ =>
-      prec.left(seq("derives", commaSep1(field("type", $._type_identifier)))),
+      prec.left(seq("derives", commaSep1(field("type", choice($._type_identifier, $.stable_type_identifier))))),
 
     class_parameters: $ =>
       prec(


### PR DESCRIPTION
Resolves #323

Summary
----
Support for dot-separated type references in derives clause
```scala
case class A() derives B.C
```