### PR TITLE
SIP-47 Clause Interleaving support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -550,10 +550,14 @@ module.exports = grammar({
       prec.right(
         seq(
           field("name", $._identifier),
-          field("type_parameters", optional($.type_parameters)),
           field(
             "parameters",
-            repeat(seq(optional($._automatic_semicolon), $.parameters)),
+            repeat(seq(optional($._automatic_semicolon),
+              choice(
+                $.parameters,
+                $.type_parameters
+              )
+            )),
           ),
           optional($._automatic_semicolon),
         ),

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -1152,6 +1152,11 @@ class A:
     val y = 2
     x + y
 
+  // SIP-47 - Clause Interleaving
+  def getOrElse(k: Key)[V >: k.Value](default: V): V
+
+  def aaa[A](using a: A)(b: List[A])[C <: a.type, D](cd: (C, D))[E]: Unit
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -1175,7 +1180,55 @@ class A:
           (infix_expression
             (identifier)
             (operator_identifier)
-            (identifier)))))))
+            (identifier))
+          (comment)))
+      (function_declaration
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (type_parameters
+          (identifier)
+          (lower_bound
+            (stable_type_identifier
+              (identifier)
+              (type_identifier))))
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+            (type_identifier))
+      (function_declaration
+        (identifier)
+        (type_parameters
+          (identifier))
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (parameters
+          (parameter
+            (identifier)
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier)))))
+        (type_parameters
+          (identifier)
+          (upper_bound
+            (singleton_type
+              (identifier)))
+          (identifier))
+        (parameters
+          (parameter
+            (identifier)
+            (tuple_type
+              (type_identifier)
+              (type_identifier))))
+        (type_parameters
+          (identifier))
+        (type_identifier)))))
 
 ================================================================================
 Extension methods (Scala 3 syntax)


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-scala/issues/438

## Problem
Scala 3.6.2 added interleaving params <https://docs.scala-lang.org/sips/clause-interleaving.html>,
as in term parameters, type parameters, and
using parameters can show up in an arbitrary order.

## Solution
This adds support for it.