### PR TITLE
feat: reduce real-world parse failures across 34 OSSs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -20,6 +20,36 @@ const PREC = {
   binding: 10,
 };
 
+// XML Name (SLS §10 / XML spec), covering namespaced names like `x:ga`.
+const XML_NAME = /[_\p{L}][-.:_\p{L}\p{Nd}]*/;
+
+// `⇒` (U+21D2) is the alternate Scala 2 spelling of `=>` (SLS 1.1, dropped in
+// Scala 3). It is not lexable as an operator_identifier (the single-opchar
+// class excludes it), so the extra token cannot collide with user operators.
+const fatArrow = () => choice("=>", alias("⇒", "=>"));
+
+// A `:` that is also accepted when it ends its line: the scanner lexes a
+// line-final lone colon as the external COLON_EOL token (scalac's COLONeol),
+// so every consumer of such a colon must accept both spellings.
+const colonEol = ($) => choice(":", alias($._colon_eol, ":"));
+
+// An expression as admitted in statement and RHS positions: do_while lives
+// OUTSIDE $.expression (after `for (...)` a `do` must always introduce the
+// for's own body, and a do-while alternative inside the bare body doubles
+// the paren-for automaton, ~+7MiB of parser.c), so every position that
+// takes statements or definition right-hand sides admits it through this
+// helper instead. Deeper operand positions (arguments, parenthesized) stay
+// unsupported, matching their near-nonexistent real-world use.
+const statementExpression = ($) => choice($.expression, $.do_while_expression);
+
+// `=>` or the context-function arrow `?=>`.
+const anyArrow = () => choice(fatArrow(), "?=>");
+
+// The function-type tail of an ascription that is actually a lambda type,
+// shared verbatim by both branches of ascription_expression.
+const ascriptionArrowTail = ($) =>
+  seq(anyArrow(), field("return_type", $._param_type));
+
 module.exports = grammar({
   name: "scala",
 
@@ -48,10 +78,39 @@ module.exports = grammar({
     "extends",
     "derives",
     "with",
+    // Only so the scanner can see when `match` is valid: a line-leading
+    // `match` continues the previous expression (`xs.filter(p)` + newline +
+    // `match ...`), so the automatic semicolon must be suppressed. The
+    // scanner never returns this token; the internal lexer matches it.
+    "match",
+    // A lone `:` that ends its line (scalac's COLONeol): starts a
+    // fewer-braces argument / template body. Lexing it externally makes the
+    // colon-argument vs across-the-newline-ascription split deterministic;
+    // see the COLON_EOL comment in scanner.c.
+    $._colon_eol,
+    $._xml_tag_start,
+    $._operator_eol,
+    // Lexed externally (with nesting) so the `/*` token does not occupy a
+    // column in every parse-table row, which costs ~0.6MiB of parser.c.
+    $.block_comment,
+    // Never returned by the scanner. Valid exactly in the states where the
+    // grammar offers it as a dead alternative (inside a line comment), which
+    // tells the scanner not to lex a block_comment there: in `// /* x`, the
+    // `/*` is line-comment text. External extras are otherwise valid in
+    // every state, so this is the only way to suppress them per state.
+    $._suppress_block_comment,
     $.error_sentinel,
   ],
 
   inline: $ => [
+    $._asterisk,
+    $._super_identifier,
+    $._this_identifier,
+    $._non_null_literal,
+    $._braced_template_body,
+    $._indented_template_body,
+    $._structural_type,
+    $._refinement,
     $._pattern,
     $._semicolon,
     $._definition,
@@ -62,6 +121,9 @@ module.exports = grammar({
     $._param_value_type,
     $._simple_type,
     $.literal,
+    $._xml_node,
+    $._xml_content,
+    $._xml_pattern_content,
   ],
 
   // Doc: https://tree-sitter.github.io/tree-sitter/creating-parsers, search "precedences"
@@ -78,6 +140,24 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.tuple_type, $.parameter_types],
+    // _xml_open_tag '/>' — a self-closing element is an xml_element where an
+    // expression is expected and an xml_pattern where a pattern is expected;
+    // in positions admitting both (e.g. for-comprehension bindings) only the
+    // continuation disambiguates.
+    [$.xml_element, $.xml_pattern],
+    [$._simple_expression, $._xml_embedded_pattern],
+    [$._simple_expression, $._xml_repeat_pattern],
+    // _simple_expression ':' identifier • '=>'/'?=>' — the identifier is
+    // either the bare function-type parameter of the ascription itself or a
+    // type_identifier reduction on the regular type path.
+    [$._type_identifier, $.ascription_expression],
+    // 'extension' • '{' — an extension definition with a braced body, or the
+    // soft identifier `extension` (valid in Scala 2) called with a block.
+    [$.extension_definition, $._soft_identifier],
+    // 'inline' • … — the soft identifier vs the inline modifier of a
+    // following definition / `inline if` / `inline match`; the continuation
+    // decides (e.g. `inline || x` keeps the identifier reading).
+    [$.inline_modifier, $._soft_identifier],
     [$.binding, $._simple_expression],
     [$.binding, $._type_identifier],
     [$.while_expression, $._simple_expression],
@@ -98,6 +178,8 @@ module.exports = grammar({
     [$._full_enum_def],
     // _start_val  identifier  ','  identifier  •  ':'  …
     [$.identifiers, $.val_declaration],
+    [$.val_declaration, $._definition_pattern],
+    [$.var_declaration, $._definition_pattern],
     // 'enum'  operator_identifier  _automatic_semicolon  '('  ')'  •  ':'  …
     [$.class_parameters],
     // 'for'  operator_identifier  ':'  _annotated_type  •  ':'  …
@@ -137,7 +219,7 @@ module.exports = grammar({
     [$.binding, $._simple_expression, $._type_identifier],
     [$.class_parameter, $._type_identifier],
     // '{'  _single_lambda_param  '=>'  expression  •  '}'  …
-    [$._block, $._indentable_expression],
+    [$._block_statements, $._indentable_expression],
     [$.match_expression, $._simple_expression],
     // _  :  Type  •  '=>'  …
     [$.self_type, $._simple_expression],
@@ -147,6 +229,11 @@ module.exports = grammar({
     [$.vararg, $.operator_identifier],
     // _simple_expression  '('  expression  •  ','  …
     [$._exprs_in_parens],
+    // _simple_expression  ':'  '('  name_and_type  ')'  •  '=>'  — the
+    // parenthesized list is either the lambda parameters of a colon argument
+    // or a named tuple type on the ascription reading; what follows `=>`
+    // (INDENT vs a same-line type) decides.
+    [$.named_tuple_type, $._colon_bindings],
     // _simple_expression  ':'  '('  wildcard  •  ','  …
     [$._annotated_type, $.binding],
     // '['  identifier  ':'  '{'  wildcard  •  ':'  …
@@ -233,7 +320,7 @@ module.exports = grammar({
       ),
 
     _top_level_definition: $ =>
-      choice($._definition, $._end_marker, $.expression),
+      choice($._definition, $._end_marker, statementExpression($)),
 
     _definition: $ =>
       choice(
@@ -272,7 +359,11 @@ module.exports = grammar({
         seq(
           sep1(
             $._semicolon,
-            choice($.enum_case_definitions, $.expression, $._definition),
+            choice(
+              $.enum_case_definitions,
+              statementExpression($),
+              $._definition,
+            ),
           ),
           optional($._semicolon),
         ),
@@ -280,10 +371,19 @@ module.exports = grammar({
 
     enum_body: $ =>
       choice(
-        prec.left(PREC.control, seq(":", $._indent, $._enum_block, $._outdent)),
+        prec.left(
+          PREC.control,
+          seq(
+            colonEol($),
+            $._indent,
+            optional($.self_type),
+            $._enum_block,
+            $._outdent,
+          ),
+        ),
         seq(
           "{",
-          // TODO: self type
+          optional($.self_type),
           optional($._enum_block),
           "}",
         ),
@@ -292,6 +392,8 @@ module.exports = grammar({
     enum_case_definitions: $ =>
       seq(
         repeat($.annotation),
+        // e.g. `private case External(...) extends ...` (dotty FileExtension)
+        optional($.modifiers),
         "case",
         choice(commaSep1($.simple_enum_case), $.full_enum_case),
       ),
@@ -349,7 +451,7 @@ module.exports = grammar({
       prec.left(
         choice(
           seq(
-            field("path", sep1(".", $._identifier)),
+            field("path", sep1(".", $._namespace_path_segment)),
             optional(
               seq(
                 ".",
@@ -367,6 +469,11 @@ module.exports = grammar({
           $.as_renamed_identifier,
         ),
       ),
+
+    // Scala 3 keywords that are valid identifiers in Scala 2 sources and thus
+    // may appear as package names in import/export paths (e.g. `import io.circe.export.Exported`).
+    _namespace_path_segment: $ =>
+      choice($._identifier, alias(choice("enum", "export"), $.identifier)),
 
     namespace_wildcard: $ => prec.left(1, choice("*", "_", "given")),
 
@@ -393,7 +500,7 @@ module.exports = grammar({
     arrow_renamed_identifier: $ =>
       seq(
         field("name", $._identifier),
-        "=>",
+        fatArrow(),
         field("alias", choice($._identifier, $.wildcard)),
       ),
 
@@ -528,7 +635,18 @@ module.exports = grammar({
     _indented_template_body: $ =>
       prec.left(
         PREC.control,
-        seq(":", $._indent, optional($.self_type), $._block, $._outdent),
+        seq(
+          colonEol($),
+          $._indent,
+          choice(
+            seq(optional($.self_type), $._block),
+            // A self type with an empty body: `trait A:` + `self: B =>`
+            // followed by the next definition (or EOF). Mirrors the braced
+            // variant in _braced_template_body1.
+            $.self_type,
+          ),
+          $._outdent,
+        ),
       ),
 
     _braced_template_body: $ =>
@@ -541,7 +659,14 @@ module.exports = grammar({
         ),
       ),
 
-    _braced_template_body1: $ => seq(optional($.self_type), $._block),
+    _braced_template_body1: $ =>
+      choice(
+        seq(optional($.self_type), $._block),
+        // A self type with an empty body: `trait A { self: B => }`. Without
+        // this the only reading of the body is an empty-bodied lambda, which
+        // breaks when another statement follows the closing brace.
+        $.self_type,
+      ),
     _braced_template_body2: $ =>
       seq(
         choice(
@@ -550,6 +675,10 @@ module.exports = grammar({
         ),
         optional($._block),
         $._outdent,
+        // A member indented shallower than its siblings pops the indent
+        // region before the closing brace; the remaining members are still
+        // part of the same braced body (scalac ignores indentation here).
+        optional($._block),
       ),
 
     /*
@@ -586,7 +715,13 @@ module.exports = grammar({
             "given",
             "extension",
             "val",
-            alias($._identifier, "_end_ident"),
+            // Only alphanumeric (or back-quoted) names: allowing operator
+            // identifiers here would swallow `end` used as a plain
+            // identifier before an infix operator (`${end - start}`).
+            alias(
+              choice($._alpha_identifier, $._backquoted_id),
+              "_end_ident",
+            ),
           ),
         ),
       ),
@@ -600,7 +735,7 @@ module.exports = grammar({
           seq(
             choice($._identifier, $.wildcard),
             optional($._self_type_ascription),
-            "=>",
+            fatArrow(),
           ),
         ),
       ),
@@ -644,7 +779,7 @@ module.exports = grammar({
     val_definition: $ =>
       seq(
         $._start_val,
-        field("pattern", choice($._pattern, $.identifiers)),
+        field("pattern", choice($._definition_pattern, $.identifiers)),
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
@@ -671,7 +806,7 @@ module.exports = grammar({
     var_definition: $ =>
       seq(
         $._start_var,
-        field("pattern", choice($._pattern, $.identifiers)),
+        field("pattern", choice($._definition_pattern, $.identifiers)),
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
@@ -788,7 +923,7 @@ module.exports = grammar({
         ),
       ),
 
-    _given_sig: $ => seq($._given_conditional, "=>"),
+    _given_sig: $ => seq($._given_conditional, fatArrow()),
 
     _given_conditional: $ =>
       choice(alias($.parameters, $.given_conditional), $.type_parameters),
@@ -815,7 +950,7 @@ module.exports = grammar({
         PREC.compound,
         seq(
           $._constructor_application,
-          choice(":", "with"),
+          choice(colonEol($), "with"),
           field("body", $.with_template_body),
         ),
       ),
@@ -836,8 +971,16 @@ module.exports = grammar({
           // but doing so increases the state of template_body to 4000
           $._structural_type,
           // This adds _simple_type, but not the above intentionally.
-          seq($._simple_type, field("arguments", $.arguments)),
-          seq($._annotated_type, field("arguments", $.arguments)),
+          // Note: constructor arguments attach only to a non-annotated simple
+          // type; after an annotation, argument lists belong to the annotation
+          // itself (scalac parses annotation arguments greedily).
+          seq(
+            $._simple_type,
+            field(
+              "arguments",
+              repeat1(prec("constructor_application", $.arguments)),
+            ),
+          ),
         ),
       ),
 
@@ -879,7 +1022,13 @@ module.exports = grammar({
 
     access_qualifier: $ => seq("[", $._identifier, "]"),
 
-    inline_modifier: $ => prec("mod", "inline"),
+    // Unlike the other soft modifiers, `inline` is valid at expression start
+    // (`inline if`, `inline match`), so a static "mod" > "soft_id" win would
+    // misparse `inline || x` (the identifier reading). Instead the token is
+    // reduced under a GLR fork (see conflicts) and the continuation decides;
+    // the dynamic precedence prefers the modifier when both readings complete
+    // (`inline if (c) a else b`).
+    inline_modifier: $ => prec.dynamic(1, "inline"),
     infix_modifier: $ => prec("mod", "infix"),
     into_modifier: $ => prec("mod", "into"),
     open_modifier: $ => prec("mod", "open"),
@@ -890,13 +1039,7 @@ module.exports = grammar({
      * InheritClauses    ::=  ['extends' ConstrApps] ['derives' QualId {',' QualId}]
      */
     extends_clause: $ =>
-      prec.left(
-        seq(
-          "extends",
-          field("type", $._constructor_applications),
-          repeat($.arguments),
-        ),
-      ),
+      prec.left(seq("extends", field("type", $._constructor_applications))),
 
     derives_clause: $ =>
       prec.left(
@@ -988,22 +1131,57 @@ module.exports = grammar({
     name_and_type: $ =>
       prec.left(
         PREC.control,
-        seq(field("name", $._identifier), ":", field("type", $._param_type)),
+        // colonEol: inside parentheses a line-final ':' is an ordinary
+        // parameter/ascription colon (scalac turns COLONeol off there), so
+        // the typed reading must accept the token the scanner produces:
+        // `(x:` + newline + `Int) => x` is a lambda. Must stay in sync with
+        // $.binding, whose token path this rule shares.
+        seq(
+          field("name", $._identifier),
+          colonEol($),
+          field("type", $._param_type),
+        ),
       ),
 
+    // Statements are separated by a semicolon or newline, and any separator
+    // may be followed by extra empty statements (`;`), so `}\n;{ ... }` and
+    // leading semicolons parse like scalac. A block of only semicolons is
+    // kept as its own branch (`{ ;; }`).
     _block: $ =>
+      prec.left(
+        choice(
+          seq(repeat1(";"), optional($._block_statements)),
+          $._block_statements,
+        ),
+      ),
+
+    // A statement separator: `;` or newline, optionally followed by extra
+    // empty statements.
+    _semis: $ => seq($._semicolon, repeat(";")),
+
+    _block_statements: $ =>
       prec.left(
         seq(
           sep1(
-            $._semicolon,
-            choice($.expression, $._definition, $._end_marker, ";"),
+            $._semis,
+            choice(
+              statementExpression($),
+              $._definition,
+              $._end_marker,
+            ),
           ),
-          optional($._semicolon),
+          optional($._semis),
         ),
       ),
 
     _indentable_expression: $ =>
-      prec.right(choice($.indented_block, $.indented_cases, $.expression)),
+      prec.right(
+        choice(
+          $.indented_block,
+          $.indented_cases,
+          statementExpression($),
+        ),
+      ),
 
     block: $ =>
       seq(
@@ -1050,6 +1228,13 @@ module.exports = grammar({
         $.literal_type,
         $._structural_type,
         $.type_lambda,
+        $.existential_type,
+      ),
+
+    // Scala 2 existential type (SLS §3.2.12): `P[T] forSome { type T }`
+    existential_type: $ =>
+      prec.left(
+        seq(field("type", $._infix_type_choice), "forSome", $._refinement),
       ),
 
     _annotated_type: $ => prec.right(choice($.annotated_type, $._simple_type)),
@@ -1199,7 +1384,7 @@ module.exports = grammar({
       ),
 
     _arrow_then_type: $ =>
-      prec.right(seq(choice("=>", "?=>"), field("return_type", $._type))),
+      prec.right(seq(anyArrow(), field("return_type", $._type))),
 
     // Deprioritize against typed_pattern._type.
     parameter_types: $ =>
@@ -1221,7 +1406,7 @@ module.exports = grammar({
 
     repeated_parameter_type: $ => seq(field("type", $._type), $._asterisk),
 
-    lazy_parameter_type: $ => seq("=>", field("type", $._param_value_type)),
+    lazy_parameter_type: $ => seq(fatArrow(), field("type", $._param_value_type)),
 
     _type_identifier: $ => alias($._identifier, $.type_identifier),
 
@@ -1239,6 +1424,23 @@ module.exports = grammar({
 
     _pattern: $ =>
       choice(
+        $._definition_pattern,
+        $.alternative_pattern,
+        $.typed_pattern,
+        $.repeat_pattern,
+      ),
+
+    // SLS 4.1: the pattern of a val/var definition is a Pattern2 — no
+    // top-level alternatives (`p | q`) or ascription. A `:` after the
+    // pattern is the definition's own type annotation (so `val a: A | B`
+    // reads `|` as a union type, not an alternative pattern); nested
+    // positions (tuples, extractor arguments) still take a full _pattern.
+    // The infix operands are restricted too: through its left recursion a
+    // full _pattern would put the alternative/typed items right back into
+    // the closure, keeping the anonymous `|` token valid where the union
+    // type's operator_identifier must win the lexer.
+    _definition_pattern: $ =>
+      choice(
         $._identifier,
         $.stable_identifier,
         $.interpolated_string_expression,
@@ -1247,13 +1449,23 @@ module.exports = grammar({
         $.named_tuple_pattern,
         $.case_class_pattern,
         $.infix_pattern,
-        $.alternative_pattern,
-        $.typed_pattern,
         $.given_pattern,
         $.quote_expression,
         $.literal,
         $.wildcard,
-        $.repeat_pattern,
+        $.xml_pattern,
+      ),
+
+    // Operands are _definition_pattern, not the full _pattern — see the
+    // closure argument on _definition_pattern above.
+    infix_pattern: $ =>
+      prec.left(
+        PREC.infix,
+        seq(
+          field("left", $._definition_pattern),
+          field("operator", $._identifier),
+          field("right", $._definition_pattern),
+        ),
       ),
 
     case_class_pattern: $ =>
@@ -1265,16 +1477,6 @@ module.exports = grammar({
           field("pattern", trailingCommaSep($.named_pattern)),
         ),
         ")",
-      ),
-
-    infix_pattern: $ =>
-      prec.left(
-        PREC.infix,
-        seq(
-          field("left", $._pattern),
-          field("operator", $._identifier),
-          field("right", $._pattern),
-        ),
       ),
 
     capture_pattern: $ =>
@@ -1324,7 +1526,6 @@ module.exports = grammar({
         $.return_expression,
         $.throw_expression,
         $.while_expression,
-        $.do_while_expression,
         $.for_expression,
         $.macro_body,
         $._simple_expression,
@@ -1366,8 +1567,19 @@ module.exports = grammar({
         $.field_expression,
         $.generic_function,
         $.call_expression,
+        $.xml_expression,
+        $.method_value,
         alias($._dot_match_expression, $.match_expression),
       ),
+
+    /**
+     * SimpleExpr ::= SimpleExpr1 '_'  (SLS 6.7 Method Values, `f _`)
+     *
+     * A simple expression, so it can be an infix operand:
+     * `iso.reverseGet _ compose iso.get`.
+     */
+    method_value: $ =>
+      prec.left(PREC.call, seq($._simple_expression, $.wildcard)),
 
     _single_lambda_param: $ =>
       prec.right(
@@ -1378,12 +1590,12 @@ module.exports = grammar({
       prec.right(
         "lambda",
         seq(
-          optional(seq(field("type_parameters", $.type_parameters), "=>")),
+          optional(seq(field("type_parameters", $.type_parameters), fatArrow())),
           field(
             "parameters",
             choice($.bindings, $.wildcard, $._single_lambda_param),
           ),
-          choice("=>", "?=>"),
+          anyArrow(),
           $._indentable_expression,
         ),
       ),
@@ -1404,8 +1616,8 @@ module.exports = grammar({
             "parameters",
             choice($.bindings, $.wildcard, $._single_lambda_param),
           ),
-          choice("=>", "?=>"),
-          $._block,
+          anyArrow(),
+          optional($._block),
         ),
       ),
 
@@ -1487,8 +1699,18 @@ module.exports = grammar({
         seq("catch", choice($._indentable_expression, $._expr_case_clause)),
       ),
 
+    // The body also admits an indented block (dotty accepts definitions and
+    // several statements there): `catch case ex: T =>` + indented lines.
+    // The block's OUTDENT bounds the body, so a following dedented statement
+    // or `finally` is not swallowed.
     _expr_case_clause: $ =>
-      prec.left(seq("case", $._case_pattern, field("body", $.expression))),
+      prec.left(
+        seq(
+          "case",
+          $._case_pattern,
+          field("body", choice($.expression, $.indented_block)),
+        ),
+      ),
 
     finally_clause: $ => prec.right(seq("finally", $._indentable_expression)),
 
@@ -1498,7 +1720,8 @@ module.exports = grammar({
     binding: $ =>
       seq(
         choice(field("name", $._identifier), $.wildcard),
-        optional(seq(":", field("type", $._param_type))),
+        // colonEol: see name_and_type (the shared-token twin of this rule).
+        optional(seq(colonEol($), field("type", $._param_type))),
       ),
 
     bindings: $ => seq("(", trailingCommaSep($.binding), ")"),
@@ -1515,7 +1738,7 @@ module.exports = grammar({
     _case_pattern: $ =>
       prec.dynamic(
         1,
-        seq(field("pattern", $._pattern), optional($.guard), "=>"),
+        seq(field("pattern", $._pattern), optional($.guard), fatArrow()),
       ),
 
     guard: $ =>
@@ -1530,7 +1753,7 @@ module.exports = grammar({
         seq(
           field("left", choice($.prefix_expression, $._simple_expression)),
           "=",
-          field("right", choice($.expression, $.indented_block)),
+          field("right", choice(statementExpression($), $.indented_block)),
         ),
       ),
 
@@ -1556,7 +1779,7 @@ module.exports = grammar({
           PREC.colon_call,
           seq(
             field("function", $._postfix_expression_choice),
-            ":",
+            colonEol($),
             field("arguments", $.colon_argument),
           ),
         ),
@@ -1573,11 +1796,37 @@ module.exports = grammar({
           optional(
             field(
               "lambda_start",
-              seq(choice($.bindings, $._identifier, $.wildcard), "=>"),
+              seq(
+                choice(
+                  alias($._colon_bindings, $.bindings),
+                  $._identifier,
+                  $.wildcard,
+                ),
+                fatArrow(),
+              ),
             ),
           ),
           choice($.indented_block, $.indented_cases),
         ),
+      ),
+
+    /*
+     * Parenthesized lambda parameters of a colon argument. A typed parameter
+     * `x: T` is parsed as $.name_and_type (aliased to binding) so that the
+     * token path is shared with $.named_tuple_type on the ascription reading:
+     * after `f: (x: T)` the two interpretations stay a single parse until the
+     * closing paren, where a declared conflict forks them. The fork then
+     * resolves deterministically at `=>` — an INDENT token continues the
+     * colon-argument lambda, a same-line type continues the ascription —
+     * matching scalac's fewer-braces rule. Keeping typed parameters out of
+     * $.binding here avoids the binding/name_and_type reduce conflict that
+     * statically killed the lambda reading.
+     */
+    _colon_bindings: $ =>
+      seq(
+        "(",
+        trailingCommaSep(choice($.binding, alias($.name_and_type, $.binding))),
+        ")",
       ),
 
     field_expression: $ =>
@@ -1607,7 +1856,7 @@ module.exports = grammar({
           "new",
           seq(
             "new",
-            field("early_defs", $._early_defs),
+            field("early_defs", $.early_defs),
             "with",
             $._constructor_application,
           ),
@@ -1615,20 +1864,65 @@ module.exports = grammar({
         seq("new", $._constructor_application),
       ),
 
-    _early_defs: $ => alias($._braced_template_body, $.early_defs),
+    // Same shape as _braced_template_body; spelled out (rather than aliasing
+    // that rule) because _braced_template_body is inlined for parser size.
+    early_defs: $ =>
+      prec.left(
+        PREC.control,
+        seq(
+          "{",
+          optional(choice($._braced_template_body1, $._braced_template_body2)),
+          "}",
+        ),
+      ),
 
     /**
      * PostfixExpr [Ascription]
      */
+    /*
+     * The optional arrow tail supports ascription to function types, e.g.
+     * `(f: Int => Int)` or `(g: A => B => C)`. It lives directly in this rule
+     * (rather than relying on $.function_type) because in type position after
+     * `:` the function-type reading is statically deprioritized in favor of
+     * self-type/lambda-parameter readings. The dynamic penalty keeps
+     * `{ x: Int => body }` parsed as a lambda parameter, matching scalac.
+     */
     ascription_expression: $ =>
       prec.left(
         seq(
-          $._postfix_expression_choice,
+          // In Scala 3 a match chain is an InfixExpr, so it can be ascribed:
+          // `info match { ... }: @unchecked`.
+          choice($._postfix_expression_choice, $.match_expression),
           ":",
-          choice($._param_type, $.annotation),
+          choice(
+            seq(
+              field("type", $._param_type),
+              repeat(prec(1, prec.dynamic(-1, ascriptionArrowTail($)))),
+            ),
+            // A function type whose parameter is a bare identifier, e.g.
+            // `(f: Int => Int)`. Sharing the `identifier '=>'` token path with
+            // colon_argument's lambda_start keeps this a shift/shift overlap
+            // instead of a shift/reduce conflict; whichever continuation
+            // matches the following input survives.
+            prec.dynamic(
+              -1,
+              seq(
+                field("type", alias($._identifier, $.type_identifier)),
+                repeat1(ascriptionArrowTail($)),
+              ),
+            ),
+            $.annotation,
+          ),
         ),
       ),
 
+    /*
+     * NOTE: a colon argument after an infix operator (`a op:\n  body`) is
+     * covered by $.call_expression via $.postfix_expression, so it is not a
+     * right-operand choice here. Keeping it here would statically shadow
+     * postfix expressions followed by an ascription, e.g.
+     * `(1 second: Duration)`.
+     */
     infix_expression: $ =>
       prec.left(
         PREC.infix,
@@ -1641,14 +1935,21 @@ module.exports = grammar({
               $._simple_expression,
             ),
           ),
-          field("operator", $._identifier),
+          // A symbolic operator that ends its line continues the expression
+          // on the next line (SLS 1.2 infers no semicolon there). The
+          // external _operator_eol token only lexes in that layout, and by
+          // winning over the internal operator token it removes the postfix
+          // reading before the newline can split the statement.
+          field(
+            "operator",
+            choice(
+              $._identifier,
+              alias($._operator_eol, $.operator_identifier),
+            ),
+          ),
           field(
             "right",
-            choice(
-              $.prefix_expression,
-              $._simple_expression,
-              seq(":", $.colon_argument),
-            ),
+            choice($.prefix_expression, $._simple_expression),
           ),
         ),
       ),
@@ -1729,17 +2030,15 @@ module.exports = grammar({
     // ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}
     _exprs_in_parens: $ => trailingCommaSep1($.expression),
 
+    // The opening is a single two-character token so that a bare `$` used as
+    // an ordinary identifier (e.g. `$(selector)`) still lexes as an
+    // identifier. A `$ident` splice already lexes as one identifier anyway.
     splice_expression: $ =>
       prec.left(
         PREC.macro,
-        seq(
-          "$",
-          choice(
-            seq("{", $._block, "}"),
-            seq("[", $._type, "]"),
-            // TODO: This would never hit, since identifier permits $ sign
-            $.identifier,
-          ),
+        choice(
+          seq("${", $._block, "}"),
+          seq("$[", $._type, "]"),
         ),
       ),
 
@@ -1748,7 +2047,15 @@ module.exports = grammar({
         PREC.macro,
         seq(
           "'",
-          choice(seq("{", $._block, "}"), seq("[", $._type, "]"), $.identifier),
+          choice(
+            seq("{", $._block, "}"),
+            seq("[", $._type, "]"),
+            $.identifier,
+            // Keyword literals are quotable (`'null`, `'true`, `'false`);
+            // `'this` already parses via identifier.
+            $.null_literal,
+            $.boolean_literal,
+          ),
         ),
       ),
 
@@ -1780,6 +2087,7 @@ module.exports = grammar({
           "tracked",
           "transparent",
           "end",
+          "extension",
         ),
       ),
 
@@ -1842,7 +2150,7 @@ module.exports = grammar({
             // Technically speaking, Sm (Math symbols https://www.compart.com/en/unicode/category/Sm)
             // should be allowed as a single-character opchar, however, it includes `=`,
             // so we should to avoid that to prevent bad parsing of `=` as infix term or type.
-            /[\-!#%&*+\/\\<>?\u005e\u007c~\u00ac\u00b1\u00d7\u00f7\u2190-\u2194\p{So}]/,
+            /[\-!#%&*+\/\\<>?\u005e\u007c~\u00ac\u00b1\u00d7\u00f7\u2190-\u2194\u2200-\u22ff\p{So}]/,
             seq(
               // opchar minus slash
               /[\-!#%&*+\\:<=>?@\u005e\u007c~\p{Sm}\p{So}]/,
@@ -1859,6 +2167,133 @@ module.exports = grammar({
             ),
           ),
         ),
+      ),
+
+    // ---------------------------------------------------------------
+    // XML literals (SLS §10)
+    //
+    // XML mode is entered only where an expression or pattern can start AND
+    // the `<` is immediately followed by a name-start character. The external
+    // scanner token $._xml_tag_start enforces both conditions: it is only
+    // valid in the grammar states that admit an XML literal, so an infix
+    // `a < b` (operator position) never reaches it, and it refuses to match
+    // when whitespace or an operator character follows the `<`, so `< b`,
+    // `<-`, `<:` and friends fall through to the regular operator tokens.
+    // Comment/CDATA/processing-instruction literals need no scanner support:
+    // their multi-character tokens win over the operator tokens by length.
+
+    // XmlExpr ::= XmlContent {Element}
+    xml_expression: $ => prec.right(repeat1($._xml_node)),
+
+    _xml_node: $ =>
+      choice(
+        $.xml_element,
+        $.xml_comment,
+        $.xml_cdata,
+        $.xml_processing_instruction,
+      ),
+
+    xml_element: $ => xmlElementShape($, $._xml_content),
+
+    // `<` + name (no whitespace in between) + attributes. Shared between
+    // expression elements and pattern elements so that GLR forks where both
+    // an expression and a pattern are viable shift the same states until the
+    // element body disambiguates them.
+    _xml_open_tag: $ =>
+      seq(
+        alias($._xml_tag_start, "<"),
+        field("name", alias(token.immediate(XML_NAME), $.xml_name)),
+        repeat($.xml_attribute),
+      ),
+
+    _xml_end_tag: $ =>
+      seq("</", field("name", alias(token(XML_NAME), $.xml_name)), ">"),
+
+    xml_attribute: $ =>
+      seq(
+        field("key", alias(token(XML_NAME), $.xml_name)),
+        "=",
+        field(
+          "value",
+          choice(
+            alias(token(choice(/"[^<"]*"/, /'[^<']*'/)), $.xml_string),
+            $.block,
+          ),
+        ),
+      ),
+
+    _xml_content: $ =>
+      choice(
+        ...xmlTextAlternatives($),
+        $.block,
+        $._xml_node,
+        // Dead alternative: `/*` in XML content is text, not a comment.
+        $._suppress_block_comment,
+      ),
+
+    xml_text: _ => token(prec(-1, /[^<{}]+/)),
+
+    xml_comment: _ =>
+      token(seq("<!--", repeat(choice(/[^-]/, seq("-", /[^-]/))), "-->")),
+
+    xml_cdata: _ =>
+      token(
+        seq(
+          "<![CDATA[",
+          repeat(choice(/[^\]]/, seq("]", /[^\]]/), seq("]]", /[^>]/))),
+          "]]>",
+        ),
+      ),
+
+    xml_processing_instruction: _ =>
+      token(seq("<?", repeat(choice(/[^?]/, seq("?", /[^>]/))), "?>")),
+
+    // XmlPattern ::= ElemPattern; embedded `{...}` blocks hold patterns.
+    xml_pattern: $ => xmlElementShape($, $._xml_pattern_content),
+
+    _xml_pattern_content: $ =>
+      choice(
+        ...xmlTextAlternatives($),
+        seq("{", trailingCommaSep1($._xml_embedded_pattern), "}"),
+        $.xml_pattern,
+        $.xml_comment,
+        $.xml_cdata,
+        $.xml_processing_instruction,
+        // Dead alternative: `/*` in XML content is text, not a comment.
+        $._suppress_block_comment,
+      ),
+
+    // A restricted top-level pattern for XML embeds. In positions where both
+    // an element and an element pattern stay viable, $.block (full statement
+    // closure, including `given` definitions) shares the state with this
+    // rule, and any alternative whose leftmost symbol is the full $._pattern
+    // (infix/alternative/repeat/typed patterns) drags given_pattern and
+    // ascriptions into the closure, conflict-cascading against the block's
+    // definitions. So only alternatives with a closed left edge are allowed
+    // here; nested pattern positions (after `@`, inside parens) still admit
+    // the full $._pattern.
+    _xml_embedded_pattern: $ =>
+      choice(
+        $._identifier,
+        $.stable_identifier,
+        $.interpolated_string_expression,
+        $.capture_pattern,
+        $.tuple_pattern,
+        $.named_tuple_pattern,
+        $.case_class_pattern,
+        $.quote_expression,
+        $.literal,
+        $.wildcard,
+        alias($._xml_repeat_pattern, $.repeat_pattern),
+        $.xml_pattern,
+      ),
+
+    // `_*` / `x*` at the top of an XML embed, without the $._pattern left
+    // recursion of $.repeat_pattern.
+    _xml_repeat_pattern: $ =>
+      seq(
+        field("pattern", choice($.wildcard, $._identifier)),
+        $._asterisk,
       ),
 
     _non_null_literal: $ =>
@@ -1935,7 +2370,18 @@ module.exports = grammar({
       alias($._interpolation_identifier, $.identifier),
 
     interpolation: $ =>
-      seq("$", choice($._aliased_interpolation_identifier, $.block)),
+      seq(
+        "$",
+        choice(
+          $._aliased_interpolation_identifier,
+          $.block,
+          // In pattern position an interpolation may hold a capture pattern,
+          // e.g. `case q"${name @ Ident(_)}" =>`. Restricted to
+          // capture_pattern to keep the pattern grammar out of expression
+          // interpolations.
+          prec.dynamic(-1, seq("{", $.capture_pattern, "}")),
+        ),
+      ),
 
     interpolated_string: $ =>
       choice(
@@ -2009,6 +2455,10 @@ module.exports = grammar({
             // language, so I think it makes sense to allow them. Maybe in the future we
             // should move them to a `deprecated` syntax node?
             /[0-3]?[0-7]{1,2}/,
+            // Any other escaped character. scalac accepts these at the lexer
+            // level in interpolated strings (their validity depends on the
+            // interpolator, e.g. quasiquotes accept a plain `\`).
+            /[^\r\n]/,
           ),
         ),
       ),
@@ -2033,7 +2483,8 @@ module.exports = grammar({
 
     unit: $ => prec(PREC.unit, seq("(", ")")),
 
-    return_expression: $ => prec.left(seq("return", optional($.expression))),
+    return_expression: $ =>
+      prec.left(seq("return", optional(statementExpression($)))),
 
     throw_expression: $ => prec.left(seq("throw", $.expression)),
 
@@ -2091,7 +2542,13 @@ module.exports = grammar({
               ),
             ),
             choice(
-              seq(field("body", $.expression)),
+              // The bare body form also admits an indented block: Scala 3
+              // allows `for (x <- xs)` + an indented multi-statement body
+              // with no `do` (dotty Typer.scala, Run.scala). Plain
+              // $.expression, NOT statementExpression: this is the one
+              // place a `do` must never start (see the helper's comment).
+              field("body", choice($.indented_block, $.expression)),
+              seq("do", field("body", $._indentable_expression)),
               seq("yield", field("body", $._indentable_expression)),
             ),
           ),
@@ -2130,16 +2587,37 @@ module.exports = grammar({
         seq(
           optional("case"),
           $._pattern,
-          choice("<-", "="),
+          choice("<-", "←", "="),
           $.expression,
           optional($.guard),
         ),
         repeat1($.guard),
       ),
 
-    _shebang: $ => alias(token(seq("#!", /.*/)), $.comment),
+    // Either a plain `#!...` first line, or the Scala 2 script header form
+    // whose shell preamble runs until a closing `!#` line:
+    //   #!/bin/sh
+    //   exec scala "$0" "$@"
+    //   !#
+    _shebang: $ =>
+      alias(
+        token(
+          seq(
+            "#!",
+            /[^\n]*/,
+            optional(seq(repeat(seq("\n", /[^\n]*/)), "\n!#")),
+          ),
+        ),
+        $.comment,
+      ),
 
-    comment: $ => seq(token("//"), choice($.using_directive, $._comment_text)),
+    // The dead $._suppress_block_comment alternative marks the after-`//` state
+    // for the external scanner; see the externals list.
+    comment: $ =>
+      seq(
+        token("//"),
+        choice($.using_directive, $._comment_text, $._suppress_block_comment),
+      ),
     _comment_text: $ => token(prec(PREC.comment, /.*/)),
 
     using_directive: $ =>
@@ -2152,8 +2630,6 @@ module.exports = grammar({
     using_directive_key: $ => token(/[^\s]+/),
     using_directive_value: $ => token(/.*/),
 
-    block_comment: $ =>
-      seq(token("/*"), repeat(choice(token(/./), token("//"))), token("*/")),
   },
 });
 
@@ -2179,4 +2655,20 @@ function trailingSep1(delimiter, rule) {
 
 function sep1(delimiter, rule) {
   return seq(rule, repeat(seq(delimiter, rule)));
+}
+
+// XML content alternatives shared between expression elements and pattern
+// elements: plain text and the `{{` / `}}` escaped literal braces.
+function xmlTextAlternatives($) {
+  return [$.xml_text, alias("{{", $.xml_text), alias("}}", $.xml_text)];
+}
+
+// Element skeleton (self-closing, or open tag + content + end tag), shared
+// between xml_element and xml_pattern, which differ only in their content
+// rule.
+function xmlElementShape($, content) {
+  return seq(
+    $._xml_open_tag,
+    choice("/>", seq(">", repeat(content), $._xml_end_tag)),
+  );
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -118,6 +118,11 @@
 
 (infix_expression operator: (identifier) @operator)
 (infix_expression operator: (operator_identifier) @operator)
+; An operator receiving a colon argument, e.g. ``xs `++`:`` — parsed as a
+; postfix expression called with the colon argument.
+(call_expression
+  function: (postfix_expression (identifier) @operator .)
+  arguments: (colon_argument))
 (infix_type operator: (operator_identifier) @operator)
 (infix_type operator: (operator_identifier) @operator)
 
@@ -149,7 +154,7 @@
   "extends"
   "derives"
   "finally"
-;; `forSome` existential types not implemented yet
+  "forSome"
 ;; `macro` not implemented yet
   "object"
   "override"
@@ -163,9 +168,12 @@
   "using"
   "end"
   "implicit"
-  "extension"
   "with"
 ] @keyword
+
+; `extension` is a soft keyword: highlight it only where it starts an
+; extension definition, not when used as a plain identifier.
+(extension_definition "extension" @keyword)
 
 [
   "abstract"
@@ -258,3 +266,12 @@
 ;; Scala CLI using directives
 (using_directive_key) @parameter
 (using_directive_value) @string
+
+;; XML literals
+(xml_name) @tag
+(xml_attribute key: (xml_name) @attribute)
+(xml_string) @string
+(xml_text) @spell
+(xml_comment) @spell @comment
+(xml_cdata) @string
+(xml_processing_instruction) @keyword.directive

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -82,8 +82,17 @@
           "name": "_end_marker"
         },
         {
-          "type": "SYMBOL",
-          "name": "expression"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "do_while_expression"
+            }
+          ]
         }
       ]
     },
@@ -249,8 +258,17 @@
                     "name": "enum_case_definitions"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "do_while_expression"
+                      }
+                    ]
                   },
                   {
                     "type": "SYMBOL",
@@ -275,8 +293,17 @@
                           "name": "enum_case_definitions"
                         },
                         {
-                          "type": "SYMBOL",
-                          "name": "expression"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "expression"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "do_while_expression"
+                            }
+                          ]
                         },
                         {
                           "type": "SYMBOL",
@@ -314,12 +341,38 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": ":"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_colon_eol"
+                    },
+                    "named": false,
+                    "value": ":"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
                 "name": "_indent"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "self_type"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -338,6 +391,18 @@
             {
               "type": "STRING",
               "value": "{"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "self_type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "CHOICE",
@@ -368,6 +433,18 @@
             "type": "SYMBOL",
             "name": "annotation"
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "modifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -683,7 +760,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_identifier"
+                      "name": "_namespace_path_segment"
                     },
                     {
                       "type": "REPEAT",
@@ -696,7 +773,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "_identifier"
+                            "name": "_namespace_path_segment"
                           }
                         ]
                       }
@@ -746,6 +823,33 @@
           }
         ]
       }
+    },
+    "_namespace_path_segment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "enum"
+              },
+              {
+                "type": "STRING",
+                "value": "export"
+              }
+            ]
+          },
+          "named": true,
+          "value": "identifier"
+        }
+      ]
     },
     "namespace_wildcard": {
       "type": "PREC_LEFT",
@@ -899,8 +1003,22 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "=>"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "⇒"
+              },
+              "named": false,
+              "value": "=>"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -1720,8 +1838,22 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": ":"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ":"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_colon_eol"
+                },
+                "named": false,
+                "value": ":"
+              }
+            ]
           },
           {
             "type": "SYMBOL",
@@ -1731,17 +1863,31 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "self_type"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "self_type"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_block"
+                  }
+                ]
               },
               {
-                "type": "BLANK"
+                "type": "SYMBOL",
+                "name": "self_type"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_block"
           },
           {
             "type": "SYMBOL",
@@ -1789,23 +1935,32 @@
       }
     },
     "_braced_template_body1": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "self_type"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "self_type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "_block"
             }
           ]
         },
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "self_type"
         }
       ]
     },
@@ -1874,6 +2029,18 @@
         {
           "type": "SYMBOL",
           "name": "_outdent"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -2047,8 +2214,17 @@
               {
                 "type": "ALIAS",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "_identifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_alpha_identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_backquoted_id"
+                    }
+                  ]
                 },
                 "named": false,
                 "value": "_end_ident"
@@ -2093,8 +2269,22 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": "=>"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "=>"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "⇒"
+                  },
+                  "named": false,
+                  "value": "=>"
+                }
+              ]
             }
           ]
         }
@@ -2226,7 +2416,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_pattern"
+                "name": "_definition_pattern"
               },
               {
                 "type": "SYMBOL",
@@ -2425,7 +2615,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_pattern"
+                "name": "_definition_pattern"
               },
               {
                 "type": "SYMBOL",
@@ -3004,8 +3194,22 @@
           "name": "_given_conditional"
         },
         {
-          "type": "STRING",
-          "value": "=>"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "⇒"
+              },
+              "named": false,
+              "value": "=>"
+            }
+          ]
         }
       ]
     },
@@ -3126,8 +3330,22 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": ":"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_colon_eol"
+                    },
+                    "named": false,
+                    "value": ":"
+                  }
+                ]
               },
               {
                 "type": "STRING",
@@ -3175,25 +3393,15 @@
                 "type": "FIELD",
                 "name": "arguments",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "arguments"
-                }
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_annotated_type"
-              },
-              {
-                "type": "FIELD",
-                "name": "arguments",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "arguments"
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "PREC",
+                    "value": "constructor_application",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "arguments"
+                    }
+                  }
                 }
               }
             ]
@@ -3380,8 +3588,8 @@
       ]
     },
     "inline_modifier": {
-      "type": "PREC",
-      "value": "mod",
+      "type": "PREC_DYNAMIC",
+      "value": 1,
       "content": {
         "type": "STRING",
         "value": "inline"
@@ -3443,13 +3651,6 @@
             "content": {
               "type": "SYMBOL",
               "name": "_constructor_applications"
-            }
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "arguments"
             }
           }
         ]
@@ -4099,8 +4300,22 @@
             }
           },
           {
-            "type": "STRING",
-            "value": ":"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ":"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_colon_eol"
+                },
+                "named": false,
+                "value": ":"
+              }
+            ]
           },
           {
             "type": "FIELD",
@@ -4117,6 +4332,59 @@
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "STRING",
+                  "value": ";"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_block_statements"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_block_statements"
+          }
+        ]
+      }
+    },
+    "_semis": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_semicolon"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "STRING",
+            "value": ";"
+          }
+        }
+      ]
+    },
+    "_block_statements": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
         "type": "SEQ",
         "members": [
           {
@@ -4126,8 +4394,17 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "do_while_expression"
+                      }
+                    ]
                   },
                   {
                     "type": "SYMBOL",
@@ -4136,10 +4413,6 @@
                   {
                     "type": "SYMBOL",
                     "name": "_end_marker"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ";"
                   }
                 ]
               },
