### PR TITLE
fix: allow empty statements before a statement in blocks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -146,7 +146,7 @@ module.exports = grammar({
     [$.binding, $._simple_expression, $._type_identifier],
     [$.class_parameter, $._type_identifier],
     // '{'  _single_lambda_param  '=>'  expression  •  '}'  …
-    [$._block, $._indentable_expression],
+    [$._block_statements, $._indentable_expression],
     [$.match_expression, $._simple_expression],
     // _  :  Type  •  '=>'  …
     [$.self_type, $._simple_expression],
@@ -1028,14 +1028,27 @@ module.exports = grammar({
         seq(field("name", $._identifier), ":", field("type", $._param_type)),
       ),
 
+    // Any separator may be followed by extra empty statements (`;`), so
+    // `}\n;{ ... }` parses like scalac. A semicolon-only block (`{ ;; }`)
+    // is kept as its own branch.
     _block: $ =>
+      prec.left(
+        choice(
+          seq(repeat1(";"), optional($._block_statements)),
+          $._block_statements,
+        ),
+      ),
+
+    _semis: $ => seq($._semicolon, repeat(";")),
+
+    _block_statements: $ =>
       prec.left(
         seq(
           sep1(
-            $._semicolon,
-            choice($.expression, $._definition, $._end_marker, ";"),
+            $._semis,
+            choice($.expression, $._definition, $._end_marker),
           ),
-          optional($._semicolon),
+          optional($._semis),
         ),
       ),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2422,3 +2422,41 @@ inline def e(inline m: String): Unit =
               (boolean_literal))
             (quote_expression
               (identifier))))))))
+
+================================================================================
+Empty statements before a statement
+================================================================================
+
+object A {
+  def f = {
+    val x = 1
+    ;{
+      val y = 2
+    }
+  }
+  ;def g = 1
+  def h = { ;; }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (block
+          (val_definition
+            (identifier)
+            (integer_literal))
+          (block
+            (val_definition
+              (identifier)
+              (integer_literal)))))
+      (function_definition
+        (identifier)
+        (integer_literal))
+      (function_definition
+        (identifier)
+        (block)))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

scalac accepts extra empty statements around any statement separator. `_block` now uses `_semis` as the separator, a `;` or newline followed by extra `;`. Leading semicolons like `;{ ... }` and `;def` get a dedicated choice branch. The semicolon-only block `{ ;; }` stays valid through that same branch.

Seen in slick [doc/code Connection.scala](https://github.com/slick/slick/blob/6d24b1511e54a1b024e397f4474e39afbae05cba/doc/code/Connection.scala#L54), [OrmToSlick.scala ](https://github.com/slick/slick/blob/6d24b1511e54a1b024e397f4474e39afbae05cba/doc/code/OrmToSlick.scala#L69)and [DBIOCombinators.scala.](https://github.com/slick/slick/blob/6d24b1511e54a1b024e397f4474e39afbae05cba/doc/code/DBIOCombinators.scala#L13)