### PR TITLE
Pin to tree-sitter 0.24.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v1
+        with:
+          tree-sitter-ref: v0.24.7
 
       - name: Generate parser from scratch and test it
         shell: bash

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v1
+        with:
+          tree-sitter-ref: v0.24.7
 
       - name: Generate parser from scratch
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-scala"
 description = "Scala grammar for tree-sitter"
-version = "0.23.4"
+version = "0.24.0"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-scala",
-  "version": "0.23.4",
+  "version": "0.24.0",
   "description": "Scala grammar for tree-sitter",
   "repository": "https://github.com/tree-sitter/tree-sitter-scala",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-scala"
 description = "Scala grammar for tree-sitter"
-version = "0.23.4"
+version = "0.24.0"
 keywords = ["incremental", "parsing", "tree-sitter", "scala"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter-scala/pull/454

## Problem/Solution

Currently GitHub CI sync picks up the latest tree-sitter CLI, which will generate parser using the latest.
This pins it to a specific version.