### PR TITLE
Allow infix inline modifier

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -1661,8 +1661,7 @@ Infix methods (Scala 3)
 ================================================================================
 
 object Test:
-  infix private def hello = 25
-
+  inline infix private def hello = 25
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -1671,6 +1670,7 @@ object Test:
     (template_body
       (function_definition
         (modifiers
+          (inline_modifier)
           (infix_modifier)
           (access_modifier))
         (identifier)

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -327,6 +327,12 @@ def other() {
   else c()
 }
 
+def another() {
+  if (a) b match {
+    case _ => c
+  } else d
+}
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -375,7 +381,21 @@ def other() {
           (identifier))
         (call_expression
           (identifier)
-          (arguments))))))
+          (arguments)))))
+  (function_definition
+    (identifier)
+    (parameters)
+    (block
+      (if_expression
+        (parenthesized_expression
+          (identifier))
+        (match_expression
+          (identifier)
+          (case_block
+            (case_clause
+              (wildcard)
+              (identifier))))
+        (identifier)))))
 
 ================================================================================
 If expressions (Scala 3 syntax)

--- a/grammar.js
+++ b/grammar.js
@@ -660,23 +660,21 @@ module.exports = grammar({
       ),
 
     modifiers: $ =>
-      prec.left(
-        repeat1(
-          choice(
-            "abstract",
-            "final",
-            "sealed",
-            "implicit",
-            "lazy",
-            "override",
-            $.access_modifier,
-            $.inline_modifier,
-            $.infix_modifier,
-            $.open_modifier,
-            $.transparent_modifier,
-          ),
-        ),
-      ),
+      prec.left(repeat1(
+        prec.left(choice(
+          "abstract",
+          "final",
+          "sealed",
+          "implicit",
+          "lazy",
+          "override",
+          $.access_modifier,
+          $.inline_modifier,
+          $.infix_modifier,
+          $.open_modifier,
+          $.transparent_modifier,
+        )),
+      )),
 
     access_modifier: $ =>
       prec.left(
@@ -790,7 +788,7 @@ module.exports = grammar({
       ),
 
     _indentable_expression: $ =>
-      choice($.indented_block, $.indented_cases, $.expression),
+      prec.right(choice($.indented_block, $.indented_cases, $.expression)),
 
     block: $ => seq("{", optional($._block), "}"),
 
@@ -1145,14 +1143,11 @@ module.exports = grammar({
      *   MatchClause       ::=  'match' <<< CaseClauses >>>
      */
     match_expression: $ =>
-      prec.left(
-        PREC.postfix,
-        seq(
-          optional($.inline_modifier),
-          field("value", $.expression),
-          "match",
-          field("body", choice($.case_block, $.indented_cases)),
-        ),
+      seq(
+        optional($.inline_modifier),
+        field("value", $.expression),
+        "match",
+        field("body", choice($.case_block, $.indented_cases)),
       ),
 
     try_expression: $ =>


### PR DESCRIPTION
Fixes #366

Rebalance precedences of `match_expression` (which can contain "inline") and `modifiers`