### PR TITLE
Add `(for_expression)` to locals.scm

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -1,6 +1,6 @@
 (template_body) @local.scope
 (lambda_expression) @local.scope
-
+(for_expression) @local.scope
 
 (function_declaration
       name: (identifier) @local.definition) @local.scope
@@ -25,6 +25,12 @@
 
 (var_declaration
   name: (identifier) @local.definition)
+
+(for_expression
+  enumerators: (enumerators
+    (enumerator
+      (tuple_pattern
+        (identifier) @local.definition))))
 
 (identifier) @local.reference
 


### PR DESCRIPTION
This change does two main things:

1. Indicate that `(for_expression)`'s introduce a `@local.scope` (this is the scope for the enumerators to be used within the loop).
2. Indicate that the `(identifiers)` within the `(enumerators)` are `@local.definition`s.

---

For the following example snippet:

```scala
val fruits = List("apple", "banana", "avocado", "papaya")

val countsToFruits = fruits.groupBy(fruit => fruit.count(_ == 'a'))

for ((count, fruits) <- countsToFruits) {
  println(s"with (fruits) 'a' × $count = $fruits")
}
```

The `count` and `fruits` identifiers are new definitions introduced by the `for` expressions scope.
