### PR TITLE
feat: quoted keyword literals `'null` / `'true` / `'false`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1809,7 +1809,13 @@ module.exports = grammar({
         PREC.macro,
         seq(
           "'",
-          choice(seq("{", $._block, "}"), seq("[", $._type, "]"), $.identifier),
+          choice(
+            seq("{", $._block, "}"),
+            seq("[", $._type, "]"),
+            $.identifier,
+            $.null_literal,
+            $.boolean_literal,
+          ),
         ),
       ),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2386,3 +2386,39 @@ def g(s: S) = (iso.reverseGet _ compose iso.get)(s) <==> s
           (identifier)))
       (operator_identifier)
       (identifier))))
+
+================================================================================
+Quoted keyword literals (Scala 3)
+================================================================================
+
+inline def e(inline m: String): Unit =
+  ${ impl('m, 'null, 'true, 'false, 'this) }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (modifiers
+      (inline_modifier))
+    (identifier)
+    (parameters
+      (parameter
+        (inline_modifier)
+        (identifier)
+        (type_identifier)))
+    (type_identifier)
+    (indented_block
+      (splice_expression
+        (call_expression
+          (identifier)
+          (arguments
+            (quote_expression
+              (identifier))
+            (quote_expression
+              (null_literal))
+            (quote_expression
+              (boolean_literal))
+            (quote_expression
+              (boolean_literal))
+            (quote_expression
+              (identifier))))))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

Scala 3 allows quoting keyword literals in macro code. `quote_expression` now accepts `null_literal` and `boolean_literal` after `'`. `'this` already parses via identifier, so no change is needed for it.

Seen in [almond Logger.scala.](https://github.com/almond-sh/almond/blob/3f7b0a6cd5f105ee54165244149c23620802e55c/modules/shared/logger/src/main/scala-3/almond/logger/Logger.scala#L13)