### PR TITLE
feat: `tracked` soft modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -708,6 +708,7 @@ module.exports = grammar({
               $.infix_modifier,
               $.into_modifier,
               $.open_modifier,
+              $.tracked_modifier,
               $.transparent_modifier,
             ),
           ),
@@ -725,6 +726,7 @@ module.exports = grammar({
     infix_modifier: $ => prec("mod", "infix"),
     into_modifier: $ => prec("mod", "into"),
     open_modifier: $ => prec("mod", "open"),
+    tracked_modifier: $ => prec("mod", "tracked"),
     transparent_modifier: $ => prec("mod", "transparent"),
 
     /**
@@ -1500,7 +1502,7 @@ module.exports = grammar({
     _soft_identifier: $ =>
       prec(
         "soft_id",
-        choice("infix", "inline", "into", "opaque", "open", "transparent", "end"),
+        choice("infix", "inline", "opaque", "open", "tracked", "transparent", "end"),
       ),
 
     /**

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -1931,3 +1931,27 @@ into trait Modifier:
       (val_declaration
         (identifier)
         (type_identifier)))))
+
+================================================================================
+'tracked' soft modifier (Scala 3)
+================================================================================
+
+class F(tracked val x: C):
+  tracked val tracked: Int
+
+--------------------------------------------------------------------------------
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (modifiers
+          (tracked_modifier))
+        (identifier)
+        (type_identifier)))
+    (template_body
+      (val_declaration
+        (modifiers
+          (tracked_modifier))
+        (identifier)
+        (type_identifier)))))


### PR DESCRIPTION
[Modularity Improvements](https://docs.scala-lang.org/scala3/reference/experimental/modularity.html) brought a new soft modifier for `val`s, both in constructor argument declarations and local val declarations.

Corresponding Scala 3 grammar changes:

```
ClsParam  ::=  {Annotation} [{Modifier | ‘tracked’} (‘val’ | ‘var’)] Param
```

```
LocalModifier     ::=  ‘tracked’
```