### PR TITLE
Relax the fidelity check for bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
           echo "all=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
           echo "c=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.\(c\|h\)$' | xargs)" >> $GITHUB_OUTPUT
           # Generated C code
-          echo "gen=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.\(c\|h\)$' | grep -v 'src/scanner.c' | xargs)" >> $GITHUB_OUTPUT
+          echo "gen=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.\(c\)$' | grep -v 'src/scanner.c' | grep -v 'bindings/python/tree_sitter_scala/binding.c' | xargs)" >> $GITHUB_OUTPUT
+
   test:
     runs-on: ${{ matrix.os }}
     needs: changedfiles

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -128,7 +128,6 @@
 (floating_point_literal) @float
 
 [
-  (symbol_literal)
   (string)
   (character_literal)
   (interpolated_string_expression)


### PR DESCRIPTION
## Problem
Apparently tree-sitter bindings are expected to beccreated manually and are allowed to be hand-edited. Currently it triggers fidelity check.

## Solution
This relaxes the C code fidelity check so bindings can be updated.