### PR TITLE
fix: applied_constructor_type and early defs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -774,7 +774,6 @@ module.exports = grammar({
           // This adds _simple_type, but not the above intentionally.
           seq($._simple_type, field("arguments", $.arguments)),
           seq($._annotated_type, field("arguments", $.arguments)),
-          seq($.compound_type, field("arguments", $.arguments)),
         ),
       ),
 
@@ -1007,7 +1006,18 @@ module.exports = grammar({
       ),
 
     applied_constructor_type: $ =>
-      prec("applied_constructor_type", seq($._type_identifier, $.arguments)),
+      prec(
+        "applied_constructor_type",
+        seq(
+          choice(
+            $.generic_type,
+            $.projected_type,
+            $.stable_type_identifier,
+            $._type_identifier,
+          ),
+          $.arguments,
+        ),
+      ),
 
     compound_type: $ =>
       choice(
@@ -1529,8 +1539,17 @@ module.exports = grammar({
           seq("new", $._constructor_application, $.template_body),
         ),
         prec("new", seq("new", $.template_body)),
+        prec("new",
+          seq("new",
+            field("early_defs", $._early_defs),
+            "with",
+            $._constructor_application,
+          ),
+        ),
         seq("new", $._constructor_application),
       ),
+
+    _early_defs: $ => alias($._braced_template_body, $.early_defs),
 
     /**
      * PostfixExpr [Ascription]

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1048,6 +1048,11 @@ class C {
       "ok"
     }
     new Array: Array
+    new T.T with A
+    new T.T[B](a) with A
+    new {
+      val a: Int = 1
+    } with C with D
   }
 }
 
@@ -1100,7 +1105,34 @@ class C {
           (ascription_expression
             (instance_expression
               (type_identifier))
-            (type_identifier)))))))
+            (type_identifier))
+          (instance_expression
+            (compound_type
+              (stable_type_identifier
+                (identifier)
+                (type_identifier))
+              (type_identifier)))
+          (instance_expression
+            (compound_type
+              (applied_constructor_type
+                (generic_type
+                  (stable_type_identifier
+                    (identifier)
+                    (type_identifier))
+                  (type_arguments
+                    (type_identifier)))
+                (arguments
+                  (identifier)))
+              (type_identifier)))
+          (instance_expression
+            (early_defs
+              (val_definition
+                (identifier)
+                (type_identifier)
+                (integer_literal)))
+            (compound_type
+              (type_identifier)
+              (type_identifier))))))))
 
 ================================================================================
 Infix expressions


### PR DESCRIPTION
Fixes #538, and adds support for early definitions.

Early definitions here are done via braced_template_body, which is not entirely correct per se because early defs do not contain statements and are esentially just `val` and `var` definitions, but I had some trouble making "letter-perfect" early defs, and this is the simplest way to correctly parse correct code.