### PR TITLE
feat: allow trailing comma in $.indented_cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -925,7 +925,7 @@ module.exports = grammar({
       ),
 
     indented_cases: $ =>
-      prec.left(seq($._indent, repeat1($.case_clause), $._outdent)),
+      prec.left(seq($._indent, repeat1($.case_clause), choice($._outdent, $._comma_outdent))),
 
     // ---------------------------------------------------------------
     // Types

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -289,6 +289,8 @@ boxTop(
     back.map: url =>
       a(b),
     title,
+    x match
+      case a => a,
 )
 
 --------------------------------------------------------------------------------
@@ -308,7 +310,13 @@ boxTop(
               (identifier)
               (arguments
                 (identifier))))))
-      (identifier))))
+      (identifier)
+      (match_expression
+        (identifier)
+        (indented_cases
+          (case_clause
+            (identifier)
+            (identifier)))))))
 
 ================================================================================
 Generic functions


### PR DESCRIPTION
This fixes cases like this:
```scala
x.apply(
  a match
    case a => a,
)
```