@@ -4150,14 +4423,23 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_semicolon"
+                      "name": "_semis"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
-                          "type": "SYMBOL",
-                          "name": "expression"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "expression"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "do_while_expression"
+                            }
+                          ]
                         },
                         {
                           "type": "SYMBOL",
@@ -4166,10 +4448,6 @@
                         {
                           "type": "SYMBOL",
                           "name": "_end_marker"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ";"
                         }
                       ]
                     }
@@ -4183,7 +4461,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_semicolon"
+                "name": "_semis"
               },
               {
                 "type": "BLANK"
@@ -4208,8 +4486,17 @@
             "name": "indented_cases"
           },
           {
-            "type": "SYMBOL",
-            "name": "expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "do_while_expression"
+              }
+            ]
           }
         ]
       }
@@ -4362,8 +4649,37 @@
         {
           "type": "SYMBOL",
           "name": "type_lambda"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "existential_type"
         }
       ]
+    },
+    "existential_type": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_infix_type_choice"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "forSome"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_refinement"
+          }
+        ]
+      }
     },
     "_annotated_type": {
       "type": "PREC_RIGHT",
@@ -5056,8 +5372,22 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "=>"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "=>"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "⇒"
+                    },
+                    "named": false,
+                    "value": "=>"
+                  }
+                ]
               },
               {
                 "type": "STRING",
@@ -5215,8 +5545,22 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "=>"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "⇒"
+              },
+              "named": false,
+              "value": "=>"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -5309,6 +5653,27 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_definition_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alternative_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "typed_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "repeat_pattern"
+        }
+      ]
+    },
+    "_definition_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
           "name": "_identifier"
         },
         {
@@ -5341,14 +5706,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "alternative_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "typed_pattern"
-        },
-        {
-          "type": "SYMBOL",
           "name": "given_pattern"
         },
         {
@@ -5365,9 +5722,42 @@
         },
         {
           "type": "SYMBOL",
-          "name": "repeat_pattern"
+          "name": "xml_pattern"
         }
       ]
