### PR TITLE
fix: accept braced-body members indented shallower than their siblings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -550,6 +550,10 @@ module.exports = grammar({
         ),
         optional($._block),
         $._outdent,
+        // A member indented shallower than its siblings pops the indent
+        // region before the closing brace; the remaining members are still
+        // part of the same braced body (scalac ignores indentation here).
+        optional($._block),
       ),
 
     /*

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2084,3 +2084,48 @@ class F(tracked val x: C):
           (tracked_modifier))
         (identifier)
         (type_identifier)))))
+
+================================================================================
+Braced body member indented shallower than its siblings
+================================================================================
+
+object hlist {
+  trait A {
+    type T
+  }
+
+ trait B[L] extends A {
+    type Out
+  }
+
+  trait C {
+    def x: Int
+  }
+}
+
+---
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (trait_definition
+        (identifier)
+        (template_body
+          (type_definition
+            (type_identifier))))
+      (trait_definition
+        (identifier)
+        (type_parameters
+          (identifier))
+        (extends_clause
+          (type_identifier))
+        (template_body
+          (type_definition
+            (type_identifier))))
+      (trait_definition
+        (identifier)
+        (template_body
+          (function_declaration
+            (identifier)
+            (type_identifier)))))))


### PR DESCRIPTION
- Spin-out from #547 
- Corresponding issue: None. [Real-world example in shapeless](https://github.com/milessabin/shapeless/blob/99efca64f4f5fe27c7b1c3391403fed1ba3f3320/core/shared/src/main/scala/shapeless/ops/hlists.scala#L1065-L1069)

Inside a braced template body, the scanner opens an indent region at the first member; a later member indented shallower than that (legal, scalac ignores indentation inside braces) popped the region before the closing brace and the remaining members fell out of the body as parse errors.

Let `_braced_template_body2` continue with a second statement block after the early OUTDENT, so the region close no longer ends the braced body.