### PR TITLE
feat: allow $.indented_block in $.assignment_expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1412,7 +1412,7 @@ module.exports = grammar({
         seq(
           field("left", choice($.prefix_expression, $._simple_expression)),
           "=",
-          field("right", $.expression),
+          field("right", choice($.expression, $.indented_block))
         ),
       ),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -355,32 +355,34 @@ class C {
 Assignments
 ================================================================================
 
-class C {
-  def main() {
-    a = b
-    a(1) = c
-  }
-}
+a = b
+a(1) = c
+views =
+  val key = 1
+  key + 1
 
 --------------------------------------------------------------------------------
 
 (compilation_unit
-  (class_definition
+  (assignment_expression
     (identifier)
-    (template_body
-      (function_definition
+    (identifier))
+  (assignment_expression
+    (call_expression
+      (identifier)
+      (arguments
+        (integer_literal)))
+    (identifier))
+  (assignment_expression
+    (identifier)
+    (indented_block
+      (val_definition
         (identifier)
-        (parameters)
-        (block
-          (assignment_expression
-            (identifier)
-            (identifier))
-          (assignment_expression
-            (call_expression
-              (identifier)
-              (arguments
-                (integer_literal)))
-            (identifier)))))))
+        (integer_literal))
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (integer_literal)))))
 
 ================================================================================
 If expressions


### PR DESCRIPTION
Fixes code like
```scala
x.copy(views =
  val key = 1
  key + 1
)
```