+    },
+    "infix_pattern": {
+      "type": "PREC_LEFT",
+      "value": 6,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_definition_pattern"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_identifier"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_definition_pattern"
+            }
+          }
+        ]
+      }
     },
     "case_class_pattern": {
       "type": "SEQ",
@@ -5511,39 +5901,6 @@
           "value": ")"
         }
       ]
-    },
-    "infix_pattern": {
-      "type": "PREC_LEFT",
-      "value": 6,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "left",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_pattern"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "operator",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_identifier"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "right",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_pattern"
-            }
-          }
-        ]
-      }
     },
     "capture_pattern": {
       "type": "PREC_RIGHT",
@@ -5855,10 +6212,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "do_while_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "for_expression"
         },
         {
@@ -5939,6 +6292,14 @@
           "name": "call_expression"
         },
         {
+          "type": "SYMBOL",
+          "name": "xml_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "method_value"
+        },
+        {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
@@ -5948,6 +6309,23 @@
           "value": "match_expression"
         }
       ]
+    },
+    "method_value": {
+      "type": "PREC_LEFT",
+      "value": 8,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_simple_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "wildcard"
+          }
+        ]
+      }
     },
     "_single_lambda_param": {
       "type": "PREC_RIGHT",
@@ -6016,8 +6394,22 @@
                     }
                   },
                   {
-                    "type": "STRING",
-                    "value": "=>"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "=>"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "STRING",
+                          "value": "⇒"
+                        },
+                        "named": false,
+                        "value": "=>"
+                      }
+                    ]
                   }
                 ]
               },
@@ -6051,8 +6443,22 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "=>"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "=>"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "⇒"
+                    },
+                    "named": false,
+                    "value": "=>"
+                  }
+                ]
               },
               {
                 "type": "STRING",
@@ -6098,8 +6504,22 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "=>"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "=>"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "⇒"
+                    },
+                    "named": false,
+                    "value": "=>"
+                  }
+                ]
               },
               {
                 "type": "STRING",
@@ -6108,8 +6528,16 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "_block"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_block"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -6399,8 +6827,17 @@
             "type": "FIELD",
             "name": "body",
             "content": {
-              "type": "SYMBOL",
-              "name": "expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "indented_block"
+                }
+              ]
             }
           }
         ]
@@ -6450,8 +6887,22 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ":"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_colon_eol"
+                      },
+                      "named": false,
+                      "value": ":"
+                    }
+                  ]
                 },
                 {
                   "type": "FIELD",
@@ -6635,8 +7086,22 @@
             ]
           },
           {
-            "type": "STRING",
-            "value": "=>"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "=>"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "⇒"
+                },
+                "named": false,
+                "value": "=>"
+              }
+            ]
           }
         ]
       }
@@ -6696,8 +7161,17 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "do_while_expression"
+                    }
+                  ]
                 },
                 {
                   "type": "SYMBOL",
@@ -6790,8 +7264,22 @@
                 }
               },
               {
-                "type": "STRING",
-                "value": ":"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_colon_eol"
+                    },
+                    "named": false,
+                    "value": ":"
+                  }
+                ]
               },
               {
                 "type": "FIELD",
@@ -6825,8 +7313,13 @@
                       "type": "CHOICE",
                       "members": [
                         {
-                          "type": "SYMBOL",
-                          "name": "bindings"
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_colon_bindings"
+                          },
+                          "named": true,
+                          "value": "bindings"
                         },
                         {
                           "type": "SYMBOL",
@@ -6839,8 +7332,22 @@
                       ]
                     },
                     {
-                      "type": "STRING",
-                      "value": "=>"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "=>"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": "⇒"
+                          },
+                          "named": false,
+                          "value": "=>"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -6865,6 +7372,97 @@
           }
         ]
       }
+    },
+    "_colon_bindings": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "binding"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "name_and_type"
+                          },
+                          "named": true,
+                          "value": "binding"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "binding"
+                              },
+                              {
+                                "type": "ALIAS",
+                                "content": {
+                                  "type": "SYMBOL",
+                                  "name": "name_and_type"
+                                },
+                                "named": true,
+                                "value": "binding"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
     },
     "field_expression": {
       "type": "PREC_LEFT",
@@ -6951,7 +7549,7 @@
                 "name": "early_defs",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_early_defs"
+                  "name": "early_defs"
                 }
               },
               {
@@ -6980,14 +7578,43 @@
         }
       ]
     },
-    "_early_defs": {
-      "type": "ALIAS",
+    "early_defs": {
+      "type": "PREC_LEFT",
+      "value": 1,
       "content": {
-        "type": "SYMBOL",
-        "name": "_braced_template_body"
-      },
-      "named": true,
-      "value": "early_defs"
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_braced_template_body1"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_braced_template_body2"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
     },
     "ascription_expression": {
       "type": "PREC_LEFT",
@@ -6996,8 +7623,17 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_postfix_expression_choice"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_postfix_expression_choice"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "match_expression"
+              }
+            ]
           },
           {
             "type": "STRING",
@@ -7007,8 +7643,133 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_param_type"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "type",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_param_type"
+                    }
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PREC",
+                      "value": 1,
+                      "content": {
+                        "type": "PREC_DYNAMIC",
+                        "value": -1,
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "=>"
+                                    },
+                                    {
+                                      "type": "ALIAS",
+                                      "content": {
+                                        "type": "STRING",
+                                        "value": "⇒"
+                                      },
+                                      "named": false,
+                                      "value": "=>"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "?=>"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "FIELD",
+                              "name": "return_type",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "_param_type"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "PREC_DYNAMIC",
+                "value": -1,
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "FIELD",
+                      "name": "type",
+                      "content": {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_identifier"
+                        },
+                        "named": true,
+                        "value": "type_identifier"
+                      }
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "=>"
+                                  },
+                                  {
+                                    "type": "ALIAS",
+                                    "content": {
+                                      "type": "STRING",
+                                      "value": "⇒"
+                                    },
+                                    "named": false,
+                                    "value": "=>"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "?=>"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "FIELD",
+                            "name": "return_type",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "_param_type"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
               },
               {
                 "type": "SYMBOL",
@@ -7050,8 +7811,22 @@
             "type": "FIELD",
             "name": "operator",
             "content": {
-              "type": "SYMBOL",
-              "name": "_identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_identifier"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_operator_eol"
+                  },
+                  "named": true,
+                  "value": "operator_identifier"
+                }
+              ]
             }
           },
           {
@@ -7067,19 +7842,6 @@
                 {
                   "type": "SYMBOL",
                   "name": "_simple_expression"
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ":"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "colon_argument"
-                    }
-                  ]
                 }
               ]
             }
@@ -7496,52 +8258,39 @@
       "type": "PREC_LEFT",
       "value": 10,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "STRING",
-            "value": "$"
-          },
-          {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "{"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_block"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "}"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "["
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_type"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "]"
-                  }
-                ]
+                "type": "STRING",
+                "value": "${"
               },
               {
                 "type": "SYMBOL",
-                "name": "identifier"
+                "name": "_block"
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "$["
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_type"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
               }
             ]
           }
@@ -7598,6 +8347,14 @@
               {
                 "type": "SYMBOL",
                 "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "null_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "boolean_literal"
               }
             ]
           }
@@ -7674,6 +8431,10 @@
           {
             "type": "STRING",
             "value": "end"
+          },
+          {
+            "type": "STRING",
+            "value": "extension"
           }
         ]
       }
@@ -7763,7 +8524,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[\\-!#%&*+\\/\\\\<>?\\u005e\\u007c~\\u00ac\\u00b1\\u00d7\\u00f7\\u2190-\\u2194\\p{So}]"
+                "value": "[\\-!#%&*+\\/\\\\<>?\\u005e\\u007c~\\u00ac\\u00b1\\u00d7\\u00f7\\u2190-\\u2194\\u2200-\\u22ff\\p{So}]"
               },
               {
                 "type": "SEQ",
@@ -7803,6 +8564,611 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "xml_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "_xml_node"
+        }
+      }
+    },
+    "_xml_node": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "xml_element"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_cdata"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_processing_instruction"
+        }
+      ]
+    },
+    "xml_element": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_xml_open_tag"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "/>"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ">"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_xml_content"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_xml_end_tag"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "_xml_open_tag": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_xml_tag_start"
+          },
+          "named": false,
+          "value": "<"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[_\\p{L}][-.:_\\p{L}\\p{Nd}]*"
+              }
+            },
+            "named": true,
+            "value": "xml_name"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "xml_attribute"
+          }
+        }
+      ]
+    },
+    "_xml_end_tag": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "</"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[_\\p{L}][-.:_\\p{L}\\p{Nd}]*"
+              }
+            },
+            "named": true,
+            "value": "xml_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "xml_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "key",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[_\\p{L}][-.:_\\p{L}\\p{Nd}]*"
+              }
+            },
+            "named": true,
+            "value": "xml_name"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "TOKEN",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\"[^<\"]*\""
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "'[^<']*'"
+                      }
+                    ]
+                  }
+                },
+                "named": true,
+                "value": "xml_string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "block"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "_xml_content": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "xml_text"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "{{"
+          },
+          "named": true,
+          "value": "xml_text"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "}}"
+          },
+          "named": true,
+          "value": "xml_text"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_xml_node"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_suppress_block_comment"
+        }
+      ]
+    },
+    "xml_text": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^<{}]+"
+        }
+      }
+    },
+    "xml_comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "<!--"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^-]"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "-"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[^-]"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "-->"
+          }
+        ]
+      }
+    },
+    "xml_cdata": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "<![CDATA["
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^\\]]"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[^\\]]"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "]]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[^>]"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "]]>"
+          }
+        ]
+      }
+    },
+    "xml_processing_instruction": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "<?"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[^?]"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "?"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[^>]"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "?>"
+          }
+        ]
+      }
+    },
+    "xml_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_xml_open_tag"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "/>"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ">"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_xml_pattern_content"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_xml_end_tag"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "_xml_pattern_content": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "xml_text"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "{{"
+          },
+          "named": true,
+          "value": "xml_text"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "}}"
+          },
+          "named": true,
+          "value": "xml_text"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_xml_embedded_pattern"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_xml_embedded_pattern"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_cdata"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_processing_instruction"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_suppress_block_comment"
+        }
+      ]
+    },
+    "_xml_embedded_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stable_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "interpolated_string_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "capture_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "named_tuple_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_class_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quote_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "wildcard"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_xml_repeat_pattern"
+          },
+          "named": true,
+          "value": "repeat_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xml_pattern"
+        }
+      ]
+    },
+    "_xml_repeat_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "wildcard"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_asterisk"
         }
       ]
     },
@@ -8215,6 +9581,27 @@
             {
               "type": "SYMBOL",
               "name": "block"
+            },
+            {
+              "type": "PREC_DYNAMIC",
+              "value": -1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "{"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "capture_pattern"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "}"
+                  }
+                ]
+              }
             }
           ]
         }
@@ -8420,6 +9807,10 @@
               {
                 "type": "PATTERN",
                 "value": "[0-3]?[0-7]{1,2}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\\r\\n]"
               }
             ]
           }
@@ -8521,8 +9912,17 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "expression"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "do_while_expression"
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -8718,14 +10118,35 @@
                 "type": "CHOICE",
                 "members": [
                   {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "indented_block"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "expression"
+                        }
+                      ]
+                    }
+                  },
+                  {
                     "type": "SEQ",
                     "members": [
+                      {
+                        "type": "STRING",
+                        "value": "do"
+                      },
                       {
                         "type": "FIELD",
                         "name": "body",
                         "content": {
                           "type": "SYMBOL",
-                          "name": "expression"
+                          "name": "_indentable_expression"
                         }
                       }
                     ]
@@ -8942,6 +10363,10 @@
                 },
                 {
                   "type": "STRING",
+                  "value": "←"
+                },
+                {
+                  "type": "STRING",
                   "value": "="
                 }
               ]
@@ -8986,7 +10411,40 @@
             },
             {
               "type": "PATTERN",
-              "value": ".*"
+              "value": "[^\\n]*"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\n"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\n]*"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "\n!#"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -9014,6 +10472,10 @@
             {
               "type": "SYMBOL",
               "name": "_comment_text"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_suppress_block_comment"
             }
           ]
         }
@@ -9074,47 +10536,6 @@
         "type": "PATTERN",
         "value": ".*"
       }
-    },
-    "block_comment": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "/*"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "."
-                }
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "//"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "*/"
-          }
-        }
-      ]
     }
   },
   "extras": [
@@ -9135,6 +10556,30 @@
     [
       "tuple_type",
       "parameter_types"
+    ],
+    [
+      "xml_element",
+      "xml_pattern"
+    ],
+    [
+      "_simple_expression",
+      "_xml_embedded_pattern"
+    ],
+    [
+      "_simple_expression",
+      "_xml_repeat_pattern"
+    ],
+    [
+      "_type_identifier",
+      "ascription_expression"
+    ],
+    [
+      "extension_definition",
+      "_soft_identifier"
+    ],
+    [
+      "inline_modifier",
+      "_soft_identifier"
     ],
     [
       "binding",
@@ -9181,6 +10626,14 @@
     [
       "identifiers",
       "val_declaration"
+    ],
+    [
+      "val_declaration",
+      "_definition_pattern"
+    ],
+    [
+      "var_declaration",
+      "_definition_pattern"
     ],
     [
       "class_parameters"
@@ -9269,7 +10722,7 @@
       "_type_identifier"
     ],
     [
-      "_block",
+      "_block_statements",
       "_indentable_expression"
     ],
     [
@@ -9290,6 +10743,10 @@
     ],
     [
       "_exprs_in_parens"
+    ],
+    [
+      "named_tuple_type",
+      "_colon_bindings"
     ],
     [
       "_annotated_type",
@@ -9468,11 +10925,43 @@
       "value": "with"
     },
     {
+      "type": "STRING",
+      "value": "match"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_colon_eol"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_xml_tag_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_operator_eol"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_suppress_block_comment"
+    },
+    {
       "type": "SYMBOL",
       "name": "error_sentinel"
     }
   ],
   "inline": [
+    "_asterisk",
+    "_super_identifier",
+    "_this_identifier",
+    "_non_null_literal",
+    "_braced_template_body",
+    "_indented_template_body",
+    "_structural_type",
+    "_refinement",
     "_pattern",
     "_semicolon",
     "_definition",
@@ -9482,7 +10971,10 @@
     "_infix_type_choice",
     "_param_value_type",
     "_simple_type",
-    "literal"
+    "literal",
+    "_xml_node",
+    "_xml_content",
+    "_xml_pattern_content"
   ],
   "supertypes": [
     "expression",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -160,6 +160,10 @@
       {
         "type": "wildcard",
         "named": true
+      },
+      {
+        "type": "xml_pattern",
+        "named": true
       }
     ]
   },
@@ -193,10 +197,6 @@
       },
       {
         "type": "character_literal",
-        "named": true
-      },
-      {
-        "type": "do_while_expression",
         "named": true
       },
       {
@@ -249,6 +249,10 @@
       },
       {
         "type": "match_expression",
+        "named": true
+      },
+      {
+        "type": "method_value",
         "named": true
       },
       {
@@ -309,6 +313,10 @@
       },
       {
         "type": "wildcard",
+        "named": true
+      },
+      {
+        "type": "xml_expression",
         "named": true
       }
     ]
@@ -611,8 +619,8 @@
     "type": "ascription_expression",
     "named": true,
     "fields": {
-      "type": {
-        "multiple": false,
+      "return_type": {
+        "multiple": true,
         "required": false,
         "types": [
           {
@@ -628,6 +636,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -637,6 +649,10 @@
           },
           {
             "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "lazy_parameter_type",
             "named": true
           },
           {
@@ -653,6 +669,96 @@
           },
           {
             "type": "projected_type",
+            "named": true
+          },
+          {
+            "type": "repeated_parameter_type",
+            "named": true
+          },
+          {
+            "type": "singleton_type",
+            "named": true
+          },
+          {
+            "type": "stable_type_identifier",
+            "named": true
+          },
+          {
+            "type": "structural_type",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          },
+          {
+            "type": "type_lambda",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "annotated_type",
+            "named": true
+          },
+          {
+            "type": "applied_constructor_type",
+            "named": true
+          },
+          {
+            "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
+            "named": true
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "generic_type",
+            "named": true
+          },
+          {
+            "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "lazy_parameter_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
+            "named": true
+          },
+          {
+            "type": "match_type",
+            "named": true
+          },
+          {
+            "type": "named_tuple_type",
+            "named": true
+          },
+          {
+            "type": "projected_type",
+            "named": true
+          },
+          {
+            "type": "repeated_parameter_type",
             "named": true
           },
           {
@@ -747,11 +853,11 @@
           "named": true
         },
         {
-          "type": "lazy_parameter_type",
+          "type": "match_expression",
           "named": true
         },
         {
-          "type": "match_expression",
+          "type": "method_value",
           "named": true
         },
         {
@@ -779,10 +885,6 @@
           "named": true
         },
         {
-          "type": "repeated_parameter_type",
-          "named": true
-        },
-        {
           "type": "splice_expression",
           "named": true
         },
@@ -800,6 +902,10 @@
         },
         {
           "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_expression",
           "named": true
         }
       ]
@@ -866,6 +972,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -904,6 +1014,10 @@
           {
             "type": "wildcard",
             "named": true
+          },
+          {
+            "type": "xml_expression",
+            "named": true
           }
         ]
       },
@@ -911,6 +1025,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -955,6 +1073,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -1063,17 +1185,15 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         }
       ]
     }
-  },
-  {
-    "type": "block_comment",
-    "named": true,
-    "extra": true,
-    "fields": {}
   },
   {
     "type": "boolean_literal",
@@ -1167,6 +1287,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -1208,6 +1332,10 @@
           },
           {
             "type": "wildcard",
+            "named": true
+          },
+          {
+            "type": "xml_expression",
             "named": true
           }
         ]
@@ -1322,6 +1450,10 @@
             "named": false
           },
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "end",
             "named": false
           },
@@ -1404,6 +1536,10 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "indented_block",
+            "named": true
           }
         ]
       },
@@ -1422,6 +1558,10 @@
       "multiple": false,
       "required": false,
       "types": [
+        {
+          "type": "do_while_expression",
+          "named": true
+        },
         {
           "type": "expression",
           "named": true
@@ -1574,6 +1714,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -1673,6 +1817,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -1833,6 +1981,10 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         }
@@ -1979,6 +2131,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -2244,6 +2400,10 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -2267,11 +2427,19 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "enum_case_definitions",
           "named": true
         },
         {
           "type": "expression",
+          "named": true
+        },
+        {
+          "type": "self_type",
           "named": true
         }
       ]
