### PR TITLE
fix(scala3): allow an indented block as the body of `catch case`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1488,7 +1488,13 @@ module.exports = grammar({
       ),
 
     _expr_case_clause: $ =>
-      prec.left(seq("case", $._case_pattern, field("body", $.expression))),
+      prec.left(
+        seq(
+          "case",
+          $._case_pattern,
+          field("body", choice($.expression, $.indented_block)),
+        ),
+      ),
 
     finally_clause: $ => prec.right(seq("finally", $._indentable_expression)),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -783,7 +783,8 @@ def main(): Unit =
           (typed_pattern
             (identifier)
             (type_identifier))
-          (identifier))))))
+          (indented_block
+            (identifier)))))))
 
 ================================================================================
 Match expressions
@@ -2161,3 +2162,41 @@ bar(a, xs: _*)
       (identifier)
       (vararg
         (identifier)))))
+
+================================================================================
+Catch case with a multi-statement indented body
+================================
+
+// https://github.com/tree-sitter/tree-sitter-scala/issues/542
+try
+  ???
+catch case ex: Throwable =>
+  val test = 123
+  println(test)
+finally
+  cleanup()
+
+---
+
+(compilation_unit
+  (comment)
+  (try_expression
+    (indented_block
+      (operator_identifier))
+    (catch_clause
+      (typed_pattern
+        (identifier)
+        (type_identifier))
+      (indented_block
+        (val_definition
+          (identifier)
+          (integer_literal))
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier)))))
+    (finally_clause
+      (indented_block
+        (call_expression
+          (identifier)
+          (arguments))))))


### PR DESCRIPTION
- Spin-out from #547
- Closes #542

A brace-less `catch case pat =>` whose body spans multiple indented lines was cut off after the first statement; the remaining statements leaked out of the try expression (issue #542, seen in real code such as [dotty's Types.scala)](https://github.com/scala/scala3/blob/03f6bdd2818b237d356828675f90c920158246e5/compiler/src/dotty/tools/dotc/core/Types.scala#L5316-L5318). Accept `$.indented_block` as the clause body: the block's OUTDENT closes it, so following statements or a `finally` clause are not swallowed.

The expected tree of the existing multi-line catch-case test now wraps the body in `indented_block`.
A legitimate shape change that comes with accepting a block there.