### PR TITLE
feat: read `|` after a definition type annotation as a union type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -107,6 +107,8 @@ module.exports = grammar({
     [$._full_enum_def],
     // _start_val  identifier  ','  identifier  •  ':'  …
     [$.identifiers, $.val_declaration],
+    [$.val_declaration, $._definition_pattern],
+    [$.var_declaration, $._definition_pattern],
     // 'enum'  operator_identifier  _automatic_semicolon  '('  ')'  •  ':'  …
     [$.class_parameters],
     // 'for'  operator_identifier  ':'  _annotated_type  •  ':'  …
@@ -119,8 +121,6 @@ module.exports = grammar({
     [$._variant_type_parameter, $.type_lambda],
     // 'given'  '('  operator_identifier  ':'  _type  •  ','  …
     [$.name_and_type, $.parameter],
-    [$._simple_expression, $.binding, $.tuple_pattern],
-    [$._simple_expression, $.tuple_pattern],
     [$._simple_expression, $._type_identifier],
     // 'if'  parenthesized_expression  •  '{'  …
     [$._if_condition, $._simple_expression],
@@ -678,7 +678,7 @@ module.exports = grammar({
     val_definition: $ =>
       seq(
         $._start_val,
-        field("pattern", choice($._pattern, $.identifiers)),
+        field("pattern", choice($._definition_pattern, $.identifiers)),
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
@@ -705,7 +705,7 @@ module.exports = grammar({
     var_definition: $ =>
       seq(
         $._start_var,
-        field("pattern", choice($._pattern, $.identifiers)),
+        field("pattern", choice($._definition_pattern, $.identifiers)),
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
@@ -1297,6 +1297,17 @@ module.exports = grammar({
 
     _pattern: $ =>
       choice(
+        $._definition_pattern,
+        $.alternative_pattern,
+        $.typed_pattern,
+        $.repeat_pattern,
+      ),
+
+    // SLS 4.1: the pattern of a val/var definition is a Pattern2, so no
+    // top-level alternatives or ascription. `val a: A | B` then reads `|`
+    // as a union type instead of an alternative pattern.
+    _definition_pattern: $ =>
+      choice(
         $._identifier,
         $.stable_identifier,
         $.interpolated_string_expression,
@@ -1305,13 +1316,10 @@ module.exports = grammar({
         $.named_tuple_pattern,
         $.case_class_pattern,
         $.infix_pattern,
-        $.alternative_pattern,
-        $.typed_pattern,
         $.given_pattern,
         $.quote_expression,
         $.literal,
         $.wildcard,
-        $.repeat_pattern,
       ),
 
     case_class_pattern: $ =>
@@ -1325,13 +1333,15 @@ module.exports = grammar({
         ")",
       ),
 
+    // Operands are _definition_pattern: a full _pattern would re-admit the
+    // excluded items through the left recursion.
     infix_pattern: $ =>
       prec.left(
         PREC.infix,
         seq(
-          field("left", $._pattern),
+          field("left", $._definition_pattern),
           field("operator", $._identifier),
-          field("right", $._pattern),
+          field("right", $._definition_pattern),
         ),
       ),
 

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -59,6 +59,52 @@ class $A$B$ {
         (type_identifier)))))
 
 ================================================================================
+Union types in val and var definitions and declarations
+================================================================================
+
+trait T {
+  val a: AnyRef | Null = null
+  var b: Link[?] | Null
+  val c: Int | String
+  val h :: t = xs
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_identifier))
+        (null_literal))
+      (var_declaration
+        (identifier)
+        (infix_type
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier)))
+          (operator_identifier)
+          (type_identifier)))
+      (val_declaration
+        (identifier)
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_identifier)))
+      (val_definition
+        (infix_pattern
+          (identifier)
+          (operator_identifier)
+          (identifier))
+        (identifier)))))
+
+================================================================================
 Operator identifiers
 ================================================================================
 


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.


`val a: AnyRef | Null = null` misparsed the `|` as an alternative_pattern. Declarations like `var b: Link[?] | Null` were errors. [SLS 4.1 ](https://scala-lang.org/files/archive/spec/3.4/04-basic-definitions.html#value-definitions)restricts the pattern of a val/var definition to Pattern2. The new `_definition_pattern` rule excludes top-level alternative and typed patterns. Infix pattern operands are restricted too because the left recursion would re-admit them.

The two `tuple_pattern` conflicts become unnecessary with this restriction and are removed. The generated parser is byte-identical with or without them.

Seen in [scala3 StreamExtensions.scala](https://github.com/scala/scala3/blob/edb79837372a79f8060bfff0dee641ced94d085c/library/src/scala/collection/convert/StreamExtensions.scala#L534).