@@ -2291,6 +2459,10 @@
         },
         {
           "type": "full_enum_case",
+          "named": true
+        },
+        {
+          "type": "modifiers",
           "named": true
         },
         {
@@ -2427,6 +2599,80 @@
     }
   },
   {
+    "type": "existential_type",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "annotated_type",
+            "named": true
+          },
+          {
+            "type": "applied_constructor_type",
+            "named": true
+          },
+          {
+            "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "generic_type",
+            "named": true
+          },
+          {
+            "type": "infix_type",
+            "named": true
+          },
+          {
+            "type": "literal_type",
+            "named": true
+          },
+          {
+            "type": "named_tuple_type",
+            "named": true
+          },
+          {
+            "type": "projected_type",
+            "named": true
+          },
+          {
+            "type": "singleton_type",
+            "named": true
+          },
+          {
+            "type": "stable_type_identifier",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "refinement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "export_declaration",
     "named": true,
     "fields": {
@@ -2548,16 +2794,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "arguments",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2579,6 +2815,10 @@
           {
             "type": "_end_ident",
             "named": false
+          },
+          {
+            "type": "do_while_expression",
+            "named": true
           },
           {
             "type": "end",
@@ -2735,6 +2975,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -2769,6 +3013,10 @@
           {
             "type": "wildcard",
             "named": true
+          },
+          {
+            "type": "xml_expression",
+            "named": true
           }
         ]
       }
@@ -2782,6 +3030,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "do_while_expression",
+          "named": true
+        },
         {
           "type": "expression",
           "named": true
@@ -2805,6 +3057,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -2946,6 +3202,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -3028,6 +3288,10 @@
         "required": true,
         "types": [
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
@@ -3083,6 +3347,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -3187,6 +3455,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -3364,6 +3636,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -3446,7 +3722,7 @@
     "named": true,
     "fields": {
       "arguments": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {
@@ -3459,6 +3735,10 @@
         "multiple": false,
         "required": false,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -3626,6 +3906,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -3750,6 +4034,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -3792,6 +4080,10 @@
           {
             "type": "wildcard",
             "named": true
+          },
+          {
+            "type": "xml_expression",
+            "named": true
           }
         ]
       }
@@ -3826,6 +4118,10 @@
         "required": false,
         "types": [
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
@@ -3843,6 +4139,10 @@
         "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -3865,6 +4165,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -3943,6 +4247,10 @@
       "types": [
         {
           "type": "_definition",
+          "named": true
+        },
+        {
+          "type": "do_while_expression",
           "named": true
         },
         {
@@ -4032,6 +4340,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -4070,6 +4382,10 @@
           {
             "type": "wildcard",
             "named": true
+          },
+          {
+            "type": "xml_expression",
+            "named": true
           }
         ]
       },
@@ -4088,13 +4404,9 @@
         ]
       },
       "right": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": ":",
-            "named": false
-          },
           {
             "type": "block",
             "named": true
@@ -4113,10 +4425,6 @@
           },
           {
             "type": "character_literal",
-            "named": true
-          },
-          {
-            "type": "colon_argument",
             "named": true
           },
           {
@@ -4152,6 +4460,10 @@
             "named": true
           },
           {
+            "type": "method_value",
+            "named": true
+          },
+          {
             "type": "null_literal",
             "named": true
           },
@@ -4190,6 +4502,10 @@
           {
             "type": "wildcard",
             "named": true
+          },
+          {
+            "type": "xml_expression",
+            "named": true
           }
         ]
       }
@@ -4209,7 +4525,79 @@
         "required": true,
         "types": [
           {
-            "type": "_pattern",
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "capture_pattern",
+            "named": true
+          },
+          {
+            "type": "case_class_pattern",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "floating_point_literal",
+            "named": true
+          },
+          {
+            "type": "given_pattern",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "infix_pattern",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "interpolated_string_expression",
+            "named": true
+          },
+          {
+            "type": "named_tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "null_literal",
+            "named": true
+          },
+          {
+            "type": "operator_identifier",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "stable_identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          },
+          {
+            "type": "xml_pattern",
             "named": true
           }
         ]
@@ -4233,7 +4621,79 @@
         "required": true,
         "types": [
           {
-            "type": "_pattern",
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "capture_pattern",
+            "named": true
+          },
+          {
+            "type": "case_class_pattern",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "floating_point_literal",
+            "named": true
+          },
+          {
+            "type": "given_pattern",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "infix_pattern",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "interpolated_string_expression",
+            "named": true
+          },
+          {
+            "type": "named_tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "null_literal",
+            "named": true
+          },
+          {
+            "type": "operator_identifier",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "stable_identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          },
+          {
+            "type": "xml_pattern",
             "named": true
           }
         ]
@@ -4386,7 +4846,7 @@
     "named": true,
     "fields": {
       "arguments": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {
@@ -4523,6 +4983,10 @@
           "named": true
         },
         {
+          "type": "capture_pattern",
+          "named": true
+        },
+        {
           "type": "identifier",
           "named": true
         }
@@ -4560,6 +5024,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -4652,6 +5120,10 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -4684,6 +5156,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -4799,6 +5275,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -4926,6 +5406,10 @@
           "named": true
         },
         {
+          "type": "method_value",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },
@@ -4963,6 +5447,10 @@
         },
         {
           "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_expression",
           "named": true
         }
       ]
@@ -5076,6 +5564,113 @@
     }
   },
   {
+    "type": "method_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "case_block",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "field_expression",
+          "named": true
+        },
+        {
+          "type": "floating_point_literal",
+          "named": true
+        },
+        {
+          "type": "generic_function",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "instance_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "match_expression",
+          "named": true
+        },
+        {
+          "type": "method_value",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "operator_identifier",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "splice_expression",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "tuple_expression",
+          "named": true
+        },
+        {
+          "type": "unit",
+          "named": true
+        },
+        {
+          "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "modifiers",
     "named": true,
     "fields": {},
@@ -5146,6 +5741,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -5287,6 +5886,10 @@
         },
         {
           "type": "compound_type",
+          "named": true
+        },
+        {
+          "type": "existential_type",
           "named": true
         },
         {
@@ -5584,6 +6187,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -5683,6 +6290,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -5825,6 +6436,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -5985,6 +6600,10 @@
           "named": true
         },
         {
+          "type": "method_value",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },
@@ -6022,6 +6641,10 @@
         },
         {
           "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_expression",
           "named": true
         }
       ]
@@ -6088,6 +6711,10 @@
           "named": true
         },
         {
+          "type": "method_value",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },
@@ -6121,6 +6748,10 @@
         },
         {
           "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_expression",
           "named": true
         }
       ]
@@ -6209,6 +6840,14 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
+          "type": "existential_type",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -6280,6 +6919,10 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -6324,6 +6967,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -6395,6 +7042,10 @@
       "required": false,
       "types": [
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         }
@@ -6419,6 +7070,10 @@
         },
         {
           "type": "compound_type",
+          "named": true
+        },
+        {
+          "type": "existential_type",
           "named": true
         },
         {
@@ -6566,6 +7221,14 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
+          "type": "existential_type",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -6702,6 +7365,10 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
@@ -6722,6 +7389,10 @@
       "types": [
         {
           "type": "_definition",
+          "named": true
+        },
+        {
+          "type": "do_while_expression",
           "named": true
         },
         {
@@ -6857,6 +7528,10 @@
         "required": true,
         "types": [
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
@@ -6937,6 +7612,10 @@
           "named": true
         },
         {
+          "type": "existential_type",
+          "named": true
+        },
+        {
           "type": "function_type",
           "named": true
         },
@@ -7013,6 +7692,10 @@
         },
         {
           "type": "compound_type",
+          "named": true
+        },
+        {
+          "type": "existential_type",
           "named": true
         },
         {
@@ -7103,6 +7786,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -7174,6 +7861,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -7359,6 +8050,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -7520,6 +8215,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -7717,6 +8416,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -7799,6 +8502,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -7915,6 +8622,10 @@
             "named": true
           },
           {
+            "type": "existential_type",
+            "named": true
+          },
+          {
             "type": "function_type",
             "named": true
           },
@@ -7997,11 +8708,83 @@
         "required": true,
         "types": [
           {
-            "type": "_pattern",
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "capture_pattern",
+            "named": true
+          },
+          {
+            "type": "case_class_pattern",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "floating_point_literal",
+            "named": true
+          },
+          {
+            "type": "given_pattern",
+            "named": true
+          },
+          {
+            "type": "identifier",
             "named": true
           },
           {
             "type": "identifiers",
+            "named": true
+          },
+          {
+            "type": "infix_pattern",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "interpolated_string_expression",
+            "named": true
+          },
+          {
+            "type": "named_tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "null_literal",
+            "named": true
+          },
+          {
+            "type": "operator_identifier",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "stable_identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          },
+          {
+            "type": "xml_pattern",
             "named": true
           }
         ]
@@ -8020,6 +8803,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -8085,6 +8872,10 @@
         "required": true,
         "types": [
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
@@ -8146,6 +8937,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -8231,11 +9026,83 @@
         "required": true,
         "types": [
           {
-            "type": "_pattern",
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "capture_pattern",
+            "named": true
+          },
+          {
+            "type": "case_class_pattern",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "floating_point_literal",
+            "named": true
+          },
+          {
+            "type": "given_pattern",
+            "named": true
+          },
+          {
+            "type": "identifier",
             "named": true
           },
           {
             "type": "identifiers",
+            "named": true
+          },
+          {
+            "type": "infix_pattern",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "interpolated_string_expression",
+            "named": true
+          },
+          {
+            "type": "named_tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "null_literal",
+            "named": true
+          },
+          {
+            "type": "operator_identifier",
+            "named": true
+          },
+          {
+            "type": "quote_expression",
+            "named": true
+          },
+          {
+            "type": "stable_identifier",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "tuple_pattern",
+            "named": true
+          },
+          {
+            "type": "wildcard",
+            "named": true
+          },
+          {
+            "type": "xml_pattern",
             "named": true
           }
         ]
@@ -8254,6 +9121,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -8318,6 +9189,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "do_while_expression",
+            "named": true
+          },
           {
             "type": "expression",
             "named": true
@@ -8409,6 +9284,10 @@
           "named": true
         },
         {
+          "type": "method_value",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },
@@ -8443,6 +9322,10 @@
         {
           "type": "wildcard",
           "named": true
+        },
+        {
+          "type": "xml_expression",
+          "named": true
         }
       ]
     }
@@ -8465,6 +9348,10 @@
           },
           {
             "type": "compound_type",
+            "named": true
+          },
+          {
+            "type": "existential_type",
             "named": true
           },
           {
@@ -8536,6 +9423,10 @@
         "required": true,
         "types": [
           {
+            "type": "do_while_expression",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
@@ -8556,6 +9447,10 @@
           {
             "type": "do",
             "named": false
+          },
+          {
+            "type": "do_while_expression",
+            "named": true
           },
           {
             "type": "expression",
@@ -8591,11 +9486,236 @@
           "named": true
         },
         {
+          "type": "do_while_expression",
+          "named": true
+        },
+        {
           "type": "expression",
           "named": true
         },
         {
           "type": "self_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "xml_attribute",
+    "named": true,
+    "fields": {
+      "key": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "xml_name",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          },
+          {
+            "type": "xml_string",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "xml_element",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "xml_name",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block",
+          "named": true
+        },
+        {
+          "type": "xml_attribute",
+          "named": true
+        },
+        {
+          "type": "xml_cdata",
+          "named": true
+        },
+        {
+          "type": "xml_comment",
+          "named": true
+        },
+        {
+          "type": "xml_element",
+          "named": true
+        },
+        {
+          "type": "xml_processing_instruction",
+          "named": true
+        },
+        {
+          "type": "xml_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "xml_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "xml_cdata",
+          "named": true
+        },
+        {
+          "type": "xml_comment",
+          "named": true
+        },
+        {
+          "type": "xml_element",
+          "named": true
+        },
+        {
+          "type": "xml_processing_instruction",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "xml_pattern",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "xml_name",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "capture_pattern",
+          "named": true
+        },
+        {
+          "type": "case_class_pattern",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "floating_point_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "interpolated_string_expression",
+          "named": true
+        },
+        {
+          "type": "named_tuple_pattern",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "operator_identifier",
+          "named": true
+        },
+        {
+          "type": "quote_expression",
+          "named": true
+        },
+        {
+          "type": "repeat_pattern",
+          "named": true
+        },
+        {
+          "type": "stable_identifier",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "tuple_pattern",
+          "named": true
+        },
+        {
+          "type": "wildcard",
+          "named": true
+        },
+        {
+          "type": "xml_attribute",
+          "named": true
+        },
+        {
+          "type": "xml_cdata",
+          "named": true
+        },
+        {
+          "type": "xml_comment",
+          "named": true
+        },
+        {
+          "type": "xml_pattern",
+          "named": true
+        },
+        {
+          "type": "xml_processing_instruction",
+          "named": true
+        },
+        {
+          "type": "xml_text",
           "named": true
         }
       ]
@@ -8622,6 +9742,14 @@
     "named": false
   },
   {
+    "type": "$[",
+    "named": false
+  },
+  {
+    "type": "${",
+    "named": false
+  },
+  {
     "type": "'",
     "named": false
   },
@@ -8635,10 +9763,6 @@
   },
   {
     "type": "*",
-    "named": false
-  },
-  {
-    "type": "*/",
     "named": false
   },
   {
@@ -8658,11 +9782,11 @@
     "named": false
   },
   {
-    "type": "/*",
+    "type": "//",
     "named": false
   },
   {
-    "type": "//",
+    "type": "/>",
     "named": false
   },
   {
@@ -8674,11 +9798,19 @@
     "named": false
   },
   {
+    "type": "<",
+    "named": false
+  },
+  {
     "type": "<%",
     "named": false
   },
   {
     "type": "<-",
+    "named": false
+  },
+  {
+    "type": "</",
     "named": false
   },
   {
@@ -8726,12 +9858,21 @@
     "named": false
   },
   {
+    "type": "_end_ident",
+    "named": false
+  },
+  {
     "type": "abstract",
     "named": false
   },
   {
     "type": "as",
     "named": false
+  },
+  {
+    "type": "block_comment",
+    "named": true,
+    "extra": true
   },
   {
     "type": "case",
@@ -8807,6 +9948,10 @@
   },
   {
     "type": "for",
+    "named": false
+  },
+  {
+    "type": "forSome",
     "named": false
   },
   {
@@ -8966,6 +10111,30 @@
     "named": false
   },
   {
+    "type": "xml_cdata",
+    "named": true
+  },
+  {
+    "type": "xml_comment",
+    "named": true
+  },
+  {
+    "type": "xml_name",
+    "named": true
+  },
+  {
+    "type": "xml_processing_instruction",
+    "named": true
+  },
+  {
+    "type": "xml_string",
+    "named": true
+  },
+  {
+    "type": "xml_text",
+    "named": true
+  },
+  {
     "type": "yield",
     "named": false
   },
@@ -8983,6 +10152,10 @@
   },
   {
     "type": "~",
+    "named": false
+  },
+  {
+    "type": "←",
     "named": false
   }
 ]

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,6 +2,7 @@
 #include "tree_sitter/array.h"
 #include "tree_sitter/parser.h"
 
+#include <string.h>
 #include <wctype.h>
 
 // #define DEBUG
@@ -33,30 +34,46 @@ enum TokenType {
   EXTENDS,
   DERIVES,
   WITH,
+  MATCH,
+  COLON_EOL,
+  XML_TAG_START,
+  OPERATOR_EOL,
+  BLOCK_COMMENT,
+  SUPPRESS_BLOCK_COMMENT,
   ERROR_SENTINEL
 };
 
