### PR TITLE
feat(scala2): `forSome` existential types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1082,6 +1082,13 @@ module.exports = grammar({
         $.literal_type,
         $._structural_type,
         $.type_lambda,
+        $.existential_type,
+      ),
+
+    // Scala 2 existential type (SLS §3.2.12): `P[T] forSome { type T }`
+    existential_type: $ =>
+      prec.left(
+        seq(field("type", $._infix_type_choice), "forSome", $._refinement),
       ),
 
     _annotated_type: $ => prec.right(choice($.annotated_type, $._simple_type)),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -149,7 +149,7 @@
   "extends"
   "derives"
   "finally"
-;; `forSome` existential types not implemented yet
+  "forSome"
 ;; `macro` not implemented yet
   "object"
   "override"

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -807,3 +807,49 @@ val c: C(42)
       (type_identifier)
       (arguments
         (integer_literal)))))
+
+================================================================================
+Existential types (Scala 2)
+================================================================================
+
+object O {
+  type E = P[T] forSome { type T }
+  def f(x: Map[K, V] forSome { type K; type V <: K }): Int = 1
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (type_definition
+        (type_identifier)
+        (existential_type
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier)))
+          (refinement
+            (type_definition
+              (type_identifier)))))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (existential_type
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier)
+                  (type_identifier)))
+              (refinement
+                (type_definition
+                  (type_identifier))
+                (type_definition
+                  (type_identifier)
+                  (upper_bound
+                    (type_identifier)))))))
+        (type_identifier)
+        (integer_literal)))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

Add existential_type for `P[T] forSome { type T }`. Tree-sitter keyword extraction keeps `forSome` usable as a plain identifier elsewhere. Highlight `forSome` as a keyword.

Seen in [shapeless package.scala.](https://github.com/milessabin/shapeless/blob/99efca64f4f5fe27c7b1c3391403fed1ba3f3320/core/shared/src/main/scala/shapeless/package.scala#L60)