### PR TITLE
Derives clause for traits

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -786,7 +786,7 @@ Trait definitions
 
 trait A extends B
 
-trait A extends B with C
+trait A extends B with C derives D
 
 trait T[U] {
 }
@@ -805,6 +805,8 @@ trait T[U] extends V.W[U] {
     (identifier)
     (extends_clause
       (type_identifier)
+      (type_identifier))
+    (derives_clause
       (type_identifier)))
   (trait_definition
     (identifier)
@@ -1330,7 +1332,7 @@ object A:
         (indented_cases
           (case_clause
             (identifier)
-              (string))))
+            (string))))
       (given_definition
         (parameters
           (parameter

--- a/grammar.js
+++ b/grammar.js
@@ -297,7 +297,7 @@ module.exports = grammar({
         $._class_constructor,
         field("extend", optional($.extends_clause)),
         field("derive", optional($.derives_clause)),
-        optional($._definition_body),
+        field("body", optional($._definition_body)),
       ),
 
     _definition_body: $ =>
@@ -325,9 +325,7 @@ module.exports = grammar({
           repeat($.annotation),
           optional($.modifiers),
           "trait",
-          $._class_constructor,
-          field("extend", optional($.extends_clause)),
-          field("body", optional($._definition_body)),
+          $._class_definition,
         ),
       ),
 


### PR DESCRIPTION
Fixes #348
`trait_definition` now includes `_class_definition` which is comprised of extends-clause, derives-clause, and body. This also slightly reduces parser size (from ~890Kb to ~780Kb)