### PR TITLE
Fix character literal

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -228,6 +228,8 @@ val myChar = 'c'
 
 val otherChar = '\u0041'
 
+val otherChar2 = '\uu0041'
+
 val anotherChar = '\n'
 
 def foo(a: Char = 'c') = a + 'd'
@@ -235,6 +237,9 @@ def foo(a: Char = 'c') = a + 'd'
 --------------------------------------------------------------------------------
 
 (compilation_unit
+  (val_definition
+    (identifier)
+    (character_literal))
   (val_definition
     (identifier)
     (character_literal))

--- a/grammar.js
+++ b/grammar.js
@@ -1554,8 +1554,7 @@ module.exports = grammar({
                 "\\",
                 choice(
                   /[^xu]/,
-                  /u[0-9a-fA-F]{4}/,
-                  /u{[0-9a-fA-F]+}/,
+                  /uu?[0-9a-fA-F]{4}/,
                   /x[0-9a-fA-F]{2}/,
                 ),
               ),


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/382
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/380

## Problem
Previously the character literal was updated copied from that of Rust apparently, but Scala doesn't have curly braces in the character literal. The regex has bug, and it's failing CI.

We do, however, support two 'u' characters.

## Solution
1. This removes the curly brace variant.
2. Instead, this adds support for `\uu0041`