### PR TITLE
feat: allow lazy repeated parameter types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,6 +60,7 @@ module.exports = grammar({
     $._identifier,
     $._postfix_expression_choice,
     $._infix_type_choice,
+    $._param_value_type,
     $.literal,
   ],
 
@@ -1096,11 +1097,22 @@ module.exports = grammar({
       ),
 
     _param_type: $ =>
-      choice($._type, $.lazy_parameter_type, $.repeated_parameter_type),
+      choice(
+        $.lazy_parameter_type,
+        $._param_value_type
+      ),
 
-    lazy_parameter_type: $ => seq("=>", field("type", $._type)),
+    _param_value_type: $ =>
+      choice(
+        field("type", $._type),
+        $.repeated_parameter_type
+      ),
 
-    repeated_parameter_type: $ => seq(field("type", $._type), $._asterisk),
+    repeated_parameter_type: $ =>
+      seq(field("type", $._type), $._asterisk),
+
+    lazy_parameter_type: $ =>
+      seq("=>", field("type", $._param_value_type)),
 
     _type_identifier: $ => alias($._identifier, $.type_identifier),
 

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -1617,9 +1617,9 @@ class Foo(x: Int)(using A, B, Runtime[Any]) extends Bar
         name: (identifier)
         type: (type_identifier)))
     class_parameters: (class_parameters
-      (type_identifier)
-      (type_identifier)
-      (generic_type
+      type: (type_identifier)
+      type: (type_identifier)
+      type: (generic_type
         type: (type_identifier)
         type_arguments: (type_arguments
           (type_identifier))))


### PR DESCRIPTION
Now the grammar defines a repeated param type and a lazy param type as mutually exclusive options.

This PR fixes this:
```scala
case class Foo(a: => A*)
```