### PR TITLE
fix(scala2): accept Unicode `⇒` as `=>` and `←` as `<-`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -20,6 +20,14 @@ const PREC = {
   binding: 10,
 };
 
+// `⇒` (U+21D2) is the alternate Scala 2 spelling of `=>` (SLS 1.1, dropped in
+// Scala 3). It is not lexable as an operator_identifier (the single-opchar
+// class excludes it), so the extra token cannot collide with user operators.
+const fatArrow = () => choice("=>", alias("⇒", "=>"));
+
+// `=>` or the context-function arrow `?=>`.
+const anyArrow = () => choice(fatArrow(), "?=>");
+
 module.exports = grammar({
   name: "scala",
 
@@ -394,7 +402,7 @@ module.exports = grammar({
     arrow_renamed_identifier: $ =>
       seq(
         field("name", $._identifier),
-        "=>",
+        fatArrow(),
         field("alias", choice($._identifier, $.wildcard)),
       ),
 
@@ -629,7 +637,7 @@ module.exports = grammar({
           seq(
             choice($._identifier, $.wildcard),
             optional($._self_type_ascription),
-            "=>",
+            fatArrow(),
           ),
         ),
       ),
@@ -817,7 +825,7 @@ module.exports = grammar({
         ),
       ),
 
-    _given_sig: $ => seq($._given_conditional, "=>"),
+    _given_sig: $ => seq($._given_conditional, fatArrow()),
 
     _given_conditional: $ =>
       choice(alias($.parameters, $.given_conditional), $.type_parameters),
@@ -1238,7 +1246,7 @@ module.exports = grammar({
       ),
 
     _arrow_then_type: $ =>
-      prec.right(seq(choice("=>", "?=>"), field("return_type", $._type))),
+      prec.right(seq(anyArrow(), field("return_type", $._type))),
 
     // Deprioritize against typed_pattern._type.
     parameter_types: $ =>
@@ -1260,7 +1268,7 @@ module.exports = grammar({
 
     repeated_parameter_type: $ => seq(field("type", $._type), $._asterisk),
 
-    lazy_parameter_type: $ => seq("=>", field("type", $._param_value_type)),
+    lazy_parameter_type: $ => seq(fatArrow(), field("type", $._param_value_type)),
 
     _type_identifier: $ => alias($._identifier, $.type_identifier),
 
@@ -1425,12 +1433,12 @@ module.exports = grammar({
       prec.right(
         "lambda",
         seq(
-          optional(seq(field("type_parameters", $.type_parameters), "=>")),
+          optional(seq(field("type_parameters", $.type_parameters), fatArrow())),
           field(
             "parameters",
             choice($.bindings, $.wildcard, $._single_lambda_param),
           ),
-          choice("=>", "?=>"),
+          anyArrow(),
           $._indentable_expression,
         ),
       ),
@@ -1451,7 +1459,7 @@ module.exports = grammar({
             "parameters",
             choice($.bindings, $.wildcard, $._single_lambda_param),
           ),
-          choice("=>", "?=>"),
+          anyArrow(),
           optional($._block),
         ),
       ),
@@ -1568,7 +1576,7 @@ module.exports = grammar({
     _case_pattern: $ =>
       prec.dynamic(
         1,
-        seq(field("pattern", $._pattern), optional($.guard), "=>"),
+        seq(field("pattern", $._pattern), optional($.guard), fatArrow()),
       ),
 
     guard: $ =>
@@ -1626,7 +1634,7 @@ module.exports = grammar({
           optional(
             field(
               "lambda_start",
-              seq(choice($.bindings, $._identifier, $.wildcard), "=>"),
+              seq(choice($.bindings, $._identifier, $.wildcard), fatArrow()),
             ),
           ),
           choice($.indented_block, $.indented_cases),
@@ -2183,7 +2191,7 @@ module.exports = grammar({
         seq(
           optional("case"),
           $._pattern,
-          choice("<-", "="),
+          choice("<-", "←", "="),
           $.expression,
           optional($.guard),
         ),

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2253,3 +2253,32 @@ enum SymbolKind derives CanEqual:
           (identifier)
           (operator_identifier)
           (identifier))))))
+
+================================================================================
+Unicode arrow in for comprehension generators
+================================================================================
+
+object A {
+  def f = for (i ← 1 to 2) println(i)
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (for_expression
+          (enumerators
+            (enumerator
+              (identifier)
+              (infix_expression
+                (integer_literal)
+                (identifier)
+                (integer_literal))))
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2288,6 +2288,67 @@ val c = inline && b
       (identifier))))
 
 ================================================================================
+Unicode fat arrow (Scala 2)
+================================================================================
+
+import a.{b ⇒ c}
+
+object A {
+  val x = xs.map { case (k, v) ⇒ k }
+  val y = xs.map(v ⇒ v)
+  def f(g: ⇒ Int): Int ⇒ Int = h ⇒ g
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (import_declaration
+    (identifier)
+    (namespace_selectors
+      (arrow_renamed_identifier
+        (identifier)
+        (identifier))))
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (case_block
+            (case_clause
+              (tuple_pattern
+                (identifier)
+                (identifier))
+              (identifier)))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (lambda_expression
+              (identifier)
+              (identifier)))))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (lazy_parameter_type
+              (type_identifier))))
+        (function_type
+          (parameter_types
+            (type_identifier))
+          (type_identifier))
+        (lambda_expression
+          (identifier)
+          (identifier))))))
+
+================================================================================
 Method values (eta expansion underscore)
 ================================================================================
 


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

Scala 2 (SLS 1.1) treats `⇒` as an alternate spelling of the reserved `=>` token. `←` is likewise accepted for `<-` in for-comprehension generators. Real-world Scala 2 code still uses both.

`⇒` is added through a shared fatArrow() helper at every internal `=>` site, so the tree shape and node names are unchanged and no conflicts are added.

`⇒` cannot collide with user-defined operators because the single-opchar class of operator_identifier excludes U+21D2. `?=>` and `=>>` are Scala-3-only and have no Unicode spellings.

Seen in [kamon DatadogAPIReporter.scala](https://github.com/kamon-io/Kamon/blob/a376f39873921a1b2def82942e06950756522307/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogAPIReporter.scala#L115) (`⇒`) and [akka VotingServiceSpec.scala](https://github.com/akka/akka-core/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/samples/akka-sample-distributed-data-java/src/multi-jvm/scala/sample/distributeddata/VotingServiceSpec.scala#L70) (`←`).