### PR TITLE
fix: restrict end marker names to alphanumeric identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -619,7 +619,13 @@ module.exports = grammar({
             "given",
             "extension",
             "val",
-            alias($._identifier, "_end_ident"),
+            // Only alphanumeric (or back-quoted) names: allowing operator
+            // identifiers here would swallow `end` used as a plain
+            // identifier before an infix operator (`${end - start}`).
+            alias(
+              choice($._alpha_identifier, $._backquoted_id),
+              "_end_ident",
+            ),
           ),
         ),
       ),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2226,3 +2226,39 @@ object A {
           (block
             (lambda_expression
               (wildcard))))))))
+
+================================================================================
+Soft keyword `end` as identifier in expressions
+================================================================================
+
+def f = {
+  val end = 1
+  println(s"took: ${end - start}ms")
+  end - start
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (block
+      (val_definition
+        (identifier)
+        (integer_literal))
+      (call_expression
+        (identifier)
+        (arguments
+          (interpolated_string_expression
+            (identifier)
+            (interpolated_string
+              (interpolation
+                (block
+                  (infix_expression
+                    (identifier)
+                    (operator_identifier)
+                    (identifier))))))))
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (identifier)))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

The end-marker rule accepted any identifier as the marker name, including operator identifiers. The precedence of "end" over "soft_id" then committed `end` plus an operator to the end-marker reading. `${end - start}` inside an interpolation parsed `end -` as a marker and broke. An end marker for a symbolic definition such as `end ::` is vanishingly rare compared to `end` as a value name followed by an infix operator. dotty also recognizes a marker only when the line contains nothing else.

Seen in [macwire TimingInterceptor.scala](https://github.com/softwaremill/macwire/blob/848ac13ef73a174009b02abf89a51274cdeb42aa/examples/scalatra/src/main/scala/com/softwaremill/macwire/examples/scalatra/util/TimingInterceptor.scala#L14).