+// Designated initializers keep the names in sync with the enum by
+// construction (a plain positional list silently desyncs when a token is
+// added mid-enum).
 const char* token_name[] = {
-  "AUTOMATIC_SEMICOLON",
-  "INDENT",
-  "OUTDENT",
-  "COMMA_OUTDENT",
-  "SIMPLE_STRING_START",
-  "SIMPLE_STRING_MIDDLE",
-  "SIMPLE_MULTILINE_STRING_START",
-  "INTERPOLATED_STRING_MIDDLE",
-  "INTERPOLATED_MULTILINE_STRING_MIDDLE",
-  "RAW_STRING_MIDDLE",
-  "RAW_STRING_MULTILINE_MIDDLE",
-  "SINGLE_LINE_STRING_END",
-  "MULTILINE_STRING_END",
-  "ELSE",
-  "CATCH",
-  "FINALLY",
-  "EXTENDS",
-  "DERIVES",
-  "WITH",
-  "ERROR_SENTINEL"
+  [AUTOMATIC_SEMICOLON] = "AUTOMATIC_SEMICOLON",
+  [INDENT] = "INDENT",
+  [OUTDENT] = "OUTDENT",
+  [COMMA_OUTDENT] = "COMMA_OUTDENT",
+  [SIMPLE_STRING_START] = "SIMPLE_STRING_START",
+  [SIMPLE_STRING_MIDDLE] = "SIMPLE_STRING_MIDDLE",
+  [SIMPLE_MULTILINE_STRING_START] = "SIMPLE_MULTILINE_STRING_START",
+  [INTERPOLATED_STRING_MIDDLE] = "INTERPOLATED_STRING_MIDDLE",
+  [INTERPOLATED_MULTILINE_STRING_MIDDLE] = "INTERPOLATED_MULTILINE_STRING_MIDDLE",
+  [RAW_STRING_START] = "RAW_STRING_START",
+  [RAW_STRING_MIDDLE] = "RAW_STRING_MIDDLE",
+  [RAW_STRING_MULTILINE_MIDDLE] = "RAW_STRING_MULTILINE_MIDDLE",
+  [SINGLE_LINE_STRING_END] = "SINGLE_LINE_STRING_END",
+  [MULTILINE_STRING_END] = "MULTILINE_STRING_END",
+  [ELSE] = "ELSE",
+  [CATCH] = "CATCH",
+  [FINALLY] = "FINALLY",
+  [EXTENDS] = "EXTENDS",
+  [DERIVES] = "DERIVES",
+  [WITH] = "WITH",
+  [MATCH] = "MATCH",
+  [COLON_EOL] = "COLON_EOL",
+  [XML_TAG_START] = "XML_TAG_START",
+  [OPERATOR_EOL] = "OPERATOR_EOL",
+  [BLOCK_COMMENT] = "BLOCK_COMMENT",
+  [SUPPRESS_BLOCK_COMMENT] = "SUPPRESS_BLOCK_COMMENT",
+  [ERROR_SENTINEL] = "ERROR_SENTINEL"
 };
 
 typedef struct {
@@ -64,6 +81,14 @@ typedef struct {
   int16_t last_indentation_size;
   int16_t last_newline_count;
   int16_t last_column;
+  // Set while the last returned token is COLON_EOL (comments in between keep
+  // it). A colon argument's body may then start at the SAME width as the
+  // current region (dotty allows it on continuation lines):
+  //   noNotes:            <- region width 10 (body of an outer colon arg)
+  //     ... elems.exists(...)
+  //   && ifNotTried(x):   <- leading-infix continuation line
+  //     val xelems = ...  <- body at width 10 == region width
+  int16_t after_colon_eol;
 } Scanner;
 
 void *tree_sitter_scala_external_scanner_create() {
@@ -83,7 +108,7 @@ void tree_sitter_scala_external_scanner_destroy(void *payload) {
 unsigned tree_sitter_scala_external_scanner_serialize(void *payload, char *buffer) {
   Scanner *scanner = (Scanner*)payload;
 
-  if ((scanner->indents.size + 3) * sizeof(int16_t) > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
+  if ((scanner->indents.size + 4) * sizeof(int16_t) > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
     return 0;
   }
 
@@ -93,6 +118,8 @@ unsigned tree_sitter_scala_external_scanner_serialize(void *payload, char *buffe
   memcpy(buffer + size, &scanner->last_newline_count, sizeof(int16_t));
   size += sizeof(int16_t);
   memcpy(buffer + size, &scanner->last_column, sizeof(int16_t));
+  size += sizeof(int16_t);
+  memcpy(buffer + size, &scanner->after_colon_eol, sizeof(int16_t));
   size += sizeof(int16_t);
 
   for (unsigned i = 0; i < scanner->indents.size; i++) {
@@ -110,6 +137,7 @@ void tree_sitter_scala_external_scanner_deserialize(void *payload, const char *b
   scanner->last_indentation_size = -1;
   scanner->last_column = -1;
   scanner->last_newline_count = 0;
+  scanner->after_colon_eol = 0;
 
   if (length == 0) {
     return;
@@ -123,6 +151,8 @@ void tree_sitter_scala_external_scanner_deserialize(void *payload, const char *b
   size += sizeof(int16_t);
   scanner->last_column = *(int16_t *)&buffer[size];
   size += sizeof(int16_t);
+  scanner->after_colon_eol = *(int16_t *)&buffer[size];
+  size += sizeof(int16_t);
 
   while (size < length) {
     array_push(&scanner->indents, *(int16_t *)&buffer[size]);
@@ -135,6 +165,32 @@ void tree_sitter_scala_external_scanner_deserialize(void *payload, const char *b
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
 static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+// Advances past horizontal whitespace; returns whether any was consumed.
+static bool advance_past_blanks(TSLexer *lexer) {
+  bool found = false;
+  while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+    advance(lexer);
+    found = true;
+  }
+  return found;
+}
+
+// Indent-stack entries carry this flag when the region holds `case` clauses
+// aligned with their `match`/`catch` (allowed since Scala 3): unlike a normal
+// region, it also closes on a line at the SAME width when that line does not
+// start another `case` clause. The flag rides in the serialized int16 widths.
+#define CASE_INDENT_FLAG ((int16_t)0x4000)
+
+static inline int16_t indent_width(int16_t entry) {
+  return entry == -1 ? -1 : (int16_t)(entry & 0x3FFF);
+}
+
+// Does a line at `width` sit exactly at the width of a flagged same-width
+// case region `prev`? Shared by every close site of such regions.
+static inline bool at_case_region_width(int16_t prev, int16_t width) {
+  return prev != -1 && (prev & CASE_INDENT_FLAG) && width == indent_width(prev);
+}
 
 // Used to detect leading infix operators on continuation lines.
 // See: https://www.scala-lang.org/api/3.x/docs/changed-features/operators.html
@@ -225,18 +281,6 @@ static bool scan_string_content(TSLexer *lexer, bool is_multiline, StringMode st
   }
 }
 
-static bool detect_comment_start(TSLexer *lexer) {
-  lexer->mark_end(lexer);
-  // Comments should not affect indentation
-  if (lexer->lookahead == '/') {
-    advance(lexer);
-    if (lexer->lookahead == '/' || lexer -> lookahead == '*') {
-      return true;
-    }
-  }
-  return false;
-}
-
 static bool scan_word(TSLexer *lexer, const char* const word) {
   for (uint8_t i = 0; word[i] != '\0'; i++) {
     if (lexer->lookahead != word[i]) {
@@ -244,26 +288,249 @@ static bool scan_word(TSLexer *lexer, const char* const word) {
     }
     advance(lexer);
   }
-  return !iswalnum(lexer->lookahead);
+  // `_` and `$` continue an identifier too: `match_` is not `match`.
+  return !(iswalnum(lexer->lookahead) || lexer->lookahead == '_' ||
+           lexer->lookahead == '$');
+}
+
+// Reads an identifier-like word (letters, digits, `_`, `$`) into `buf`
+// (capacity `cap` including the NUL). Returns its length, or -1 when the
+// word overflows the buffer or contains a non-ASCII character (it cannot be
+// an ASCII keyword then); the whole word is consumed either way. Unlike a
+// chain of scan_word calls, a failed keyword comparison never leaves the
+// lexer mid-identifier (`cobject` must not be misread as `c` + `object`).
+static int read_word(TSLexer *lexer, char *buf, int cap) {
+  int len = 0;
+  bool not_keyword = false;
+  while (iswalnum(lexer->lookahead) || lexer->lookahead == '_' ||
+         lexer->lookahead == '$') {
+    if (lexer->lookahead > 127 || len >= cap - 1) {
+      not_keyword = true;
+    } else {
+      buf[len] = (char)lexer->lookahead;
+      len++;
+    }
+    advance(lexer);
+  }
+  buf[len] = '\0';
+  return not_keyword ? -1 : len;
+}
+
+// Is `word` one of the `count` strings in `words`?
+static bool word_in(const char *word, const char *const words[],
+                    unsigned count) {
+  for (unsigned i = 0; i < count; i++) {
+    if (strcmp(word, words[i]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Core of the block-comment skippers (nesting, SLS 1.4); the caller has
+// consumed the leading "/*". Returns true when the matching "*/" was
+// consumed; false when stopped early — at EOF, at a newline (when
+// stop_at_newline; the newline is not consumed), or on budget exhaustion.
+// Charges *budget per consumed character when budget is non-NULL.
+static bool consume_block_comment_body_ex(TSLexer *lexer,
+                                          bool stop_at_newline, int *budget) {
+  unsigned depth = 1;
+  while (depth > 0) {
+    if (lexer->eof(lexer) || (budget != NULL && *budget <= 0) ||
+        (stop_at_newline && lexer->lookahead == '\n')) {
+      return false;
+    }
+    if (lexer->lookahead == '/') {
+      advance(lexer);
+      if (lexer->lookahead == '*') {
+        advance(lexer);
+        depth++;
+      }
+    } else if (lexer->lookahead == '*') {
+      advance(lexer);
+      if (lexer->lookahead == '/') {
+        advance(lexer);
+        depth--;
+      }
+    } else {
+      advance(lexer);
+    }
+    if (budget != NULL) {
+      (*budget)--;
+    }
+  }
+  return true;
+}
+
+// Stops just past the matching "*/" (or at EOF).
+static void consume_block_comment_body(TSLexer *lexer) {
+  consume_block_comment_body_ex(lexer, false, NULL);
+}
+
+// Stops at a newline: returns whether the comment ended on the line it
+// started on. Used where a comment crossing the line end means "the line
+// ends here" and the rest of the comment does not matter.
+static bool consume_block_comment_body_on_line(TSLexer *lexer) {
+  return consume_block_comment_body_ex(lexer, true, NULL);
+}
+
+// After a token that must end its line: is the rest only blanks and
+// comments? A line comment, or a block comment running past the line end,
+// counts as yes (comments are transparent to scalac's line handling); code
+// after a same-line block comment counts as no.
+static bool rest_of_line_is_blank_or_comments(TSLexer *lexer) {
+  for (;;) {
+    advance_past_blanks(lexer);
+    if (lexer->eof(lexer) || lexer->lookahead == '\n' ||
+        lexer->lookahead == '\r') {
+      return true;
+    }
+    if (lexer->lookahead != '/') {
+      return false;
+    }
+    advance(lexer);
+    if (lexer->lookahead == '/') {
+      while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+        advance(lexer);
+      }
+      return true;
+    }
+    if (lexer->lookahead != '*') {
+      return false;  // a lone '/' is code
+    }
+    advance(lexer);
+    if (!consume_block_comment_body_on_line(lexer)) {
+      return true;  // the comment runs past the line end
+    }
+  }
+}
+
+// Skips a double-quoted string body; the caller has consumed the opening
+// quote. Stops after the closing quote or at EOL/EOF (unterminated).
+// Charges *budget per consumed character when non-NULL. Shared by the
+// line scanners so their string handling cannot drift.
+static void skip_string_tail(TSLexer *lexer, int *budget) {
+  while (!lexer->eof(lexer) && lexer->lookahead != '"' &&
+         lexer->lookahead != '\n') {
+    if (lexer->lookahead == '\\') {
+      advance(lexer);
+      if (budget != NULL) {
+        (*budget)--;
+      }
+    }
+    advance(lexer);
+    if (budget != NULL) {
+      (*budget)--;
+    }
+  }
+  if (lexer->lookahead == '"') {
+    advance(lexer);
+    if (budget != NULL) {
+      (*budget)--;
+    }
+  }
+}
+
+// Skips a back-quoted identifier body; the caller has consumed the opening
+// back-tick. Stops after the closing tick or at EOL/EOF.
+static void skip_backticked_tail(TSLexer *lexer, int *budget) {
+  while (!lexer->eof(lexer) && lexer->lookahead != '`' &&
+         lexer->lookahead != '\n') {
+    advance(lexer);
+    if (budget != NULL) {
+      (*budget)--;
+    }
+  }
+  if (lexer->lookahead == '`') {
+    advance(lexer);
+    if (budget != NULL) {
+      (*budget)--;
+    }
+  }
+}
+
+// After an opening `'`: a character literal (`'('`, `'\n'`) is skipped
+// whole and reveals no code, while quote syntax (`'{ q }`, `'sym`) reveals
+// its first character, which IS code the caller must process (most
+// importantly for bracket-depth bookkeeping). Distinguishing the two needs
+// two characters of lookahead. Returns the revealed character, or 0.
+static int32_t skip_char_or_quote_tail(TSLexer *lexer, int *budget) {
+  if (lexer->lookahead == '\\') {
+    advance(lexer);
+    if (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+      advance(lexer);
+    }
+    if (lexer->lookahead == '\'') {
+      advance(lexer);
+    }
+    if (budget != NULL) {
+      (*budget) -= 3;
+    }
+    return 0;
+  }
+  if (lexer->eof(lexer) || lexer->lookahead == '\n') {
+    return 0;
+  }
+  int32_t quoted = lexer->lookahead;
+  advance(lexer);
+  if (budget != NULL) {
+    (*budget)--;
+  }
+  if (lexer->lookahead == '\'') {
+    advance(lexer);  // a character literal: `quoted` was not code
+    if (budget != NULL) {
+      (*budget)--;
+    }
+    return 0;
+  }
+  return quoted;
+}
+
+// After a leading operator and its whitespace: does an operand follow?
+// Comments and line breaks are transparent — scalac reads the next real
+// token, so `||  // but consider NotGiven` + newline + `tps.hasAnnotation`
+// is a continuation — and only EOF (a comment-only tail) means there is
+// none. An inline comment does not count as the operand itself, though:
+// `|| /* c */ x` finds `x`, not the `/`.
+static bool has_operand(TSLexer *lexer) {
+  for (;;) {
+    if (lexer->eof(lexer)) {
+      return false;
+    }
+    if (iswspace(lexer->lookahead)) {
+      advance(lexer);
+      continue;
+    }
+    if (lexer->lookahead != '/') {
+      return true;
+    }
+    advance(lexer);
+    if (lexer->lookahead == '/') {
+      while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+        advance(lexer);
+      }
+      continue;
+    }
+    if (lexer->lookahead != '*') {
+      return true;  // a lone '/' is code
+    }
+    advance(lexer);
+    consume_block_comment_body(lexer);
+  }
 }
 
 // Returns true if the lookahead starts a leading infix operator — a symbolic
-// operator or back-ticked identifier followed by whitespace and then a
-// non-whitespace operand on the same line. Such a line is a continuation of
-// the previous expression, so neither AUTOMATIC_SEMICOLON nor OUTDENT should
-// fire ahead of it. Advances the lexer; the caller must not rely on position.
+// operator or back-ticked identifier followed by whitespace and then an
+// operand. Such a line is a continuation of the previous expression, so
+// neither AUTOMATIC_SEMICOLON nor OUTDENT should fire ahead of it. Advances
+// the lexer; the caller must not rely on position.
 static bool is_leading_infix_continuation(TSLexer *lexer) {
   if (is_op_char(lexer->lookahead)) {
     advance(lexer);
     while (is_op_char(lexer->lookahead)) {
       advance(lexer);
     }
-    bool found_space = false;
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
-      advance(lexer);
-      found_space = true;
-    }
-    return found_space && !iswspace(lexer->lookahead) && !lexer->eof(lexer);
+    return advance_past_blanks(lexer) && has_operand(lexer);
   }
   if (lexer->lookahead == '`') {
     advance(lexer);
@@ -274,14 +541,258 @@ static bool is_leading_infix_continuation(TSLexer *lexer) {
       return false;
     }
     advance(lexer);
-    bool found_space = false;
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
-      advance(lexer);
-      found_space = true;
-    }
-    return found_space && !iswspace(lexer->lookahead) && !lexer->eof(lexer);
+    return advance_past_blanks(lexer) && has_operand(lexer);
   }
   return false;
+}
+
+// Scans the rest of the line and reports whether it ENDS in a `then` or
+// `do` keyword at bracket depth 0 (skipping strings, characters, quotes,
+// back-ticked identifiers and comments; a trailing comment still counts as
+// the line end). A dedented leading infix operator whose line ends in
+// `then`/`do` continues an enclosing conditional, so the indented regions
+// between them must close:
+//   if xs.indexSatisfying(from = index): imp =>
+//       imp.selectors.exists(p)
+//   < nextImport then
+// Advances the lexer; the caller must have called mark_end.
+static bool line_ends_conditional(TSLexer *lexer) {
+  int depth = 0;
+  // Whether the last thing seen is a depth-0 `then`/`do`; any code after it
+  // clears the flag again, so only a line-final keyword reports true.
+  bool pending = false;
+  while (!lexer->eof(lexer) && lexer->lookahead != '\n' &&
+         lexer->lookahead != '\r') {
+    int32_t c = lexer->lookahead;
+    if (c == ' ' || c == '\t') {
+      advance(lexer);
+    } else if (c == '(' || c == '[' || c == '{') {
+      depth++;
+      pending = false;
+      advance(lexer);
+    } else if (c == ')' || c == ']' || c == '}') {
+      depth--;
+      pending = false;
+      advance(lexer);
+    } else if (c == '"') {
+      pending = false;
+      advance(lexer);
+      skip_string_tail(lexer, NULL);
+    } else if (c == '\'') {
+      pending = false;
+      advance(lexer);
+      int32_t quoted = skip_char_or_quote_tail(lexer, NULL);
+      if (quoted == '(' || quoted == '[' || quoted == '{') {
+        depth++;
+      } else if (quoted == ')' || quoted == ']' || quoted == '}') {
+        depth--;
+      }
+    } else if (c == '`') {
+      // A back-ticked identifier is never the `then`/`do` keyword.
+      pending = false;
+      advance(lexer);
+      skip_backticked_tail(lexer, NULL);
+    } else if (c == '/') {
+      advance(lexer);
+      if (lexer->lookahead == '/') {
+        break;  // rest of the line is a comment
+      }
+      if (lexer->lookahead == '*') {
+        advance(lexer);
+        if (!consume_block_comment_body_on_line(lexer)) {
+          break;  // the comment runs past the line end
+        }
+      } else {
+        pending = false;  // a lone '/' is code
+      }
+    } else if (iswalpha(c) || c == '_' || c == '$') {
+      char word[sizeof "then"];
+      int len = read_word(lexer, word, (int)sizeof word);
+      pending = depth == 0 && len > 0 &&
+                (strcmp(word, "then") == 0 || strcmp(word, "do") == 0);
+    } else {
+      pending = false;
+      advance(lexer);
+    }
+  }
+  return pending;
+}
+
+// Peeks whether the next word is a keyword that can only continue the
+// enclosing expression (else/catch/finally): an indented block never starts
+// with one. Advances the lexer; the caller must have called mark_end (or
+// return false right away). The mid-line OUTDENT gate in scan() dispatches
+// on the same first letters (e/c/f) before calling this; keep them in sync.
+static bool is_block_closing_keyword(TSLexer *lexer) {
+  switch (lexer->lookahead) {
+    case 'e': return scan_word(lexer, "else");
+    case 'c': return scan_word(lexer, "catch");
+    case 'f': return scan_word(lexer, "finally");
+    default: return false;
+  }
+}
+
+// Scans the rest of the line for a `=>` (or `⇒`) arrow at bracket depth 0.
+// This is what distinguishes a `case` CLAUSE from an enum `case A, B` /
+// `case C(...) extends D` definition when deciding whether a freshly
+// opened region holds case clauses (only clauses carry the arrow on their
+// line). Advances the lexer; the caller must have called mark_end.
+static bool line_has_case_arrow(TSLexer *lexer) {
+  int depth = 0;
+  while (!lexer->eof(lexer) && lexer->lookahead != '\n' &&
+         lexer->lookahead != '\r') {
+    int32_t c = lexer->lookahead;
+    if (c == '(' || c == '[' || c == '{') {
+      depth++;
+      advance(lexer);
+    } else if (c == ')' || c == ']' || c == '}') {
+      depth--;
+      advance(lexer);
+    } else if (c == '"') {
+      advance(lexer);
+      skip_string_tail(lexer, NULL);
+    } else if (c == '\'') {
+      advance(lexer);
+      int32_t quoted = skip_char_or_quote_tail(lexer, NULL);
+      if (quoted == '(' || quoted == '[' || quoted == '{') {
+        depth++;
+      } else if (quoted == ')' || quoted == ']' || quoted == '}') {
+        depth--;
+      }
+    } else if (c == '`') {
+      advance(lexer);
+      skip_backticked_tail(lexer, NULL);
+    } else if (c == '/') {
+      advance(lexer);
+      if (lexer->lookahead == '/') {
+        return false;  // rest of the line is a comment
+      }
+      if (lexer->lookahead == '*') {
+        advance(lexer);
+        if (!consume_block_comment_body_on_line(lexer)) {
+          return false;  // the comment runs past the line end
+        }
+      }
+    } else if (c == 0x21D2) {  // `⇒`, the Scala 2 spelling of `=>`
+      advance(lexer);
+      if (depth == 0) {
+        return true;
+      }
+    } else if (is_op_char(c)) {
+      bool starts_eq = c == '=';
+      advance(lexer);
+      bool second_gt = lexer->lookahead == '>';
+      int extra = 0;
+      while (is_op_char(lexer->lookahead)) {
+        advance(lexer);
+        extra++;
+      }
+      // Exactly `=>`: not `==>`, not `=>>` (extra counts what follows the
+      // first character, so a plain arrow has exactly the `>`).
+      if (depth == 0 && starts_eq && second_gt && extra == 1) {
+        return true;
+      }
+    } else {
+      advance(lexer);
+    }
+  }
+  return false;
+}
+
+// After the word `case`: does `class`/`object` follow (a definition, not a
+// clause)? Reads the next word whole — chained scan_word calls would
+// misread an identifier like `cobject` as `c` + `object` after the partial
+// match. Advances the lexer.
+static bool is_case_definition_word(TSLexer *lexer) {
+  advance_past_blanks(lexer);
+  char word[sizeof "object"];
+  int len = read_word(lexer, word, (int)sizeof word);
+  return len > 0 &&
+         (strcmp(word, "class") == 0 || strcmp(word, "object") == 0);
+}
+
+// Peeks whether the line starts a `case` clause — the word `case` not
+// followed by `class`/`object` (which begin a definition instead). Advances
+// the lexer; the caller must have called mark_end (or return false).
+static bool is_case_clause_intro(TSLexer *lexer) {
+  return scan_word(lexer, "case") && !is_case_definition_word(lexer);
+}
+
+// Lexes a whole block comment as the BLOCK_COMMENT token. The caller has
+// consumed the leading "/*". Block comments are lexed externally rather than
+// in the grammar so that the `/*` token does not occupy a column in every
+// parse-table row (~0.6MiB of parser.c).
+static bool finish_block_comment(TSLexer *lexer) {
+  lexer->mark_end(lexer);
+  lexer->result_symbol = BLOCK_COMMENT;
+  LOG("    BLOCK_COMMENT\n");
+  return true;
+}
+
+static bool lex_block_comment(TSLexer *lexer) {
+  consume_block_comment_body(lexer);
+  return finish_block_comment(lexer);
+}
+
+// Result of looking for a comment at a layout boundary (INDENT/OUTDENT).
+typedef enum {
+  COMMENT_NONE,   // not a comment; the lexer may have advanced past a lone '/'
+  COMMENT_LEXED,  // a block comment was lexed as BLOCK_COMMENT: return true
+  COMMENT_ABORT,  // a comment starts here: give up on the layout token
+  COMMENT_SAME_LINE_CODE,  // block comment(s) skipped, code follows on the
+                           // same line; the lexer stands at that code and
+                           // nothing was marked — the caller must make its
+                           // layout decision with the code's column as the
+                           // effective indentation (a comment does not set
+                           // the indentation of its line, the code does)
+} CommentAtLayout;
+
+// Comments should not affect indentation: detect one at a layout boundary
+// (as the old detect_comment_start guard did). Line comments are internal
+// tokens; block comments must be lexed here since the internal lexer no
+// longer knows them. The caller must have called mark_end.
+static CommentAtLayout check_comment_at_layout(TSLexer *lexer,
+                                               const bool *valid_symbols) {
+  if (lexer->lookahead != '/') {
+    return COMMENT_NONE;
+  }
+  advance(lexer);
+  if (lexer->lookahead == '*' && valid_symbols[BLOCK_COMMENT]) {
+    advance(lexer);
+    for (;;) {
+      consume_block_comment_body(lexer);
+      advance_past_blanks(lexer);
+      if (lexer->eof(lexer) || lexer->lookahead == '\n' ||
+          lexer->lookahead == '\r') {
+        finish_block_comment(lexer);
+        return COMMENT_LEXED;
+      }
+      if (lexer->lookahead == '/') {
+        advance(lexer);
+        if (lexer->lookahead == '*') {
+          advance(lexer);
+          continue;  // another block comment on the same line
+        }
+        if (lexer->lookahead == '/') {
+          // A trailing line comment: no more code on this line. Consume it
+          // into the comment token (the extent cannot be re-marked back).
+          while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+            advance(lexer);
+          }
+          finish_block_comment(lexer);
+          return COMMENT_LEXED;
+        }
+        // A lone '/' is code (the column is off by one; harmless).
+        return COMMENT_SAME_LINE_CODE;
+      }
+      return COMMENT_SAME_LINE_CODE;
+    }
+  }
+  if (lexer->lookahead == '/' || lexer->lookahead == '*') {
+    return COMMENT_ABORT;
+  }
+  // A lone '/' is not a comment; the lexer stays advanced past it.
+  return COMMENT_NONE;
 }
 
 static inline void debug_indents(Scanner *scanner) {
@@ -292,8 +803,27 @@ static inline void debug_indents(Scanner *scanner) {
   LOG("\n");
 }
 
+static bool scan_impl(void *payload, TSLexer *lexer,
+                      const bool *valid_symbols);
+
 bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
                                              const bool *valid_symbols) {
+  Scanner *scanner = (Scanner *)payload;
+  bool res = scan_impl(payload, lexer, valid_symbols);
+  // Track "the last returned token was a fewer-braces colon" (comments in
+  // between keep it; a false return does not persist state anyway).
+  if (res) {
+    if (lexer->result_symbol == COLON_EOL) {
+      scanner->after_colon_eol = 1;
+    } else if (lexer->result_symbol != BLOCK_COMMENT) {
+      scanner->after_colon_eol = 0;
+    }
+  }
+  return res;
+}
+
+static bool scan_impl(void *payload, TSLexer *lexer,
+                      const bool *valid_symbols) {
   #ifdef DEBUG
   {
     if (valid_symbols[ERROR_SENTINEL]) {
@@ -314,6 +844,7 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
 
   Scanner *scanner = (Scanner *)payload;
   int16_t prev = scanner->indents.size > 0 ? *array_back(&scanner->indents) : -1;
+  int16_t prev_width = indent_width(prev);
   int16_t newline_count = 0;
   int16_t indentation_size = 0;
 
@@ -334,11 +865,145 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
   // token, tree-sitter only makes it valid in grammar contexts where comma
   // termination is expected (colon_argument, _indentable_expression).
   if (valid_symbols[COMMA_OUTDENT] && lexer->lookahead == ',' && prev != -1) {
-    if (scanner->indents.size > 0) {
-      array_pop(&scanner->indents);
-    }
+    // A comma closes the indented block only when it separates elements of
+    // an enclosing bracketed list: a `)`/`]` at bracket depth 0 follows —
+    // on the same line (`... else expr, more)`) or within the next few
+    // lines (`g(x), h(y)` + `)`), including the trailing-comma case. A
+    // depth-0 `}` instead closes the enclosing brace block whose last
+    // statement the comma is internal to (`foo { _ => import a.b, c.d }`),
+    // and a statement continuing with no closer in sight is internal too
+    // (`import a.b, c.d`, `case A, B`): no token is returned, the internal
+    // ',' wins. With lookahead ',' no other external token can fire, making
+    // the early false return safe.
     lexer->mark_end(lexer);
+    if (valid_symbols[ERROR_SENTINEL]) {
+      // Error recovery: every symbol looks valid — keep the old O(1)
+      // pop-and-fire instead of scanning ahead from every comma.
+      array_pop(&scanner->indents);
+      lexer->result_symbol = COMMA_OUTDENT;
+      return true;
+    }
+    advance(lexer);
+    bool fire = false;
+    bool content_seen = false;
+    int depth = 0;
+    // Bounds the closer search: a wrapped argument list closes within a few
+    // lines, while an unbounded scan would make each internal comma (enum
+    // `case A, B`, import lists) cost the rest of the file.
+    int budget = 800;
+    for (;;) {
+      if (lexer->eof(lexer) || budget <= 0) {
+        break;
+      }
+      int32_t c = lexer->lookahead;
+      if (c == '\n' && !content_seen) {
+        // Trailing comma: whatever follows on the next lines is the next
+        // list element (or the closer), however far away.
+        fire = true;
+        break;
+      }
+      if (c == '(' || c == '[' || c == '{') {
+        depth++;
+        content_seen = true;
+        advance(lexer);
+        budget--;
+      } else if (c == ')' || c == ']') {
+        if (depth == 0) {
+          fire = true;
+          break;
+        }
+        depth--;
+        advance(lexer);
+        budget--;
+      } else if (c == '}') {
+        if (depth == 0) {
+          break;
+        }
+        depth--;
+        advance(lexer);
+        budget--;
+      } else if (c == '/') {
+        advance(lexer);
+        budget--;
+        if (lexer->lookahead == '/') {
+          while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+            advance(lexer);
+            budget--;
+          }
+        } else if (lexer->lookahead == '*') {
+          advance(lexer);
+          consume_block_comment_body_ex(lexer, false, &budget);
+        } else {
+          content_seen = true;
+        }
+      } else if (c == '"') {
+        content_seen = true;
+        advance(lexer);
+        budget--;
+        skip_string_tail(lexer, &budget);
+      } else if (c == '`') {
+        // A back-ticked identifier may contain brackets; they are not code.
+        content_seen = true;
+        advance(lexer);
+        budget--;
+        skip_backticked_tail(lexer, &budget);
+      } else if (c == '\'') {
+        content_seen = true;
+        advance(lexer);
+        budget--;
+        int32_t quoted = skip_char_or_quote_tail(lexer, &budget);
+        if (quoted == '(' || quoted == '[' || quoted == '{') {
+          depth++;
+        } else if (quoted == ')' || quoted == ']') {
+          if (depth == 0) {
+            fire = true;
+            break;
+          }
+          depth--;
+        } else if (quoted == '}') {
+          if (depth == 0) {
+            break;
+          }
+          depth--;
+        }
+      } else {
+        if (c != ' ' && c != '\t' && c != '\r' && c != '\n') {
+          content_seen = true;
+        }
+        advance(lexer);
+        budget--;
+      }
+    }
+    if (!fire) {
+      return false;
+    }
+    array_pop(&scanner->indents);
     lexer->result_symbol = COMMA_OUTDENT;
+    return true;
+  }
+
+  // Mid-cascade close of a same-width case region: a deeper region was just
+  // popped and the pending line sits exactly at this region's width. The
+  // region stays open only when the line starts another `case` clause; the
+  // false return is safe because the internal `case` keyword is the only
+  // token that can follow (mirrors the same-width INDENT at the bottom).
+  // The column check pins this to the cascade position: the saved
+  // last_indentation_size can go stale mid-line when the states in between
+  // have no external tokens (e.g. right after a case clause's `=>`).
+  if (valid_symbols[OUTDENT] && !valid_symbols[ERROR_SENTINEL] &&
+      scanner->last_indentation_size != -1 &&
+      at_case_region_width(prev, scanner->last_indentation_size) &&
+      (lexer->eof(lexer)
+           ? scanner->last_column == -1
+           : (int16_t)lexer->get_column(lexer) == scanner->last_column)) {
+    lexer->mark_end(lexer);
+    if (is_case_clause_intro(lexer)) {
+      return false;
+    }
+    array_pop(&scanner->indents);
+    LOG("    pop\n");
+    LOG("    OUTDENT (same-width case region, cascade)\n");
+    lexer->result_symbol = OUTDENT;
     return true;
   }
 
@@ -358,7 +1023,7 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
         (
           scanner->last_indentation_size != -1 &&
           prev != -1 &&
-          scanner->last_indentation_size < prev
+          scanner->last_indentation_size < prev_width
         )
       )
   ) {
@@ -372,18 +1037,107 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
   }
   scanner->last_indentation_size = -1;
 
+  // The plain INDENT geometry: deeper than the current region (an empty
+  // stack rides on prev_width == -1: any width is deeper), or same-width
+  // right after a fewer-braces colon (see after_colon_eol in Scanner).
+  bool indent_geometry =
+      indentation_size > prev_width ||
+      (scanner->after_colon_eol && indentation_size == prev_width);
   if (
       valid_symbols[INDENT] &&
       newline_count > 0 &&
+      // An indented block cannot start with a closing delimiter, e.g. the
+      // `}` after an empty-bodied lambda: `foo { x =>\n  }`
+      lexer->lookahead != '}' &&
+      lexer->lookahead != ')' &&
+      lexer->lookahead != ']' &&
       (
-        scanner->indents.size == 0 ||
-        indentation_size > *array_back(&scanner->indents)
+        indent_geometry ||
+        // A comment sitting exactly at the region width can hide a deeper
+        // line behind it (`x match` + `  /* c */ case a => b`): probe it,
+        // the code's own column decides below.
+        (indentation_size == prev_width && lexer->lookahead == '/')
       )
   ) {
-    if (detect_comment_start(lexer)) {
-      return false;
+    lexer->mark_end(lexer);
+    switch (check_comment_at_layout(lexer, valid_symbols)) {
+      case COMMENT_LEXED: return true;
+      case COMMENT_ABORT: return false;
+      case COMMENT_SAME_LINE_CODE: {
+        // The line's content starts after the comment; its column is the
+        // effective indentation (`if x then` + `  /* c */ body`).
+        int16_t effective = (int16_t)lexer->get_column(lexer);
+        if (effective > prev_width) {
+          indentation_size = effective;
+          break;
+        }
+        // The code does not open a block after all; lex the comment.
+        return finish_block_comment(lexer);
+      }
+      case COMMENT_NONE:
+        if (!indent_geometry) {
+          return false;  // entered only to probe a comment; this is code
+        }
+        break;
     }
-    array_push(&scanner->indents, indentation_size);
+    // An indented block cannot start with a keyword that continues the
+    // enclosing expression (the `finally` in `try if (c) a.removeIf(b)` +
+    // `finally d.set(false)`), nor with `yield`/`do`: they belong to an
+    // enclosing `for (...)` whose body production is also indentable — an
+    // INDENT would commit to a bare indented-block body and orphan the
+    // keyword. Read the word whole: chained scan_word calls would leave the
+    // lexer mid-identifier on a partial match and the later guards would
+    // misread its tail (`cdo`, `eyield`, `e+ x`).
+    int16_t entry = indentation_size;
+    switch (lexer->lookahead) {
+      // Only these letters can start one of the stopper keywords (or
+      // `case`); any other word start pushes the INDENT with no word scan.
+      case 'e': case 'c': case 'f': case 'y': case 'd': {
+        static const char *const block_opening_stoppers[] = {
+            "else", "catch", "finally", "yield", "do"};
+        char word[sizeof "finally"];
+        int len = read_word(lexer, word, (int)sizeof word);
+        if (len > 0 &&
+            word_in(word, block_opening_stoppers,
+                    sizeof(block_opening_stoppers) /
+                        sizeof(block_opening_stoppers[0]))) {
+          return false;
+        }
+        // At top level the indent stack is empty and this branch accepts
+        // any width, so the same-width `case` branch at the bottom of
+        // scan() never sees `x match` + width-0 `case` lines: flag the
+        // region here instead, so a same-width non-case line closes it
+        // (CASE_INDENT_FLAG). Only when the line carries a depth-0 `=>`:
+        // an enum body's `case A, B` / `case C(...) extends D` opens
+        // through this branch too, and flagging it would break the enum
+        // (the flagged close fires at the first non-case member, and the
+        // clause-continuation check blocks the semicolon between cases).
+        if (scanner->indents.size == 0 && len == 4 &&
+            strcmp(word, "case") == 0 && !is_case_definition_word(lexer) &&
+            line_has_case_arrow(lexer)) {
+          entry |= CASE_INDENT_FLAG;
+        }
+        break;
+      }
+      case '|':
+      case '&':
+        // Nor with a leading `|`/`&` infix operator: it continues the
+        // previous expression (`if (false)` + `  || true` + `then ...`),
+        // and an INDENT here would commit the parse to an indented block
+        // before the infix reading can be tried (mirrors the ASI/OUTDENT
+        // guards). Only `|`/`&` runs: they cannot start a statement, while
+        // a general symbolic head is a legal first statement of the new
+        // block (`??? ++ 1`, `*> io`, a back-ticked DSL word) — and after
+        // a fewer-braces colon the line can only be the body (a `:` line
+        // cannot be continued by an infix).
+        if (!scanner->after_colon_eol && is_leading_infix_continuation(lexer)) {
+          return false;
+        }
+        break;
+      default:
+        break;
+    }
+    array_push(&scanner->indents, entry);
     lexer->result_symbol = INDENT;
     LOG("    INDENT\n");
     return true;
@@ -391,18 +1145,46 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
 
   // This saves the indentation_size and newline_count so it can be used
   // in subsequent calls for multiple outdent or auto-semicolon.
+  // A same-width case region also closes on a line at its own width when
+  // that line does not start another `case` clause.
+  bool case_region_close =
+      newline_count > 0 && at_case_region_width(prev, indentation_size);
   if (valid_symbols[OUTDENT] &&
       (lexer->lookahead == 0 ||
       (
         newline_count > 0 &&
         prev != -1 &&
-        indentation_size < prev
-      )
+        indentation_size < prev_width
+      ) ||
+      case_region_close
       )
   ) {
     lexer->mark_end(lexer);
-    if (detect_comment_start(lexer)) {
-      return false;
+    switch (check_comment_at_layout(lexer, valid_symbols)) {
+      case COMMENT_LEXED: return true;
+      case COMMENT_ABORT: return false;
+      case COMMENT_SAME_LINE_CODE: {
+        // The line's content starts after the comment; its column is the
+        // effective indentation ( ` /** doc */ override def f...` inside a
+        // braced body must not close the region at the comment's column).
+        int16_t effective = (int16_t)lexer->get_column(lexer);
+        if (effective < prev_width) {
+          indentation_size = effective;
+          break;
+        }
+        // Not an outdent after all — but the automatic semicolon has
+        // suppression rules of its own (leading `.`/infix operator,
+        // else/catch/finally/match), so it must not be emitted here
+        // sight unseen. Lex the comment and let the next scan decide,
+        // carrying the pending newline through the last_newline_count /
+        // last_column recovery below (` /* c */ .map(g)` and
+        // ` /* c */ else 2` continue their statement; ` /* c */ val b = 2`
+        // still gets its semicolon).
+        scanner->last_newline_count = newline_count;
+        scanner->last_column = effective;
+        return finish_block_comment(lexer);
+      }
+      case COMMENT_NONE: break;
     }
     scanner->last_indentation_size = indentation_size;
     scanner->last_newline_count = newline_count;
@@ -412,8 +1194,17 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
       scanner->last_column = (int16_t)lexer->get_column(lexer);
     }
     // Don't close the indented block when the next line starts with a leading
-    // infix operator: that operator continues the previous expression.
-    if (lexer->lookahead != 0 && is_leading_infix_continuation(lexer)) {
+    // infix operator: that operator continues the previous expression inside
+    // the current region even when the operator line is dedented.
+    // Exception: when the line ends in a depth-0 `then`/`do`, the operator
+    // continues an enclosing conditional and the regions between do close
+    // (see line_ends_conditional).
+    if (lexer->lookahead != 0 && is_leading_infix_continuation(lexer) &&
+        !line_ends_conditional(lexer)) {
+      return false;
+    }
+    // A same-width `case` line continues the case region instead.
+    if (case_region_close && is_case_clause_intro(lexer)) {
       return false;
     }
     if (scanner->indents.size > 0) {
@@ -425,14 +1216,20 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
     return true;
   }
 
-  // Recover newline_count from the outdent reset
+  // Recover newline_count from the outdent reset. Only when this scan did
+  // not cross a newline itself: a scan that consumed its own newline is at a
+  // fresh line's decision point, and the saved count would be stale — the
+  // column pin alone cannot tell a later line at the same column apart (a
+  // false-returning scan does not persist the reset below, so the saved
+  // values can survive across a whole line).
   bool is_eof = lexer->eof(lexer);
   if (
       (
         scanner->last_newline_count > 0 &&
         (is_eof && scanner->last_column == -1)
       ) ||
-      (!is_eof && lexer->get_column(lexer) == (uint32_t)scanner->last_column)
+      (!is_eof && newline_count == 0 &&
+       lexer->get_column(lexer) == (uint32_t)scanner->last_column)
   ) {
     newline_count += scanner->last_newline_count;
   }
@@ -459,81 +1256,132 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
       if (lexer->lookahead == '/') {
         return false;
       }
-      if (lexer->lookahead == '*') {
+      if (lexer->lookahead == '*' && valid_symbols[BLOCK_COMMENT]) {
         advance(lexer);
-        while (!lexer->eof(lexer)) {
-          if (lexer->lookahead == '*') {
-            advance(lexer);
-            if (lexer->lookahead == '/') {
-              advance(lexer);
-              break;
-            }
-          } else {
-            advance(lexer);
-          }
+        // Peek through the comment. When the rest of the line is blank the
+        // decision is deferred: consume the comment as a token and let the
+        // newline after it re-trigger this branch. When code follows on the
+        // same line, the pending newline must not be lost once the comment
+        // token is consumed (`val a = 1` + `/* c */ val b = 2` still needs
+        // its semicolon) — but the suppression rules must apply to that
+        // code too (`/* c */ else 2` must not be split), so the comment is
+        // lexed first and the newline carried to the next scan through the
+        // last_newline_count / last_column recovery above. (Either way the
+        // token extent includes any trailing blanks: the end-of-comment
+        // position cannot be re-marked once the lexer has peeked past it.)
+        consume_block_comment_body(lexer);
+        advance_past_blanks(lexer);
+        if (!(lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
+              lexer->eof(lexer))) {
+          scanner->last_newline_count = newline_count;
+          scanner->last_column = (int16_t)lexer->get_column(lexer);
         }
-        while (iswspace(lexer->lookahead)) {
-          if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
-            return false;
-          }
-          skip(lexer);
-        }
-        // If some code is present at the same line after comment end,
-        // we should still produce AUTOMATIC_SEMICOLON, e.g. in
-        // val a = 1
-        // /* comment */ val b = 2
-        return true;
+        return finish_block_comment(lexer);
       }
+      // A lone '/' falls through with the lexer advanced past it, matching
+      // the old flow.
     }
 
-    if (valid_symbols[ELSE]) {
-      return !scan_word(lexer, "else");
-    }
-
-    if (valid_symbols[CATCH]) {
-      if (scan_word(lexer, "catch")) {
+    // Don't insert the automatic semicolon before a leading infix operator:
+    // symbolic (`|| b`) or back-ticked (`a` \`in\` `b`), followed by
+    // horizontal whitespace and an operand on the same line. Checked before
+    // the keyword scans below so neither ever reads a position the other
+    // has advanced past (`m|| x` must not have its `||` misread as leading
+    // infix after a failed `match` scan) — the two first-char classes are
+    // disjoint. A blank line still separates the statements.
+    if (is_op_char(lexer->lookahead) || lexer->lookahead == '`') {
+      if (newline_count == 1 && is_leading_infix_continuation(lexer)) {
         return false;
       }
-    }
-
-    if (valid_symbols[FINALLY]) {
-      if  (scan_word(lexer, "finally")) {
-        return false;
-      }
-    }
-
-    if (valid_symbols[EXTENDS]) {
-      if (scan_word(lexer, "extends")) {
-        return false;
-      }
-    }
-
-    if (valid_symbols[WITH]) {
-      if (scan_word(lexer, "with")) {
-        return false;
-      }
-    }
-
-    if (valid_symbols[DERIVES]) {
-      if (scan_word(lexer, "derives")) {
-        return false;
-      }
-    }
-
-    if (newline_count > 1) {
       return true;
     }
 
-    // Don't insert automatic semicolon before leading infix operators:
-    // - symbolic, e.g. || or &&
-    // - back-ticked, e.g. `in`
-    // Only suppress if the operator is followed by horizontal whitespace
-    // and then non-newline content on the same line, meaning it has an operand.
-    if (is_leading_infix_continuation(lexer)) {
-      return false;
+    // A following keyword that continues the enclosing expression suppresses
+    // the automatic semicolon, even when several such keywords are valid at
+    // once (e.g. a dangling `if` waiting for `else` inside a `try` whose
+    // `finally` comes next). Dispatch on the first character so scan_word
+    // never consumes a prefix shared by two keywords ("else"/"extends");
+    // a partial match may leave the lexer mid-identifier, but nothing after
+    // the switch reads the position again.
+    switch (lexer->lookahead) {
+      case 'e':
+        if (!valid_symbols[ELSE] && !valid_symbols[EXTENDS]) {
+          break;
+        }
+        advance(lexer);
+        if (valid_symbols[ELSE] && scan_word(lexer, "lse")) {
+          return false;
+        }
+        if (valid_symbols[EXTENDS] && scan_word(lexer, "xtends")) {
+          return false;
+        }
+        break;
+      case 'c':
+        if (valid_symbols[CATCH] && scan_word(lexer, "catch")) {
+          return false;
+        }
+        break;
+      case 'f':
+        if (valid_symbols[FINALLY] && scan_word(lexer, "finally")) {
+          return false;
+        }
+        break;
+      case 'w':
+        if (valid_symbols[WITH] && scan_word(lexer, "with")) {
+          return false;
+        }
+        break;
+      case 'd':
+        if (valid_symbols[DERIVES] && scan_word(lexer, "derives")) {
+          return false;
+        }
+        break;
+      case 'm':
+        // `match` never starts a statement, so when it is valid it always
+        // continues the previous expression (Scala 3 allows the chain
+        // `xs.filter(p)` + newline + `match ...`).
+        if (valid_symbols[MATCH] && scan_word(lexer, "match")) {
+          return false;
+        }
+        break;
+      default:
+        break;
     }
 
     return true;
+  }
+
+  // A mid-line else/catch/finally that is not directly shiftable must first
+  // close the open indented block, e.g. the `else` in:
+  //   if (c)
+  //     x match {
+  //       case 1 => 1
+  //     } else 2
+  // Skipped during error recovery, where every symbol looks valid.
+  if (
+      valid_symbols[OUTDENT] &&
+      !valid_symbols[ERROR_SENTINEL] &&
+      newline_count == 0 &&
+      prev != -1 &&
+      (
+        (lexer->lookahead == 'e' && !valid_symbols[ELSE]) ||
+        (lexer->lookahead == 'c' && !valid_symbols[CATCH]) ||
+        (lexer->lookahead == 'f' && !valid_symbols[FINALLY])
+      )
+  ) {
+    lexer->mark_end(lexer);
+    if (is_block_closing_keyword(lexer)) {
+      if (scanner->indents.size > 0) {
+        array_pop(&scanner->indents);
+      }
+      LOG("    pop\n");
+      LOG("    OUTDENT (mid-line closing keyword)\n");
+      lexer->result_symbol = OUTDENT;
+      return true;
+    }
+    // The lexer has advanced past an identifier starting with e/c/f; nothing
+    // else in this invocation could match it, so give up on external tokens.
+    return false;
   }
 
   while (iswspace(lexer->lookahead)) {
@@ -541,6 +1389,176 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
       newline_count++;
     }
     skip(lexer);
+  }
+
+  // XML mode (SLS §10) is entered only where an expression or pattern can
+  // start (that is where the grammar makes XML_TAG_START valid) AND the `<`
+  // is immediately followed by a name-start character. `< b` and `<-`, `<:`,
+  // `<=` etc. fall through to the regular operator tokens.
+  if (valid_symbols[XML_TAG_START] && lexer->lookahead == '<') {
+    advance(lexer);
+    if (iswalpha(lexer->lookahead) || lexer->lookahead == '_') {
+      lexer->mark_end(lexer);
+      lexer->result_symbol = XML_TAG_START;
+      return true;
+    }
+    return false;
+  }
+
+  // A symbolic infix operator that ends its line continues the expression on
+  // the next line (SLS 1.2: no semicolon inference after an infix operator).
+  // Lexed here because the decision needs the rest of the line: the internal
+  // lexer would hand the same characters to the regular operator token, whose
+  // statement would then be split by the automatic semicolon / outdent at the
+  // newline (misreading the operator as postfix). Skipped in error recovery,
+  // where every symbol looks valid.
+  if ((valid_symbols[OPERATOR_EOL] || valid_symbols[COLON_EOL]) &&
+      !valid_symbols[ERROR_SENTINEL] && is_op_char(lexer->lookahead)) {
+    // Collect the operator; anything longer than 3 chars cannot be one of the
+    // reserved sequences checked below.
+    int32_t op[3] = {0, 0, 0};
+    int op_len = 0;
+    while (is_op_char(lexer->lookahead)) {
+      if (op_len < 3) {
+        op[op_len] = lexer->lookahead;
+      }
+      op_len++;
+      advance(lexer);
+    }
+    lexer->mark_end(lexer);
+    // Reserved sequences are not infix operators: `=`, `=>`/`?=>`/`=>>`,
+    // `<-`, `<:`, `>:`, `<%`, `:` (colon argument), `#`, `@`.
+    if (op_len == 1 && op[0] == ':') {
+      // A lone `:` that ends its line is the fewer-braces colon (scalac's
+      // COLONeol). Deciding it here kills the across-the-newline ascription
+      // reading at the token level; without this, every nesting level of
+      // `a:` > `b:` > `c:` keeps a doomed GLR fork alive to the end of the
+      // region, and past ~4 levels the version cap discards the correct one.
+      // Trailing comments count as end of line; code on the same line
+      // makes it a plain (ascription/lambda) colon.
+      if (valid_symbols[COLON_EOL] &&
+          rest_of_line_is_blank_or_comments(lexer)) {
+        lexer->result_symbol = COLON_EOL;
+        return true;
+      }
+      return false;
+    }
+    if (op_len == 1 && (op[0] == '=' || op[0] == '#' || op[0] == '@')) {
+      return false;
+    }
+    if (op_len == 2 &&
+        ((op[0] == '=' && op[1] == '>') || (op[0] == '<' && op[1] == '-') ||
+         (op[0] == '<' && op[1] == ':') || (op[0] == '>' && op[1] == ':') ||
+         (op[0] == '<' && op[1] == '%'))) {
+      return false;
+    }
+    if (op_len == 3 && ((op[0] == '?' && op[1] == '=' && op[2] == '>') ||
+                        (op[0] == '=' && op[1] == '>' && op[2] == '>'))) {
+      return false;
+    }
+    // The branch is also entered for COLON_EOL-only states; everything from
+    // here on lexes OPERATOR_EOL, which must be valid.
+    if (!valid_symbols[OPERATOR_EOL]) {
+      return false;
+    }
+    // The operator must end its line; trailing comments count as the line
+    // end (they are transparent to scalac's newline handling: `p || // c`
+    // still continues on the next line).
+    if (!rest_of_line_is_blank_or_comments(lexer)) {
+      return false;
+    }
+    // The right operand must be able to start an expression; if the next
+    // non-blank character closes a delimiter or list instead (e.g. a vararg
+    // splice `xs*` before a `)` on its own line), this is not a continuation.
+    // Comments between the operator and the operand are skipped.
+    for (;;) {
+      while (iswspace(lexer->lookahead)) {
+        advance(lexer);
+      }
+      if (lexer->lookahead == '/') {
+        advance(lexer);
+        if (lexer->lookahead == '/') {
+          while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+            advance(lexer);
+          }
+          continue;
+        }
+        if (lexer->lookahead == '*') {
+          advance(lexer);
+          consume_block_comment_body(lexer);
+          continue;
+        }
+        // A lone '/' cannot start an operand, so the operator was postfix.
+        return false;
+      }
+      break;
+    }
+    if (lexer->eof(lexer) || lexer->lookahead == ')' ||
+        lexer->lookahead == ']' || lexer->lookahead == '}' ||
+        lexer->lookahead == ',' || lexer->lookahead == ';' ||
+        lexer->lookahead == '.' || lexer->lookahead == '=' ||
+        // No expression starts with `@` either: the next line is an
+        // annotated definition (`x --?` + `@deprecated val y = 1`).
+        lexer->lookahead == '@') {
+      return false;
+    }
+    // Nor can the operand be a keyword that only continues or starts a
+    // statement. This matters for symbolic identifiers used as expressions:
+    // in `if (c) ???` + `else d` the `???` must stay a plain expression.
+    if (lexer->lookahead >= 'a' && lexer->lookahead <= 'z') {
+      static const char *const non_operand_words[] = {
+          "case", "catch",  "do",   "else",  "finally", "for",   "if",
+          "match", "return", "then", "throw", "try",     "while", "yield",
+          // Definition/modifier keywords: a line starting with one of these
+          // begins a new statement, so the operator was postfix (`x --?` +
+          // `val y = ...`, Scala 2 postfixOps).
+          "abstract", "class", "def",    "enum",      "export", "final",
+          "given",    "import", "implicit", "lazy",   "object", "override",
+          "package",  "private", "protected", "sealed", "trait", "type",
+          "val",      "var",
+      };
+      // Sized for the longest word above; read_word reports a longer (or
+      // non-ASCII) identifier as -1, which correctly skips the check.
+      char word[sizeof "protected"];
+      int len = read_word(lexer, word, (int)sizeof word);
+      if (len > 0 &&
+          word_in(word, non_operand_words,
+                  sizeof(non_operand_words) / sizeof(non_operand_words[0]))) {
+        return false;
+      }
+      lexer->result_symbol = OPERATOR_EOL;
+      return true;
+    }
+    // A leading infix operator on the next line continues the postfix
+    // reading of the previous line instead: `a ???` + `|| b`.
+    if (is_leading_infix_continuation(lexer)) {
+      return false;
+    }
+    lexer->result_symbol = OPERATOR_EOL;
+    return true;
+  }
+
+  // Mid-line block comments (no layout decision pending). Suppressed where
+  // the slashes are ordinary text instead: after `//` (SUPPRESS_BLOCK_COMMENT, a
+  // dead grammar alternative that marks that state) and where a
+  // string-content token is expected (`s"a /* b"`). During error recovery
+  // all symbols look valid, and there lexing the comment is the safe choice.
+  if (valid_symbols[BLOCK_COMMENT] && lexer->lookahead == '/' &&
+      (valid_symbols[ERROR_SENTINEL] ||
+       !(valid_symbols[SUPPRESS_BLOCK_COMMENT] ||
+         valid_symbols[SIMPLE_STRING_MIDDLE] ||
+         valid_symbols[INTERPOLATED_STRING_MIDDLE] ||
+         valid_symbols[RAW_STRING_MIDDLE] ||
+         valid_symbols[RAW_STRING_MULTILINE_MIDDLE] ||
+         valid_symbols[INTERPOLATED_MULTILINE_STRING_MIDDLE] ||
+         valid_symbols[MULTILINE_STRING_END]))) {
+    advance(lexer);
+    if (lexer->lookahead == '*') {
+      advance(lexer);
+      return lex_block_comment(lexer);
+    }
+    // A lone '/' or a line comment: nothing else external can match here.
+    return false;
   }
 
   if (valid_symbols[SIMPLE_STRING_START] && lexer->lookahead == '"') {
@@ -606,6 +1624,30 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
   // simple multiline string context.
   if (valid_symbols[MULTILINE_STRING_END]) {
     return scan_string_content(lexer, true, STRING_MODE_SIMPLE);
+  }
+
+  // Scala 3 allows the `case` clauses of a `match`/`catch` to align with the
+  // enclosing region instead of being indented deeper (`x match` + newline +
+  // `case ...` at the same width). Open the case region here — flagged, so
+  // the OUTDENT logic above also closes it on a same-width non-case line.
+  // Only the states right after `match`/`catch`(/`=>`. of a case) have
+  // INDENT valid with a same-width `case` line, so the grammar needs no new
+  // production. Checked last: with lookahead 'c' no other external token can
+  // fire, making the false return safe.
+  if (valid_symbols[INDENT] && !valid_symbols[ERROR_SENTINEL] &&
+      newline_count > 0 && lexer->lookahead == 'c' &&
+      // The empty stack needs no arm here: the generic INDENT branch accepts
+      // any width there and sets CASE_INDENT_FLAG itself.
+      prev != -1 && indentation_size == prev_width) {
+    lexer->mark_end(lexer);
+    if (is_case_clause_intro(lexer)) {
+      array_push(&scanner->indents,
+                 (int16_t)(indentation_size | CASE_INDENT_FLAG));
+      lexer->result_symbol = INDENT;
+      LOG("    INDENT (same-width case region)\n");
+      return true;
+    }
+    return false;
   }
 
   return false;

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -85,3 +85,26 @@ trait Function0[@specialized(Unit, Int, Double) T] {
     (type_parameters
       (annotation (type_identifier) (arguments (identifier) (identifier) (identifier))) (identifier))
     (template_body (function_declaration (identifier) (type_identifier)))))
+
+================================
+Annotated parent type with annotation arguments
+================================
+
+case class B2(s: String) extends Base @Second(3, "e") @Third(4)
+
+---
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter (identifier) (type_identifier)))
+    (extends_clause
+      (annotated_type
+        (type_identifier)
+        (annotation
+          (type_identifier)
+          (arguments (integer_literal) (string)))
+        (annotation
+          (type_identifier)
+          (arguments (integer_literal)))))))

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -27,9 +27,7 @@ Block comments
 
 (compilation_unit
   (block_comment)
-  (block_comment
-    (block_comment
-      (block_comment))))
+  (block_comment))
 
 ================================================================================
 Single line comments with block comment
@@ -95,6 +93,21 @@ Shebang
 #!/usr/bin/env -S scala-cli shebang -S 3
 
 "shebang"
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (comment)
+  (string))
+
+================================================================================
+Shebang: Scala 2 script header ending in !#
+================================================================================
+
+#!/bin/sh
+exec scala "$0" "$@"
+!#
+
+"script body"
 --------------------------------------------------------------------------------
 
 (compilation_unit

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -59,6 +59,52 @@ class $A$B$ {
         (type_identifier)))))
 
 ================================================================================
+Union types in val and var definitions and declarations
+================================================================================
+
+trait T {
+  val a: AnyRef | Null = null
+  var b: Link[?] | Null
+  val c: Int | String
+  val h :: t = xs
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_identifier))
+        (null_literal))
+      (var_declaration
+        (identifier)
+        (infix_type
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier)))
+          (operator_identifier)
+          (type_identifier)))
+      (val_declaration
+        (identifier)
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_identifier)))
+      (val_definition
+        (infix_pattern
+          (identifier)
+          (operator_identifier)
+          (identifier))
+        (identifier)))))
+
+================================================================================
 Operator identifiers
 ================================================================================
 
