### PR TITLE
fix: accept `do` and bare indented bodies after parenthesized for enumerators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -28,6 +28,11 @@ const fatArrow = () => choice("=>", alias("⇒", "=>"));
 // `=>` or the context-function arrow `?=>`.
 const anyArrow = () => choice(fatArrow(), "?=>");
 
+// An expression as admitted in statement and RHS positions. do_while lives
+// outside $.expression: after `for (...)` a `do` must introduce the for's own
+// body, and a do-while fork there doubles the paren-for automaton (~+7MiB).
+const statementExpression = ($) => choice($.expression, $.do_while_expression);
+
 module.exports = grammar({
   name: "scala",
 
@@ -242,7 +247,7 @@ module.exports = grammar({
       ),
 
     _top_level_definition: $ =>
-      choice($._definition, $._end_marker, $.expression),
+      choice($._definition, $._end_marker, statementExpression($)),
 
     _definition: $ =>
       choice(
@@ -1044,13 +1049,26 @@ module.exports = grammar({
     _block_statements: $ =>
       prec.left(
         seq(
-          sep1($._semis, choice($.expression, $._definition, $._end_marker)),
+          sep1(
+            $._semis,
+            choice(
+              statementExpression($),
+              $._definition,
+              $._end_marker,
+            ),
+          ),
           optional($._semis),
         ),
       ),
 
     _indentable_expression: $ =>
-      prec.right(choice($.indented_block, $.indented_cases, $.expression)),
+      prec.right(
+        choice(
+          $.indented_block,
+          $.indented_cases,
+          statementExpression($),
+        ),
+      ),
 
     block: $ =>
       seq(
@@ -1389,7 +1407,6 @@ module.exports = grammar({
         $.return_expression,
         $.throw_expression,
         $.while_expression,
-        $.do_while_expression,
         $.for_expression,
         $.macro_body,
         $._simple_expression,
@@ -1611,7 +1628,7 @@ module.exports = grammar({
         seq(
           field("left", choice($.prefix_expression, $._simple_expression)),
           "=",
-          field("right", choice($.expression, $.indented_block)),
+          field("right", choice(statementExpression($), $.indented_block)),
         ),
       ),
 
@@ -2120,7 +2137,8 @@ module.exports = grammar({
 
     unit: $ => prec(PREC.unit, seq("(", ")")),
 
-    return_expression: $ => prec.left(seq("return", optional($.expression))),
+    return_expression: $ =>
+      prec.left(seq("return", optional(statementExpression($)))),
 
     throw_expression: $ => prec.left(seq("throw", $.expression)),
 
@@ -2178,7 +2196,8 @@ module.exports = grammar({
               ),
             ),
             choice(
-              seq(field("body", $.expression)),
+              field("body", $.expression),
+              seq("do", field("body", $._indentable_expression)),
               seq("yield", field("body", $._indentable_expression)),
             ),
           ),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1678,6 +1678,85 @@ def f() = {
             (identifier)))))))
 
 ================================================================================
+Do-while in assignment and return positions
+================================================================================
+
+object O {
+  var w = 0
+  w = do step() while (cond)
+  def r: Unit = { return do step() while (cond) }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (var_definition
+        (identifier)
+        (integer_literal))
+      (assignment_expression
+        (identifier)
+        (do_while_expression
+          (call_expression
+            (identifier)
+            (arguments))
+          (parenthesized_expression
+            (identifier))))
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (block
+          (return_expression
+            (do_while_expression
+              (call_expression
+                (identifier)
+                (arguments))
+              (parenthesized_expression
+                (identifier)))))))))
+
+================================================================================
+Do-while in statement positions
+================================================================================
+
+do g() while (c)
+
+val v = do g() while (c)
+
+def f =
+  do g() while (c)
+  1
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (do_while_expression
+    (call_expression
+      (identifier)
+      (arguments))
+    (parenthesized_expression
+      (identifier)))
+  (val_definition
+    (identifier)
+    (do_while_expression
+      (call_expression
+        (identifier)
+        (arguments))
+      (parenthesized_expression
+        (identifier))))
+  (function_definition
+    (identifier)
+    (indented_block
+      (do_while_expression
+        (call_expression
+          (identifier)
+          (arguments))
+        (parenthesized_expression
+          (identifier)))
+      (integer_literal))))
+
+================================================================================
 For comprehensions
 ================================================================================
 
@@ -2460,3 +2539,61 @@ object A {
       (function_definition
         (identifier)
         (block)))))
+
+================================================================================
+Parenthesized for with do, and yield on the next line
+================================================================================
+
+def f =
+  for ((a, b) <- xs) do
+    g(a)
+  for (param <- params; idx <- indices(param))
+  yield param.name
+  for (typearg <- tree.typeargs)
+  do
+    h(typearg)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (for_expression
+        (enumerators
+          (enumerator
+            (tuple_pattern
+              (identifier)
+              (identifier))
+            (identifier)))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier)))))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (identifier))
+          (enumerator
+            (identifier)
+            (call_expression
+              (identifier)
+              (arguments
+                (identifier)))))
+        (field_expression
+          (identifier)
+          (identifier)))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (field_expression
+              (identifier)
+              (identifier))))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.


`for (x <- xs) do body` and a bare indented body after `for (...)` were errors. Adding a `do` branch there while do_while stays inside `$.expression` would make `do` ambiguous after `for (...)` and grow parser.c by about 7MiB. Instead `do_while_expression` moves out of `$.expression`. The new `statementExpression` helper re-admits it in statement and RHS positions. Assignment right-hand sides and `return` keep accepting do-while through the helper.

Seen in scala3 [ParsedLogicalPackage.scala](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala#L97), [Typer.scala ](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/compiler/src/dotty/tools/dotc/typer/Typer.scala#L3068)and [Run.scala](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/compiler/src/dotty/tools/dotc/Run.scala#L417-L418)