### PR TITLE
feat: method values (`f _`) as simple expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1398,8 +1398,16 @@ module.exports = grammar({
         $.field_expression,
         $.generic_function,
         $.call_expression,
+        $.method_value,
         alias($._dot_match_expression, $.match_expression),
       ),
+
+    /**
+     * SimpleExpr ::= SimpleExpr1 '_'  (SLS 6.7 Method Values, `f _`)
+     * A simple expression, so it can be an infix operand.
+     */
+    method_value: $ =>
+      prec.left(PREC.call, seq($._simple_expression, $.wildcard)),
 
     _single_lambda_param: $ =>
       prec.right(

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2286,3 +2286,42 @@ val c = inline && b
       (identifier)
       (operator_identifier)
       (identifier))))
+
+================================================================================
+Method values (eta expansion underscore)
+================================================================================
+
+val h = f _
+def g(s: S) = (iso.reverseGet _ compose iso.get)(s) <==> s
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (method_value
+      (identifier)
+      (wildcard)))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (infix_expression
+      (call_expression
+        (parenthesized_expression
+          (infix_expression
+            (method_value
+              (field_expression
+                (identifier)
+                (identifier))
+              (wildcard))
+            (identifier)
+            (field_expression
+              (identifier)
+              (identifier))))
+        (arguments
+          (identifier)))
+      (operator_identifier)
+      (identifier))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

`expr _` had no rule of its own. The underscore lexed as an identifier and the whole expression parsed as a postfix expression. A postfix expression cannot be an infix operand, so `(iso.reverseGet _ compose iso.get)(s)` broke. A new method_value simple expression covers it. Where it is valid the underscore now lexes as the wildcard keyword token, so the old postfix reading simply disappears.

Seen in [monocle IsoLaws.scala](https://github.com/optics-dev/Monocle/blob/3aa940b81c5ff3bfd40ec438ae0580b5b59c8bfe/core/shared/src/main/scala/monocle/law/IsoLaws.scala#L12-L13).