### PR TITLE
ci: Generate in all oses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         uses: tree-sitter/setup-action/cli@v1
 
       - name: Generate parser from scratch and test it
-        if: ${{ runner.os == 'Linux' || needs.changedfiles.outputs.c }}
         shell: bash
         run: tree-sitter generate
 


### PR DESCRIPTION
## Problem
Currently generate is called only on Linux, or C changed, but the test is run on all oses.

## Solution
Always run `tree-sitter generate`.