@@ -141,6 +187,8 @@ Reserved keywords
 val val = ???
 
 --------------------------------------------------------------------------------
+
+
 
 ================================================================================
 Package
@@ -2084,3 +2132,283 @@ class F(tracked val x: C):
           (tracked_modifier))
         (identifier)
         (type_identifier)))))
+
+================================================================================
+Scala 3 keywords as import path segments
+================================================================================
+
+import io.circe.export.Exported
+import sttp.tapir.generated.reuse.enum.TapirGeneratedEndpoints.Status
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (import_declaration
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)))
+
+================================================================================
+Unicode arrow in for comprehension generators
+================================================================================
+
+object A {
+  def f = for (i ← 1 to 2) println(i)
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (for_expression
+          (enumerators
+            (enumerator
+              (identifier)
+              (infix_expression
+                (integer_literal)
+                (identifier)
+                (integer_literal))))
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))))
+
+================================
+Braced body member indented shallower than its siblings
+================================
+
+object hlist {
+  trait A {
+    type T
+  }
+
+ trait B[L] extends A {
+    type Out
+  }
+
+  trait C {
+    def x: Int
+  }
+}
+
+---
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (trait_definition
+        (identifier)
+        (template_body
+          (type_definition
+            (type_identifier))))
+      (trait_definition
+        (identifier)
+        (type_parameters
+          (identifier))
+        (extends_clause
+          (type_identifier))
+        (template_body
+          (type_definition
+            (type_identifier))))
+      (trait_definition
+        (identifier)
+        (template_body
+          (function_declaration
+            (identifier)
+            (type_identifier)))))))
+
+================================
+Self type with empty body
+================================
+
+trait A { self: Node => }
+
+trait B { self: Meta.type => }
+
+trait C { this: X =>
+}
+
+---
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier))))
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (singleton_type
+          (identifier)))))
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier)))))
+
+================================================================================
+Colon template body with a self type and an empty body
+================================================================================
+
+trait OriginWarning(val origin: String):
+  self: Warning =>
+object OriginWarning:
+  val NoOrigin = "..."
+
+transparent trait Pure extends Any:
+  this: Pure =>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier)))
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier))))
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (string))))
+  (trait_definition
+    (modifiers
+      (transparent_modifier))
+    (identifier)
+    (extends_clause
+      (type_identifier))
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier)))))
+
+================================================================================
+Enum with a self type and a modifier on a case
+================================================================================
+
+enum SymbolKind derives CanEqual:
+  kind =>
+
+  case Val, Var
+  private case External(override val toLowerCase: String) extends FileExtension(toLowerCase)
+  def isVar: Boolean = kind == Var
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (enum_definition
+    (identifier)
+    (derives_clause
+      (type_identifier))
+    (enum_body
+      (self_type
+        (identifier))
+      (enum_case_definitions
+        (simple_enum_case
+          (identifier))
+        (simple_enum_case
+          (identifier)))
+      (enum_case_definitions
+        (modifiers
+          (access_modifier))
+        (full_enum_case
+          (identifier)
+          (class_parameters
+            (class_parameter
+              (modifiers)
+              (identifier)
+              (type_identifier)))
+          (extends_clause
+            (type_identifier)
+            (arguments
+              (identifier)))))
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier))))))
+
+================================================================================
+Parenthesized typed lambda parameter wrapped across the newline
+================================================================================
+
+val f = (x:
+    Int) => x
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (lambda_expression
+      (bindings
+        (binding
+          (identifier)
+          (type_identifier)))
+      (identifier))))
+
+================================================================================
+Do-while in assignment and return positions
+================================================================================
+
+object O {
+  var w = 0
+  w = do step() while (cond)
+  def r: Unit = { return do step() while (cond) }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (var_definition
+        (identifier)
+        (integer_literal))
+      (assignment_expression
+        (identifier)
+        (do_while_expression
+          (call_expression
+            (identifier)
+            (arguments))
+          (parenthesized_expression
+            (identifier))))
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (block
+          (return_expression
+            (do_while_expression
+              (call_expression
+                (identifier)
+                (arguments))
+              (parenthesized_expression
+                (identifier)))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -215,9 +215,10 @@ class C:
               (identifier)
               (arguments
                 (string))))))
