### PR TITLE
fix: self types with empty bodies, empty-bodied lambdas, enum self types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -280,10 +280,19 @@ module.exports = grammar({
 
     enum_body: $ =>
       choice(
-        prec.left(PREC.control, seq(":", $._indent, $._enum_block, $._outdent)),
+        prec.left(
+          PREC.control,
+          seq(
+            ":",
+            $._indent,
+            optional($.self_type),
+            $._enum_block,
+            $._outdent,
+          ),
+        ),
         seq(
           "{",
-          // TODO: self type
+          optional($.self_type),
           optional($._enum_block),
           "}",
         ),
@@ -292,6 +301,8 @@ module.exports = grammar({
     enum_case_definitions: $ =>
       seq(
         repeat($.annotation),
+        // e.g. `private case External(...) extends ...`
+        optional($.modifiers),
         "case",
         choice(commaSep1($.simple_enum_case), $.full_enum_case),
       ),
@@ -528,7 +539,18 @@ module.exports = grammar({
     _indented_template_body: $ =>
       prec.left(
         PREC.control,
-        seq(":", $._indent, optional($.self_type), $._block, $._outdent),
+        seq(
+          ":",
+          $._indent,
+          choice(
+            seq(optional($.self_type), $._block),
+            // A self type with an empty body: `trait A:` + `self: B =>`
+            // followed by the next definition (or EOF). Mirrors the braced
+            // variant in _braced_template_body1.
+            $.self_type,
+          ),
+          $._outdent,
+        ),
       ),
 
     _braced_template_body: $ =>
@@ -541,7 +563,14 @@ module.exports = grammar({
         ),
       ),
 
-    _braced_template_body1: $ => seq(optional($.self_type), $._block),
+    _braced_template_body1: $ =>
+      choice(
+        seq(optional($.self_type), $._block),
+        // A self type with an empty body: `trait A { self: B => }`. Without
+        // this the only reading of the body is an empty-bodied lambda, which
+        // breaks when another statement follows the closing brace.
+        $.self_type,
+      ),
     _braced_template_body2: $ =>
       seq(
         choice(
@@ -1405,7 +1434,7 @@ module.exports = grammar({
             choice($.bindings, $.wildcard, $._single_lambda_param),
           ),
           choice("=>", "?=>"),
-          $._block,
+          optional($._block),
         ),
       ),
 

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2084,3 +2084,127 @@ class F(tracked val x: C):
           (tracked_modifier))
         (identifier)
         (type_identifier)))))
+
+================================================================================
+Self type with empty body
+================================================================================
+
+trait A { self: Node => }
+
+trait B { self: Meta.type => }
+
+trait C { this: X =>
+}
+
+---
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier))))
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (singleton_type
+          (identifier)))))
+  (trait_definition
+    (identifier)
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier)))))
+
+================================================================================
+Colon template body with a self type and an empty body
+================================================================================
+
+trait OriginWarning(val origin: String):
+  self: Warning =>
+object OriginWarning:
+  val NoOrigin = "..."
+
+transparent trait Pure extends Any:
+  this: Pure =>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier)))
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier))))
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (string))))
+  (trait_definition
+    (modifiers
+      (transparent_modifier))
+    (identifier)
+    (extends_clause
+      (type_identifier))
+    (template_body
+      (self_type
+        (identifier)
+        (type_identifier)))))
+
+================================================================================
+Enum with a self type and a modifier on a case
+================================================================================
+
+enum SymbolKind derives CanEqual:
+  kind =>
+
+  case Val, Var
+  private case External(override val toLowerCase: String) extends FileExtension(toLowerCase)
+  def isVar: Boolean = kind == Var
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (enum_definition
+    (identifier)
+    (derives_clause
+      (type_identifier))
+    (enum_body
+      (self_type
+        (identifier))
+      (enum_case_definitions
+        (simple_enum_case
+          (identifier))
+        (simple_enum_case
+          (identifier)))
+      (enum_case_definitions
+        (modifiers
+          (access_modifier))
+        (full_enum_case
+          (identifier)
+          (class_parameters
+            (class_parameter
+              (modifiers)
+              (identifier)
+              (type_identifier)))
+          (extends_clause
+            (type_identifier)
+            (arguments
+              (identifier)))))
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2165,7 +2165,7 @@ bar(a, xs: _*)
 
 ================================================================================
 Catch case with a multi-statement indented body
-================================
+================================================================================
 
 // https://github.com/tree-sitter/tree-sitter-scala/issues/542
 try
@@ -2200,3 +2200,29 @@ finally
         (call_expression
           (identifier)
           (arguments))))))
+
+================================================================================
+Lambda with an empty body
+================================================================================
+
+object A {
+  def g = persist(evt) { _ =>
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (call_expression
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier)))
+          (block
+            (lambda_expression
+              (wildcard))))))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.


Four related gaps around SelfType  and empty lambda bodies:

1. `foo { x => }` — a block lambda with an empty body was a parse error; the body block is now optional. This grammar change is included here  because the empty-body self-type fix below builds on it.
    Seen in [akka](https://github.com/akka/akka-core/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/akka-stream-tests-tck/src/test/scala/akka/stream/tck/ForeachSinkSubscriberTest.scala#L15-L16)/[pekko](https://github.com/apache/pekko/blob/4fe1f4a2d98c43469b196123f032daf1da9e0410/stream-tests-tck/src/test/scala/org/apache/pekko/stream/tck/ForeachSinkSubscriberTest.scala#L25-L26).
2. `trait A { self: B => }` — a braced template body that is only a self type had no production. The empty-bodied-lambda reading must complete without error recovery so that the GLR fork reaches condense, where self_type's dynamic precedence wins; with the lambda branch still erroring, the recovery version shadowed the self-type reading.
   Seen in [circe](https://github.com/circe/circe/blob/e884a42003270af4738e32442768de27c266452f/modules/tests/js/src/test/scala/io/circe/FloatJsonTests.scala#L25) and [scala-xml](https://github.com/scala/scala-xml/blob/a4c4e52e88ea92fb019650208984170942407db4/shared/src/main/scala-2.12/scala/xml/ScalaVersionSpecific.scala#L38-L44).
3. `trait A:` + `self: B =>` with no members after it — the same gap for colon template bodies. 
     Seen in [dotty](https://github.com/scala/scala3/blob/03f6bdd2818b237d356828675f90c920158246e5/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala#L44-L46).
4. [enum bodies did not accept a self type ](https://github.com/scala/scala3/blob/03f6bdd2818b237d356828675f90c920158246e5/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala#L161-L162)at all, and [enum cases did not accept modifiers](https://github.com/scala/scala3/blob/03f6bdd2818b237d356828675f90c920158246e5/compiler/src/dotty/tools/io/FileExtension.scala#L16).
     Seen in dotty.