### PR TITLE
Bump smoke test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: scala/scala
-          ref: v2.13.10
+          ref: v2.13.14
           path: scala_scala
 
-      - name: checkout lampepfl/dotty
+      - name: checkout scala/scala3
         if: ${{ runner.os == 'Linux' }}
         uses: actions/checkout@v4
         with:
-          repository: lampepfl/dotty
-          ref: 3.3.0
+          repository: scala/scala3
+          ref: 3.5.0-RC2
           path: dotty
+
+      - name: checkout lichess-org/lila
+        if: ${{ runner.os == 'Linux' }}
+        uses: actions/checkout@v4
+        with:
+          repository: lichess-org/lila
+          ref: 83e61b9ef617164fe1d3a5112fcc611d0e5a7ea9
+          path: lila
 
       - name: checkout nvim-treesitter/nvim-treesitter
         if: ${{ runner.os == 'Linux' }}
@@ -93,6 +101,7 @@ jobs:
         env:
           SCALA_SCALA_DIR: scala_scala
           DOTTY_DIR: dotty
+          LILA_DIR: lila
         run: script/smoke_test.sh
 
       - name: copy nvim-treesitter queries

--- a/script/smoke_test.sh
+++ b/script/smoke_test.sh
@@ -3,8 +3,9 @@
 # This is an integration test to generally check the quality of parsing.
 
 SCALA_SCALA_LIBRARY_EXPECTED=100
-SCALA_SCALA_COMPILER_EXPECTED=97
-DOTTY_COMPILER_EXPECTED=85
+SCALA_SCALA_COMPILER_EXPECTED=96
+DOTTY_COMPILER_EXPECTED=83
+LILA_MODULES_EXPECTED=84
 SYNTAX_COMPLEXITY_CEILING=1400
 
 if [ ! -d "$SCALA_SCALA_DIR" ]; then
@@ -77,6 +78,7 @@ check_complexity () {
 run_tree_sitter "$SCALA_SCALA_DIR/src/library/"  $SCALA_SCALA_LIBRARY_EXPECTED   scala2-library
 run_tree_sitter "$SCALA_SCALA_DIR/src/compiler/" $SCALA_SCALA_COMPILER_EXPECTED  scala2-compiler
 run_tree_sitter "$DOTTY_DIR/compiler/"           $DOTTY_COMPILER_EXPECTED        dotty-compiler
+run_tree_sitter "$LILA_DIR/modules/"             $LILA_MODULES_EXPECTED          lila-modules
 
 check_complexity $SYNTAX_COMPLEXITY_CEILING
 


### PR DESCRIPTION
**Problem**
We currently use scala/scala and scala/scala3 to run the smoke test, but the versions are slightly older.

**Solution**
1. This bumps the versions to latest. Thankfully not much regression on the percentage.
2. This also adds lila for testing.