### PR TITLE
Sync locals from nvim-tree-sitter.

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -1,14 +1,17 @@
 (template_body) @local.scope
 (lambda_expression) @local.scope
-
+(block) @local.scope
 
 (function_declaration
-      name: (identifier) @local.definition) @local.scope
-
-(function_definition
       name: (identifier) @local.definition)
 
+(function_definition
+      name: (identifier) @local.definition) @local.scope
+
 (parameter
+  name: (identifier) @local.definition)
+
+(class_parameter
   name: (identifier) @local.definition)
 
 (binding


### PR DESCRIPTION
1. Add `(block)` as a `@local.scope`
2. Fix the scope for functions. `function_declaration` is used for
   abstract functions, while `function_definition` is used for the
   actual concrete functions (along with their function bodies).
3. Add `(class_parameter)`'s `name` as a local definition.

References:

- https://github.com/nvim-treesitter/nvim-treesitter/pull/4723
- https://github.com/nvim-treesitter/nvim-treesitter/pull/4594
