### PR TITLE
fix: suppress automatic semicolon only when infix operator is actually followed by an operand

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -485,13 +485,20 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
     // Don't insert automatic semicolon before leading infix operators:
     // - symbolic, e.g. || or &&
     // - back-ticked, e.g. `in`
+    // Only suppress if the operator is followed by horizontal whitespace
+    // and then non-newline content on the same line, meaning it has an operand.
     if (is_op_char(lexer->lookahead) || lexer->lookahead == '`') {
       if (is_op_char(lexer->lookahead)) {
         advance(lexer);
         while (is_op_char(lexer->lookahead)) {
           advance(lexer);
         }
-        if (iswspace(lexer->lookahead)) {
+        bool found_space = false;
+        while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+          advance(lexer);
+          found_space = true;
+        }
+        if (found_space && !iswspace(lexer->lookahead) && !lexer->eof(lexer)) {
           return false;
         }
       } else if (lexer->lookahead == '`') {
@@ -501,7 +508,12 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
         }
         if (lexer->lookahead == '`') {
           advance(lexer);
-          if (iswspace(lexer->lookahead)) {
+          bool found_space = false;
+          while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+            advance(lexer);
+            found_space = true;
+          }
+          if (found_space && !iswspace(lexer->lookahead) && !lexer->eof(lexer)) {
             return false;
           }
         }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1108,6 +1108,27 @@ class C {
             (identifier)))))))
 
 ================================================================================
+??? as standalone statement
+================================================================================
+
+final def a =
+  println(1)
+  ???
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (modifiers)
+    name: (identifier)
+    body: (indented_block
+      (call_expression
+        function: (identifier)
+        arguments: (arguments
+          (integer_literal)))
+      (operator_identifier))))
+
+================================================================================
 Postfix expressions
 ================================================================================
 


### PR DESCRIPTION
Fixes a bug #507 introduced in #493