-      (infix_expression
-        (identifier)
-        (identifier)
+      (call_expression
+        (postfix_expression
+          (identifier)
+          (identifier))
         (colon_argument
           (indented_block
             (val_definition
@@ -783,7 +784,8 @@ def main(): Unit =
           (typed_pattern
             (identifier)
             (type_identifier))
-          (identifier))))))
+          (indented_block
+            (identifier)))))))
 
 ================================================================================
 Match expressions
@@ -2161,3 +2163,1727 @@ bar(a, xs: _*)
       (identifier)
       (vararg
         (identifier)))))
+
+================================================================================
+Ascription to function types
+================================================================================
+
+object A {
+  val a = (this.unsubscribe: ActorRef => Unit)
+  val b = (fooMock.overloaded[Double]: Double => String).expects(1.0)
+  val c = PriorityGenerator({ case 1 => 2 }: Any => Int)
+  val d = (1 second: Duration)
+  val e = (identity _ : Int => Int)
+  val f = (handler: String => Context ?=> String)
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (type_identifier)
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (parenthesized_expression
+              (ascription_expression
+                (generic_function
+                  (field_expression
+                    (identifier)
+                    (identifier))
+                  (type_arguments
+                    (type_identifier)))
+                (type_identifier)
+                (type_identifier)))
+            (identifier))
+          (arguments
+            (floating_point_literal))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (identifier)
+          (arguments
+            (ascription_expression
+              (case_block
+                (case_clause
+                  (integer_literal)
+                  (integer_literal)))
+              (type_identifier)
+              (type_identifier)))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (postfix_expression
+              (integer_literal)
+              (identifier))
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (method_value
+              (identifier)
+              (wildcard))
+            (type_identifier)
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (lambda_expression
+            (identifier)
+            (type_identifier)
+            (lambda_expression
+              (identifier)
+              (identifier))))))))
+
+================================================================================
+Lambda with an empty body
+================================================================================
+
+object A {
+  def g = persist(evt) { _ =>
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (call_expression
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier)))
+          (block
+            (lambda_expression
+              (wildcard))))))))
+
+================================================================================
+Soft keyword extension used as an identifier
+================================================================================
+
+object A {
+  def journal: ActorRef =
+    extension.journalFor(null)
+  def f = x match {
+    case 1 =>
+      extension.remove(name)
+      Behaviors.same
+  }
+  val s = s"snapshot-${extension}"
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (indented_block
+          (call_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (arguments
+              (null_literal)))))
+      (function_definition
+        (identifier)
+        (match_expression
+          (identifier)
+          (case_block
+            (case_clause
+              (integer_literal)
+              (call_expression
+                (field_expression
+                  (identifier)
+                  (identifier))
+                (arguments
+                  (identifier)))
+              (field_expression
+                (identifier)
+                (identifier))))))
+      (val_definition
+        (identifier)
+        (interpolated_string_expression
+          (identifier)
+          (interpolated_string
+            (interpolation
+              (block
+                (identifier)))))))))
+
+================================================================================
+Mid-line else and finally after a brace-less if
+================================================================================
+
+object A {
+  def f =
+    if (c)
+      x match {
+        case 1 => 1
+      } else 2
+  def g = {
+    try if (force) graduates.removeIf(notAlive)
+    finally if (locked) gcStatus.set(false)
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (indented_block
+          (if_expression
+            (parenthesized_expression
+              (identifier))
+            (indented_block
+              (match_expression
+                (identifier)
+                (case_block
+                  (case_clause
+                    (integer_literal)
+                    (integer_literal)))))
+            (integer_literal))))
+      (function_definition
+        (identifier)
+        (block
+          (try_expression
+            (if_expression
+              (parenthesized_expression
+                (identifier))
+              (call_expression
+                (field_expression
+                  (identifier)
+                  (identifier))
+                (arguments
+                  (identifier))))
+            (finally_clause
+              (if_expression
+                (parenthesized_expression
+                  (identifier))
+                (call_expression
+                  (field_expression
+                    (identifier)
+                    (identifier))
+                  (arguments
+                    (boolean_literal)))))))))))
+
+================================================================================
+Mid-line else after an indented consequence
+================================================================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/539
+def a = if (true)
+  1 else 2
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (comment)
+  (function_definition
+    (identifier)
+    (if_expression
+      (parenthesized_expression
+        (boolean_literal))
+      (indented_block
+        (integer_literal))
+      (integer_literal))))
+
+================================================================================
+Catch on the same indentation as the match cases in a try body
+================================================================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/540
+try optag match
+  case  _                                     => null
+  catch case ex: ArithmeticException => null
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (comment)
+  (try_expression
+    (match_expression
+      (identifier)
+      (indented_cases
+        (case_clause
+          (wildcard)
+          (null_literal))))
+    (catch_clause
+      (typed_pattern
+        (identifier)
+        (type_identifier))
+      (null_literal))))
+
+================================================================================
+Bare dollar identifier called with arguments
+================================================================================
+
+object A {
+  def f = {
+    $(s"$selector *[name=$fieldName]").fill.`with`(fieldValue)
+    $(selector).submit()
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (block
+          (call_expression
+            (field_expression
+              (field_expression
+                (call_expression
+                  (identifier)
+                  (arguments
+                    (interpolated_string_expression
+                      (identifier)
+                      (interpolated_string
+                        (interpolation
+                          (identifier))
+                        (interpolation
+                          (identifier))))))
+                (identifier))
+              (identifier))
+            (arguments
+              (identifier)))
+          (call_expression
+            (field_expression
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier)))
+              (identifier))
+            (arguments)))))))
+
+================================
+Soft keyword `inline` as identifier in expressions
+================================
+
+val a = !inline || b
+val c = inline && b
+
+---
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_expression
+      (prefix_expression
+        (identifier))
+      (operator_identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier))))
+
+================================
+Trailing infix operator line continuation
+================================
+
+def f = for {
+  pipeline = a >>>
+               b >>>
+               c
+  _ <- queue.take *>
+         ref.update(g)
+} yield pipeline
+
+val cond =
+  if (c) ???
+  else d
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (for_expression
+      (enumerators
+        (enumerator
+          (identifier)
+          (infix_expression
+            (infix_expression
+              (identifier)
+              (operator_identifier)
+              (identifier))
+            (operator_identifier)
+            (identifier)))
+        (enumerator
+          (wildcard)
+          (infix_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (operator_identifier)
+            (call_expression
+              (field_expression
+                (identifier)
+                (identifier))
+              (arguments
+                (identifier))))))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (indented_block
+      (if_expression
+        (parenthesized_expression
+          (identifier))
+        (operator_identifier)
+        (identifier)))))
+
+================================
+Catch case with a multi-statement indented body
+================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/542
+try
+  ???
+catch case ex: Throwable =>
+  val test = 123
+  println(test)
+finally
+  cleanup()
+
+---
+
+(compilation_unit
+  (comment)
+  (try_expression
+    (indented_block
+      (operator_identifier))
+    (catch_clause
+      (typed_pattern
+        (identifier)
+        (type_identifier))
+      (indented_block
+        (val_definition
+          (identifier)
+          (integer_literal))
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier)))))
+    (finally_clause
+      (indented_block
+        (call_expression
+          (identifier)
+          (arguments))))))
+
+================================
+If-then with a multiline condition continued by a leading infix operator
+================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/541
+if (false)
+  || true
+then
+  print("true")
+
+---
+
+(compilation_unit
+  (comment)
+  (if_expression
+    (infix_expression
+      (parenthesized_expression
+        (boolean_literal))
+      (operator_identifier)
+      (boolean_literal))
+    (indented_block
+      (call_expression
+        (identifier)
+        (arguments
+          (string))))))
+
+================================
+Braceless match with cases at the same indentation
+================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/264
+object A:
+  a match
+  case b =>
+  case c =>
+
+def foo =
+  name match
+  case n: Int =>
+    body1
+    body2
+  case _ =>
+    body3
+  done()
+
+---
+
+(compilation_unit
+  (comment)
+  (object_definition
+    (identifier)
+    (template_body
+      (match_expression
+        (identifier)
+        (indented_cases
+          (case_clause
+            (identifier))
+          (case_clause
+            (identifier))))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (match_expression
+        (identifier)
+        (indented_cases
+          (case_clause
+            (typed_pattern
+              (identifier)
+              (type_identifier))
+            (identifier)
+            (identifier))
+          (case_clause
+            (wildcard)
+            (identifier))))
+      (call_expression
+        (identifier)
+        (arguments)))))
+
+================================
+Nested braceless match inside same-indentation cases
+================================
+
+def f =
+  x match
+  case A(p) =>
+    y match
+    case B => b
+    case _ => c
+  case None => d
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (match_expression
+        (identifier)
+        (indented_cases
+          (case_clause
+            (case_class_pattern
+              (type_identifier)
+              (identifier))
+            (match_expression
+              (identifier)
+              (indented_cases
+                (case_clause
+                  (identifier)
+                  (identifier))
+                (case_clause
+                  (wildcard)
+                  (identifier)))))
+          (case_clause
+            (identifier)
+            (identifier)))))))
+
+================================
+Multi-clause import inside a brace lambda body
+================================
+
+def f = runTestCommon() { _ =>
+  import scala.tools.scalap, scalap.scalax.rules.scalasig.ByteCode
+  1
+}
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (call_expression
+      (call_expression
+        (identifier)
+        (arguments))
+      (block
+        (lambda_expression
+          (wildcard)
+          (indented_block
+            (import_declaration
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier))
+            (integer_literal)))))))
+
+================================
+Postfix operator at end of line before a definition keyword
+================================
+
+trait RunnerSpec {
+  val optPos = "pos" / "run compilation tests (success)" --?
+  val optNeg = "neg" / "run compilation tests (failure)" --?
+}
+
+---
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (postfix_expression
+          (infix_expression
+            (string)
+            (operator_identifier)
+            (string))
+          (operator_identifier)))
+      (val_definition
+        (identifier)
+        (postfix_expression
+          (infix_expression
+            (string)
+            (operator_identifier)
+            (string))
+          (operator_identifier))))))
+
+================================
+For with an enumerator continued after a trailing infix operator
+================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/358
+for
+  _ <- a *>
+       b
+yield ()
+
+---
+
+(compilation_unit
+  (comment)
+  (for_expression
+    (enumerators
+      (enumerator
+        (wildcard)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier))))
+    (unit)))
+
+================================
+Soft keyword `end` as identifier in expressions
+================================
+
+def f = {
+  val end = 1
+  println(s"took: ${end - start}ms")
+  end - start
+}
+
+---
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (block
+      (val_definition
+        (identifier)
+        (integer_literal))
+      (call_expression
+        (identifier)
+        (arguments
+          (interpolated_string_expression
+            (identifier)
+            (interpolated_string
+              (interpolation
+                (block
+                  (infix_expression
+                    (identifier)
+                    (operator_identifier)
+                    (identifier))))))))
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (identifier)))))
+
+================================
+Method values (eta expansion underscore)
+================================
+
+val h = f _
+def g(s: S) = (iso.reverseGet _ compose iso.get)(s) <==> s
+
+---
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (method_value
+      (identifier)
+      (wildcard)))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (infix_expression
+      (call_expression
+        (parenthesized_expression
+          (infix_expression
+            (method_value
+              (field_expression
+                (identifier)
+                (identifier))
+              (wildcard))
+            (identifier)
+            (field_expression
+              (identifier)
+              (identifier))))
+        (arguments
+          (identifier)))
+      (operator_identifier)
+      (identifier))))
+
+================================================================================
+Empty statements before a statement (`;{ ... }`, `;def`)
+================================================================================
+
+object A {
+  def f = {
+    val x = 1
+    ;{
+      val y = 2
+    }
+  }
+  ;def g = 1
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (block
+          (val_definition
+            (identifier)
+            (integer_literal))
+          (block
+            (val_definition
+              (identifier)
+              (integer_literal)))))
+      (function_definition
+        (identifier)
+        (integer_literal)))))
+
+================================================================================
+Unicode fat arrow (Scala 2)
+================================================================================
+
+import a.{b ⇒ c}
+
+object A {
+  val x = xs.map { case (k, v) ⇒ k }
+  val y = xs.map(v ⇒ v)
+  def f(g: ⇒ Int): Int ⇒ Int = h ⇒ g
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (import_declaration
+    (identifier)
+    (namespace_selectors
+      (arrow_renamed_identifier
+        (identifier)
+        (identifier))))
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (case_block
+            (case_clause
+              (tuple_pattern
+                (identifier)
+                (identifier))
+              (identifier)))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (lambda_expression
+              (identifier)
+              (identifier)))))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (lazy_parameter_type
+              (type_identifier))))
+        (function_type
+          (parameter_types
+            (type_identifier))
+          (type_identifier))
+        (lambda_expression
+          (identifier)
+          (identifier))))))
+
+================================================================================
+Quoted keyword literals (Scala 3)
+================================================================================
+
+inline def e(inline m: String): Unit =
+  ${ impl('m, 'null, 'true, 'false) }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (modifiers
+      (inline_modifier))
+    (identifier)
+    (parameters
+      (parameter
+        (inline_modifier)
+        (identifier)
+        (type_identifier)))
+    (type_identifier)
+    (indented_block
+      (splice_expression
+        (call_expression
+          (identifier)
+          (arguments
+            (quote_expression
+              (identifier))
+            (quote_expression
+              (null_literal))
+            (quote_expression
+              (boolean_literal))
+            (quote_expression
+              (boolean_literal))))))))
+
+================================================================================
+Line-leading match continuing a method chain
+================================================================================
+
+def f =
+  xs
+    .partition(deepTest)
+      // partition into full matches and head matches
+    match
+      case (Nil, partials) => partials
+      case givenImports => givenImports
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (match_expression
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (identifier)))
+        (comment)
+        (indented_cases
+          (case_clause
+            (tuple_pattern
+              (identifier)
+              (identifier))
+            (identifier))
+          (case_clause
+            (identifier)
+            (identifier)))))))
+
+================================================================================
+Deeply nested bare colon arguments
+================================================================================
+
+def g =
+  typeRest:
+    infixTypeRest(inContextBound):
+      refinedTypeRest:
+        withTypeRest:
+          annotTypeRest:
+            simpleTypeRest(tuple)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (call_expression
+        (identifier)
+        (colon_argument
+          (indented_block
+            (call_expression
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier)))
+              (colon_argument
+                (indented_block
+                  (call_expression
+                    (identifier)
+                    (colon_argument
+                      (indented_block
+                        (call_expression
+                          (identifier)
+                          (colon_argument
+                            (indented_block
+                              (call_expression
+                                (identifier)
+                                (colon_argument
+                                  (indented_block
+                                    (call_expression
+                                      (identifier)
+                                      (arguments
+                                        (identifier)))))))))))))))))))))
+
+================================================================================
+Ascribed match expression (`}: @unchecked`)
+================================================================================
+
+def f =
+  val (a, b) = info match {
+    case Poly(tps, cinfo) => (tps, cinfo)
+    case cinfo => (Nil, cinfo)
+  }: @unchecked
+  a
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (val_definition
+        (tuple_pattern
+          (identifier)
+          (identifier))
+        (ascription_expression
+          (match_expression
+            (identifier)
+            (case_block
+              (case_clause
+                (case_class_pattern
+                  (type_identifier)
+                  (identifier)
+                  (identifier))
+                (tuple_expression
+                  (identifier)
+                  (identifier)))
+              (case_clause
+                (identifier)
+                (tuple_expression
+                  (identifier)
+                  (identifier)))))
+          (annotation
+            (type_identifier))))
+      (identifier))))
+
+================================================================================
+Parenthesized for with do, yield on the next line, and a bare indented body
+================================================================================
+
+def f =
+  for ((a, b) <- xs) do
+    g(a)
+  for (x <- xs)
+    val y = h(x)
+    k(y)
+  for (param <- params; idx <- indices(param))
+  yield param.name
+  for (typearg <- tree.typeargs)
+  do
+    h(typearg)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (for_expression
+        (enumerators
+          (enumerator
+            (tuple_pattern
+              (identifier)
+              (identifier))
+            (identifier)))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier)))))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (identifier)))
+        (indented_block
+          (val_definition
+            (identifier)
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier))))
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier)))))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (identifier))
+          (enumerator
+            (identifier)
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier)))))
+        (field_expression
+          (identifier)
+          (identifier)))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (field_expression
+              (identifier)
+              (identifier))))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))))
+
+================================================================================
+Leading infix operator continuing inside colon-argument regions
+================================================================================
+
+def f: Boolean =
+  trace(msg, show = true):
+    noNotes:
+      elems.exists(g)
+  || !x.isTerminal
+    && ifNotTried(x):
+      val xelems = x.elems
+      xelems.forall(h)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (type_identifier)
+    (indented_block
+      (call_expression
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier)
+            (assignment_expression
+              (identifier)
+              (boolean_literal))))
+        (colon_argument
+          (indented_block
+            (call_expression
+              (identifier)
+              (colon_argument
+                (indented_block
+                  (call_expression
+                    (infix_expression
+                      (infix_expression
+                        (call_expression
+                          (field_expression
+                            (identifier)
+                            (identifier))
+                          (arguments
+                            (identifier)))
+                        (operator_identifier)
+                        (prefix_expression
+                          (field_expression
+                            (identifier)
+                            (identifier))))
+                      (operator_identifier)
+                      (call_expression
+                        (identifier)
+                        (arguments
+                          (identifier))))
+                    (colon_argument
+                      (indented_block
+                        (val_definition
+                          (identifier)
+                          (field_expression
+                            (identifier)
+                            (identifier)))
+                        (call_expression
+                          (field_expression
+                            (identifier)
+                            (identifier))
+                          (arguments
+                            (identifier)))))))))))))))
+
+================================================================================
+Dedented leading infix operator closing into an enclosing conditional
+================================================================================
+
+def f =
+  if xs.indexSatisfying(from = index): imp =>
+      imp.selectors.exists(p)
+  < nextImport then
+    action()
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (if_expression
+        (infix_expression
+          (call_expression
+            (call_expression
+              (field_expression
+                (identifier)
+                (identifier))
+              (arguments
+                (assignment_expression
+                  (identifier)
+                  (identifier))))
+            (colon_argument
+              (identifier)
+              (indented_block
+                (call_expression
+                  (field_expression
+                    (field_expression
+                      (identifier)
+                      (identifier))
+                    (identifier))
+                  (arguments
+                    (identifier))))))
+          (operator_identifier)
+          (identifier))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments)))))))
+
+================================================================================
+Leading infix continuation after a line whose statement ends with a comment
+================================================================================
+
+def allowed =
+  m.isDeprecated
+  || sym.info.typeSymbol.match        // more ubiquity
+     case dd.DummyImplicitClass => true
+     case tps =>
+       tps.isMarkerTrait // no members
+       ||                // but consider NotGiven
+       tps.hasAnnotation(x)
+  || sym.info.isSingleton // DSL friendly
+  || sym.info.isRefined // can't be expressed
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (infix_expression
+        (field_expression
+          (identifier)
+          (identifier))
+        (operator_identifier)
+        (match_expression
+          (field_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (identifier))
+          (comment)
+          (indented_cases
+            (case_clause
+              (stable_identifier
+                (identifier)
+                (identifier))
+              (boolean_literal))
+            (case_clause
+              (identifier)
+              (postfix_expression
+                (field_expression
+                  (identifier)
+                  (identifier))
+                (comment)
+                (operator_identifier))
+              (comment)
+              (infix_expression
+                (infix_expression
+                  (call_expression
+                    (field_expression
+                      (identifier)
+                      (identifier))
+                    (arguments
+                      (identifier)))
+                  (operator_identifier)
+                  (field_expression
+                    (field_expression
+                      (identifier)
+                      (identifier))
+                    (identifier)))
+                (comment)
+                (operator_identifier)
+                (field_expression
+                  (field_expression
+                    (identifier)
+                    (identifier))
+                  (identifier))))
+            (comment)))))))
+
+================================================================================
+Block comment closed by same-line code inside a braced body
+================================================================================
+
+class Foo {
+  def a: Int = 1
+
+ /** doc
+  *
+  */ override def apply(f: From) = super.apply(f)
+
+  def flip: Int = 2
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (integer_literal))
+      (block_comment)
+      (function_definition
+        (modifiers)
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (identifier))))
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (integer_literal)))))
+
+================================================================================
+Identifier starting with a keyword prefix at line start (`match_`)
+================================================================================
+
+def f = {
+  val match_ = {
+    treeCopy.Match(match0, match0.cases)
+  }
+  match_ setType B1.tpe
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (block
+      (val_definition
+        (identifier)
+        (block
+          (call_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (arguments
+              (identifier)
+              (field_expression
+                (identifier)
+                (identifier))))))
+      (infix_expression
+        (identifier)
+        (identifier)
+        (field_expression
+          (identifier)
+          (identifier))))))
+
+================================================================================
+Fewer-braces colon followed by a trailing comment
+================================================================================
+
+def f =
+  xs.foldLeft(z): // combine
+    (acc, x) =>
+      acc + x
+  ys.map: /* elementwise */
+    y =>
+      y * 2
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (call_expression
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (identifier)))
+        (comment)
+        (colon_argument
+          (indented_block
+            (lambda_expression
+              (bindings
+                (binding
+                  (identifier))
+                (binding
+                  (identifier)))
+              (indented_block
+                (infix_expression
+                  (identifier)
+                  (operator_identifier)
+                  (identifier)))))))
+      (call_expression
+        (field_expression
+          (identifier)
+          (identifier))
+        (block_comment)
+        (colon_argument
+          (indented_block
+            (lambda_expression
+              (identifier)
+              (indented_block
+                (infix_expression
+                  (identifier)
+                  (operator_identifier)
+                  (integer_literal))))))))))
+
+================================================================================
+Leading operator statements with trailing comments keep their block
+================================================================================
+
+def f =
+  ??? // TODO
+  println("x")
+
+def g =
+  ??? /* TODO */
+  h()
+
+def i =
+  p || // c
+  q
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (operator_identifier)
+      (comment)
+      (call_expression
+        (identifier)
+        (arguments
+          (string)))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (operator_identifier)
+      (block_comment)
+      (call_expression
+        (identifier)
+        (arguments))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (comment)
+        (identifier)))))
+
+================================================================================
+Dedented block comment before a continuation line
+================================================================================
+
+def f =
+  xs
+ /* c */ .map(g)
+
+def h =
+  val a = x
+ /* c */ || y
+  a
+
+class A {
+  def g: Int = 1
+  def f = if (c) 1
+ /* x */ else 2
+}
+
+val a = 1
+/* c */ val b = 2
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (call_expression
+        (field_expression
+          (identifier)
+          (block_comment)
+          (identifier))
+        (arguments
+          (identifier)))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (block_comment)
+          (operator_identifier)
+          (identifier)))
+      (identifier)))
+  (class_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (integer_literal))
+      (function_definition
+        (identifier)
+        (if_expression
+          (parenthesized_expression
+            (identifier))
+          (integer_literal)
+          (block_comment)
+          (integer_literal)))))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (block_comment)
+  (val_definition
+    (identifier)
+    (integer_literal)))
+
+================================================================================
+Indented bodies starting with keyword-prefixed identifiers
+================================================================================
+
+def f =
+  cdo(1)
+  eyield(2)
+  e+ x
+  g()
+
+def m =
+  xs
+  m|| x
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (call_expression
+        (identifier)
+        (arguments
+          (integer_literal)))
+      (call_expression
+        (identifier)
+        (arguments
+          (integer_literal)))
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (identifier))
+      (call_expression
+        (identifier)
+        (arguments))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (identifier)
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (identifier)))))
+
+================================================================================
+Comma closing an indented block: closer on a later line, char literal, brace lambda
+================================================================================
+
+val r = foo(
+  xs.map: x =>
+    g(x), h(y)
+)
+
+val s = foo(
+  xs.map: x =>
+    g(x), h('(') )
+
+def t = runTestCommon() { _ =>
+  import a.b, c.d }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (arguments
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (colon_argument
+            (identifier)
+            (indented_block
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier))))))
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (arguments
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (colon_argument
+            (identifier)
+            (indented_block
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier))))))
+        (call_expression
+          (identifier)
+          (arguments
+            (character_literal))))))
+  (function_definition
+    (identifier)
+    (call_expression
+      (call_expression
+        (identifier)
+        (arguments))
+      (block
+        (lambda_expression
+          (wildcard)
+          (indented_block
+            (import_declaration
+              (identifier)
+              (identifier)
+              (identifier)
+              (identifier))))))))
+
+================================================================================
+Comment between match and its case clauses
+================================================================================
+
+def f =
+  x match
+  /* c */ case a => b
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (match_expression
+        (identifier)
+        (indented_cases
+          (block_comment)
+          (case_clause
+            (identifier)
+            (identifier)))))))
+
+================================================================================
+Top-level match with cases at width zero and a following statement
+================================================================================
+
+x match
+case 1 => a
+case 2 => b
+val z = 1
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (match_expression
+    (identifier)
+    (indented_cases
+      (case_clause
+        (integer_literal)
+        (identifier))
+      (case_clause
+        (integer_literal)
+        (identifier))))
+  (val_definition
+    (identifier)
+    (integer_literal)))
+
+================================================================================
+Operator at end of line before an annotated definition
+================================================================================
+
+trait R {
+  val optPos = "pos" --?
+  @deprecated val g = 1
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (postfix_expression
+          (string)
+          (operator_identifier)))
+      (val_definition
+        (annotation
+          (type_identifier))
+        (identifier)
+        (integer_literal)))))
+
+================================================================================
+Backquoted then on a leading infix continuation line
+================================================================================
+
+def f =
+  val cond =
+      x.exists(p)
+  && q.`then`
+  cond
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (val_definition
+        (identifier)
+        (indented_block
+          (infix_expression
+            (call_expression
+              (field_expression
+                (identifier)
+                (identifier))
+              (arguments
+                (identifier)))
+            (operator_identifier)
+            (field_expression
+              (identifier)
+              (identifier)))))
+      (identifier))))
+
+================================================================================
+Colon template body starting with a backquoted DSL statement
+================================================================================
+
+class T extends F:
+  `empty list` should work
+  more()
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (extends_clause
+      (type_identifier))
+    (template_body
+      (infix_expression
+        (identifier)
+        (identifier)
+        (identifier))
+      (call_expression
+        (identifier)
+        (arguments)))))

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -386,3 +386,63 @@ yield ()
           (arguments
             (integer_literal)))))
     (unit)))
