### PR TITLE
feat: `into` soft modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -707,6 +707,7 @@ module.exports = grammar({
               $.access_modifier,
               $.inline_modifier,
               $.infix_modifier,
+              $.into_modifier,
               $.open_modifier,
               $.transparent_modifier,
             ),
@@ -723,6 +724,7 @@ module.exports = grammar({
 
     inline_modifier: $ => prec("mod", "inline"),
     infix_modifier: $ => prec("mod", "infix"),
+    into_modifier: $ => prec("mod", "into"),
     open_modifier: $ => prec("mod", "open"),
     transparent_modifier: $ => prec("mod", "transparent"),
 
@@ -1496,7 +1498,7 @@ module.exports = grammar({
     _soft_identifier: $ =>
       prec(
         "soft_id",
-        choice("infix", "inline", "opaque", "open", "transparent", "end"),
+        choice("infix", "inline", "into", "opaque", "open", "transparent", "end"),
       ),
 
     /**

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -1912,3 +1912,22 @@ export printUnit.Test as _
     (as_renamed_identifier
       (identifier)
       (wildcard))))
+
+================================================================================
+'into' soft modifier (Scala 3)
+================================================================================
+
+into trait Modifier:
+  val into: Int
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (modifiers
+      (into_modifier))
+    (identifier)
+    (template_body
+      (val_declaration
+        (identifier)
+        (type_identifier)))))


### PR DESCRIPTION
Support for [`into` soft modifier](https://docs.scala-lang.org/scala3/reference/experimental/into.html#second-scheme-into-as-a-modifier)

Example usage:
```scala
into trait Modifier
```