### PR TITLE
Allow $.function_declaration as extension body

### DIFF
--- a/corpus/definitions.txt
+++ b/corpus/definitions.txt
@@ -1187,6 +1187,9 @@ object A:
   
   extension [A1](d: D) def foo = "foo"
 
+trait B:
+  extension (x: Int) def bar: String
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -1211,7 +1214,18 @@ object A:
             (type_identifier)))
         (function_definition
           (identifier)
-          (string))))))
+          (string)))))
+  (trait_definition
+    (identifier)
+    (template_body
+      (extension_definition
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (function_declaration
+          (identifier)
+          (type_identifier))))))
 
 ================================================================================
 Given instance definitions (Scala 3 syntax)

--- a/grammar.js
+++ b/grammar.js
@@ -575,7 +575,11 @@ module.exports = grammar({
           field("parameters", repeat($.parameters)),
           field(
             "body",
-            choice($._extension_template_body, $.function_definition),
+            choice(
+              $._extension_template_body,
+              $.function_definition,
+              $.function_declaration,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Fixes #374

Also, this case seems to be not covered by the [ebnf](https://docs.scala-lang.org/scala3/reference/syntax.html#)