+
+================================================================================
+Capture patterns inside string interpolation patterns
+================================================================================
+
+object A {
+  def f = t match {
+    case q"${name0 @ CompanianAliases(Name(_))}.$_" => 1
+    case p"/items/${idString @ int(id)}" => 2
+  }
+  val t = q"$JsPath \ $cn"
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (match_expression
+          (identifier)
+          (case_block
+            (case_clause
+              (interpolated_string_expression
+                (identifier)
+                (interpolated_string
+                  (interpolation
+                    (capture_pattern
+                      (identifier)
+                      (case_class_pattern
+                        (type_identifier)
+                        (case_class_pattern
+                          (type_identifier)
+                          (wildcard)))))
+                  (interpolation
+                    (identifier))))
+              (integer_literal))
+            (case_clause
+              (interpolated_string_expression
+                (identifier)
+                (interpolated_string
+                  (interpolation
+                    (capture_pattern
+                      (identifier)
+                      (case_class_pattern
+                        (type_identifier)
+                        (identifier))))))
+              (integer_literal)))))
+      (val_definition
+        (identifier)
+        (interpolated_string_expression
+          (identifier)
+          (interpolated_string
+            (interpolation
+              (identifier))
+            (escape_sequence)
+            (interpolation
+              (identifier))))))))

--- a/test/corpus/types-pending.txt
+++ b/test/corpus/types-pending.txt
@@ -1,7 +1,5 @@
-
 ================================================================================
 Subclass with multiline params and unnamed after named param
-:skip
 ================================================================================
 
 // https://github.com/tree-sitter/tree-sitter-scala/issues/465
@@ -14,9 +12,30 @@ class Child extends Base(
 
 --------------------------------------------------------------------------------
 
+(compilation_unit
+  (comment)
+  (comment)
+  (class_definition
+    (identifier)
+    (extends_clause
+      (type_identifier)
+      (arguments
+        (assignment_expression
+          (identifier)
+          (indented_block
+            (for_expression
+              (enumerators
+                (enumerator
+                  (identifier)
+                  (call_expression
+                    (identifier)
+                    (arguments
+                      (string)))))
+              (identifier))
+            (string)))))))
+
 ================================================================================
 case class nested in an object definition
-:skip
 ================================================================================
 
 // https://github.com/tree-sitter/tree-sitter-scala/issues/329
@@ -29,4 +48,18 @@ end Merge
 
 --------------------------------------------------------------------------------
 
-
+(compilation_unit
+  (comment)
+  (object_definition
+    (identifier)
+    (template_body
+      (class_definition
+        (identifier)
+        (class_parameters
+          (class_parameter
+            (identifier)
+            (type_identifier))
+          (class_parameter
+            (identifier)
+            (type_identifier)))
+        (template_body)))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -770,6 +770,7 @@ type A = Foo | Bar & Buz
 type B = "foo" | "bar" & "buz"
 
 --------------------------------------------------------------------------------
+
 (compilation_unit
   (type_definition
     (type_identifier)
@@ -800,10 +801,99 @@ Applied Constructor Types (Scala 3)
 val c: C(42)
 
 --------------------------------------------------------------------------------
+
 (compilation_unit
   (val_declaration
     (identifier)
     (applied_constructor_type
       (type_identifier)
       (arguments
+        (integer_literal)))))
+
+================================================================================
+Unicode math symbols as type operators
+================================================================================
+
+object P {
+  type ¬[T] = T => Nothing
+  type ∨[T, U] = ¬[¬[T] ∧ ¬[U]]
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (type_definition
+        (type_identifier)
+        (type_parameters
+          (identifier))
+        (function_type
+          (parameter_types
+            (type_identifier))
+          (type_identifier)))
+      (type_definition
+        (type_identifier)
+        (type_parameters
+          (identifier)
+          (identifier))
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (infix_type
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier)))
+              (operator_identifier)
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier))))))))))
+
+================================================================================
+Existential types (Scala 2)
+================================================================================
+
+object O {
+  type E = P[T] forSome { type T }
+  def f(x: Map[K, V] forSome { type K; type V <: K }): Int = 1
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (type_definition
+        (type_identifier)
+        (existential_type
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier)))
+          (refinement
+            (type_definition
+              (type_identifier)))))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (existential_type
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier)
+                  (type_identifier)))
+              (refinement
+                (type_definition
+                  (type_identifier))
+                (type_definition
+                  (type_identifier)
+                  (upper_bound
+                    (type_identifier)))))))
+        (type_identifier)
         (integer_literal)))))

--- a/test/corpus/xml.txt
+++ b/test/corpus/xml.txt
@@ -1,0 +1,267 @@
+================================================================================
+XML literal: simple element
+================================================================================
+
+val a = <b>hi</b>
+val b = <x/>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_text)
+        (xml_name))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)))))
+
+================================================================================
+XML literal: attributes
+================================================================================
+
+val a = <x y="1" z='2'/>
+val b = <link xmlns=""/>
+val c = <elem key={x1} />
+val d = <z:hello foo="bar" xmlns:z="z">text</z:hello>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_attribute
+          (xml_name)
+          (xml_string)))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string)))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (block
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_text)
+        (xml_name)))))
+
+================================================================================
+XML literal: nested elements and embedded expressions
+================================================================================
+
+val a =
+  <bks>
+    <book><title>{name}</title></book>
+    {{escaped}}
+  </bks>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (indented_block
+      (xml_expression
+        (xml_element
+          (xml_name)
+          (xml_element
+            (xml_name)
+            (xml_element
+              (xml_name)
+              (block
+                (identifier))
+              (xml_name))
+            (xml_name))
+          (xml_text)
+          (xml_text)
+          (xml_text)
+          (xml_name))))))
+
+================================================================================
+XML literal: comment, CDATA, processing instruction
+================================================================================
+
+val a = <!-- thissa comment -->.toString
+val b = <?pi foo bar?>.toString
+val c = <![CDATA[ "quoted" ]]>.toString
+val d = <a><!-- inner --><![CDATA[x]]><?p q?></a>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_comment))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_processing_instruction))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_cdata))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_comment)
+        (xml_cdata)
+        (xml_processing_instruction)
+        (xml_name)))))
+
+================================================================================
+XML literal: element sequence
+================================================================================
+
+val ns = <a/><b/>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name))
+      (xml_element
+        (xml_name)))))
+
+================================================================================
+XML literal: `<` operators are unaffected
+================================================================================
+
+val cmp = a < b
+val cmpParen = if (x <y) x else y
+val shift = 1 << 2
+val leadingInfix = a
+  < b
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (if_expression
+      (parenthesized_expression
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (integer_literal)
+      (operator_identifier)
+      (integer_literal)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier))))
+
+================================================================================
+XML patterns
+================================================================================
+
+def m(x: Node) = x match {
+  case <hello/> => true
+  case <x:ga/> => true
+  case <t>{_*}</t> => false
+  case <a>{ns @ _*}</a> => ns
+  case <bks><book/>{rest @ _*}</bks> => rest
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (xml_pattern
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (repeat_pattern
+              (wildcard))
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (capture_pattern
+              (identifier)
+              (repeat_pattern
+                (wildcard)))
+            (xml_name))
+          (identifier))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (xml_pattern
+              (xml_name))
+            (capture_pattern
+              (identifier)
+              (repeat_pattern
+                (wildcard)))
+            (xml_name))
+          (identifier))))))


### PR DESCRIPTION
Parses 14,336 / 14,446 (99.24%) of real-world Scala files

Measured against akka, almond, better-files, Binding.scala, caliban, cats-collections, circe, eff, http4s, iron, kamon, macwire, monocle, parquet4s, play-json, playframework, refined, Scala 2, Scala 3 (except the experimental capture checking), scala-logging, scala-xml, scalacache, scalacheck, scalamock, scalikejdbc, scopt, shapeless, skunk, slick, spire, squants, sttp, tapir, zio.

The below issues are closed by this PR:
Closes #264
Closes #329
Closes #358 
Closes #465 
Closes #539 
Closes #540
Closes #541
Closes #542

Additionally, two optimizations were added since Parser.c neared its 33 MiB ceiling.
1. Inlining eight hidden rules cut large-state count 4495→2875 (−2.2 MiB).
2. Moving block comments to the external scanner removed a slash-star `/*` column from every parse state (−460 KB).

(Parser grew up a bit for Scala2/3 repo after these two optimization)

Net: 29.6 MiB (3.4 MiB headroom), ~30% faster parsing, tree shape unchanged.
