### PR TITLE
fix: keep soft keyword `inline` usable as an identifier in expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -78,6 +78,7 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.tuple_type, $.parameter_types],
+    [$.inline_modifier, $._soft_identifier],
     [$.binding, $._simple_expression],
     [$.binding, $._type_identifier],
     [$.while_expression, $._simple_expression],
@@ -912,7 +913,10 @@ module.exports = grammar({
 
     access_qualifier: $ => seq("[", $._identifier, "]"),
 
-    inline_modifier: $ => prec("mod", "inline"),
+    // Unlike other soft modifiers `inline` is also valid at expression start,
+    // so a static "mod" win would misparse `inline || x`; fork instead and
+    // prefer the modifier only when both readings complete (`inline if`).
+    inline_modifier: $ => prec.dynamic(1, "inline"),
     infix_modifier: $ => prec("mod", "infix"),
     into_modifier: $ => prec("mod", "into"),
     open_modifier: $ => prec("mod", "open"),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2226,3 +2226,27 @@ object A {
           (block
             (lambda_expression
               (wildcard))))))))
+
+================================================================================
+Soft keyword `inline` as identifier in expressions
+================================================================================
+
+val a = !inline || b
+val c = inline && b
+
+---
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_expression
+      (prefix_expression
+        (identifier))
+      (operator_identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.
 
`inline` is the only soft modifier that is also valid at expression start (`inline if`, `inline match`), so the static "mod" > "soft_id" precedence made the parser commit to inline_modifier and break plain identifier uses such as `!inline || x`.
Seen in[ playframework Results.scala](https://github.com/playframework/playframework/blob/cb6b3b9938746723d0bbea7f1c7ac03cd4361f4c/core/play/src/main/scala/play/api/mvc/Results.scala#L556-L557)

The token is now reduced under a GLR fork declared as a conflict between inline_modifier and _soft_identifier; the continuation picks the surviving reading, and a dynamic precedence on inline_modifier prefers the modifier when both readings complete (`inline if (c) a else b`).
