### PR TITLE
Support for string escapes

### DIFF
--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -2,15 +2,30 @@
 Simple strings
 ================================================================================
 
+val emptyString = ""
+
 val oneLineString = "I'm just on one line"
+
+val stringWithCommentLikeContent1 = "// not a comment"
+
+val stringWithCommentLikeContent2 = "/* not a comment */"
+
+val stringWithEscapeSequence = "first line\nsecond line"
 
 val multiLineString = """
   a
   $thisIsntInterpolated
   ${thisEither}
+  no escape codes in multiline strings \uD83D\uDE00 \n
 """
 
-val multiLineString2 = """""""
+val emptyMultilineStringf = """"""
+
+val stringOfOneDoubleQuote = """""""
+
+val multiLineString3 = """\{@inheritDoc\p{Zs}*\}"""
+
+val blackslashDoesNotEscapeClosingQuote = """\"""
 
 --------------------------------------------------------------------------------
 
@@ -23,17 +38,84 @@ val multiLineString2 = """""""
     (string))
   (val_definition
     (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string
+      (escape_sequence)))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
+    (string))
+  (val_definition
+    (identifier)
     (string)))
+
+================================================================================
+Escape sequences in strings
+================================================================================
+
+val singleEscapeCode = "\n"
+
+val singleCharacterEscapes = "\n\r\t\b\f\'\"\\"
+
+val unicodeEscape = "\uD83D\UDE00"
+
+val repeatedUs = "\uuuuD83D\UUDE00"
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (string
+      (escape_sequence)))
+  (val_definition
+    (identifier)
+    (string
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)))
+  (val_definition
+    (identifier)
+    (string
+      (escape_sequence)
+      (escape_sequence)))
+  (val_definition
+    (identifier)
+    (string
+      (escape_sequence)
+      (escape_sequence))))
 
 ================================================================================
 Interpolated strings
 ================================================================================
 
+val empty = s""
+
+val emptyMultiline = s""""""
+
 val string1 = s"a $b ${c}"
 
 val string2 = f"hi $name%s"
 
-val string3 = raw"Not a new line \n${ha}"
+val string3 = raw"Not a really a new line \n${ha}."
 
 val string4 = s"""
 works even in multiline strings, ${name}
@@ -47,9 +129,29 @@ val string7 = s"$$ $a"
 
 val string8 = s"$"$a"
 
+val string9 = s"$"$a\uD83D\UDE00\n"
+
+val multiline = raw"""
+  $$
+  ${interp}
+  \n
+  \x
+  \"
+\"""
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
   (val_definition
     (identifier)
     (interpolated_string_expression
@@ -99,16 +201,9 @@ val string8 = s"$"$a"
     (identifier)
     (interpolated_string_expression
       (identifier)
-        (interpolated_string
-          (interpolation
-            (identifier))
-          (interpolation
-            (identifier)))))
-  (val_definition
-    (identifier)
-    (interpolated_string_expression
-      (identifier)
       (interpolated_string
+        (interpolation
+          (identifier))
         (interpolation
           (identifier)))))
   (val_definition
@@ -116,8 +211,178 @@ val string8 = s"$"$a"
     (interpolated_string_expression
       (identifier)
       (interpolated_string
+        (escape_sequence)
         (interpolation
-          (identifier))))))
+          (identifier)))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (identifier)))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (identifier))
+        (escape_sequence)
+        (escape_sequence)
+        (escape_sequence))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (block
+            (identifier)))))))
+
+================================================================================
+Raw strings
+================================================================================
+
+val emptyRaw = raw""
+
+val emptyMultilineRaw = raw""""""
+
+val invalidEscapeCodesAllowedAndValidEscapesIgnored = raw"\n\t\x\w\g\k"
+
+val ErasedFunctionN = raw"ErasedFunction(\d+)".r
+
+val escapedAndInterpolated = raw"Not a really a new line \n${ha}."
+
+val blackslashQuoteDoesNotCloseString = raw"\""
+
+val doubleSlashQuoteDoesCloseString = raw"\\"
+
+val dollarEscapeInSingleLine = raw"$$"
+
+val slashDoesNotEscapeDollarSign = raw"\$$"
+
+val multiline = raw"""
+  $$
+  ${interp}
+  \n
+  \x
+  \"
+\"""
+
+val ensureIdentifierNamedRawStillWorks = someFunction(raw)
+
+val raw = raw(raw)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (field_expression
+      (interpolated_string_expression
+        (identifier)
+        (interpolated_string))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (interpolation
+          (block
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string)))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (block
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (arguments
+        (identifier))))
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (arguments
+        (identifier)))))
+
+================================================================================
+Raw and interpolated strings have equivalent parse trees
+================================================================================
+
+val raw = raw"Foo $$ ${bar}"
+
+val raw = s"Foo $$ ${bar}"
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (block
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (interpolated_string_expression
+      (identifier)
+      (interpolated_string
+        (escape_sequence)
+        (interpolation
+          (block
+            (identifier)))))))
 
 
 ================================================================================


### PR DESCRIPTION
I also slightly changed the definition of `interpolated_string` by
qualifying the open quotes with `token.immediate(…)`. Prior to this
change the rule would incorrectly match `foo ""` as an `interpolated_string_expression`

I ran these changes against all of the `.scala` files in
https://github.com/scala/scala3 and https://github.com/scala/scala.

The files in `scala/scala3` that newly have errors are:
* `tests/neg/fEscapes.scala`
* `tests/neg/unicodeEscapes-interpolations.scala`
* `tests/pos/multiLineOps.scala`
* `tests/run/i14164.scala`

The first two are tests containing examples of invalid escape
sequences that are expected to fail. `multiLineOps.scala` contains a
line `send_! "!"` that now parses with an error. Previously this
parsed as an `interpolated_string_expression`, which is also entirely
incorrect, So this error is a result of the adding
`token.immediate('"')` to the definition of `interpolated_string`, and
I do not think the change is a regression. Similarly, `i14164.scala`
contains a multi-line expression that previously incorrectly parsed to
`interpolated_string_expression`, and now parses more correctly,
though with an error.

The files in `scala/scala` that newly have errors are similar. Two
test files with intentionally broken escape sequences, and the same
`multiLineOps.scala`.