### PR TITLE
fix: ascription to function types and ascribed match expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -28,6 +28,9 @@ const fatArrow = () => choice("=>", alias("⇒", "=>"));
 // `=>` or the context-function arrow `?=>`.
 const anyArrow = () => choice(fatArrow(), "?=>");
 
+const ascriptionArrowTail = ($) =>
+  seq(anyArrow(), field("return_type", $._param_type));
+
 // An expression as admitted in statement and RHS positions. do_while lives
 // outside $.expression: after `for (...)` a `do` must introduce the for's own
 // body, and a do-while fork there doubles the paren-for automaton (~+7MiB).
@@ -97,6 +100,7 @@ module.exports = grammar({
     [$.while_expression, $._simple_expression],
     [$.if_expression],
     [$.match_expression],
+    [$._type_identifier, $.ascription_expression],
     [$._given_constructor, $._type_identifier],
     [$.instance_expression],
     // In case of: 'extension'  _indent  '{'  'case'  operator_identifier  'if'  operator_identifier  •  '=>'  …
@@ -1718,12 +1722,30 @@ module.exports = grammar({
     /**
      * PostfixExpr [Ascription]
      */
+    // The arrow tail lives here (not via $.function_type) because after `:`
+    // the function-type reading loses statically to self-type/lambda readings.
+    // The dynamic penalty keeps `{ x: Int => body }` a lambda, like scalac.
     ascription_expression: $ =>
       prec.left(
         seq(
-          $._postfix_expression_choice,
+          choice($._postfix_expression_choice, $.match_expression),
           ":",
-          choice($._param_type, $.annotation),
+          choice(
+            seq(
+              field("type", $._param_type),
+              repeat(prec(1, prec.dynamic(-1, ascriptionArrowTail($)))),
+            ),
+            // The alias shares the `identifier '=>'` token path with
+            // colon_argument's lambda start (shift/shift, not shift/reduce).
+            prec.dynamic(
+              -1,
+              seq(
+                field("type", alias($._identifier, $.type_identifier)),
+                repeat1(ascriptionArrowTail($)),
+              ),
+            ),
+            $.annotation,
+          ),
         ),
       ),
 
@@ -1740,13 +1762,11 @@ module.exports = grammar({
             ),
           ),
           field("operator", $._identifier),
+          // No colon-argument choice here: postfix_expression already covers
+          // `a op:` bodies, and it shadowed postfix ascriptions.
           field(
             "right",
-            choice(
-              $.prefix_expression,
-              $._simple_expression,
-              seq(":", $.colon_argument),
-            ),
+            choice($.prefix_expression, $._simple_expression),
           ),
         ),
       ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -118,6 +118,10 @@
 
 (infix_expression operator: (identifier) @operator)
 (infix_expression operator: (operator_identifier) @operator)
+; An operator taking a colon argument parses as a postfix expression call.
+(call_expression
+  function: (postfix_expression (identifier) @operator .)
+  arguments: (colon_argument))
 (infix_type operator: (operator_identifier) @operator)
 (infix_type operator: (operator_identifier) @operator)
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -215,9 +215,10 @@ class C:
               (identifier)
               (arguments
                 (string))))))
-      (infix_expression
-        (identifier)
-        (identifier)
+      (call_expression
+        (postfix_expression
+          (identifier)
+          (identifier))
         (colon_argument
           (indented_block
             (val_definition
@@ -2597,3 +2598,129 @@ def f =
             (identifier)
             (arguments
               (identifier))))))))
+
+================================================================================
+Ascription to function types
+================================================================================
+
+object A {
+  val a = (this.unsubscribe: ActorRef => Unit)
+  val b = (fooMock.overloaded[Double]: Double => String).expects(1.0)
+  val c = PriorityGenerator({ case 1 => 2 }: Any => Int)
+  val d = (1 second: Duration)
+  val e = (identity _ : Int => Int)
+  val f = (handler: String => Context ?=> String)
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (type_identifier)
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (field_expression
+            (parenthesized_expression
+              (ascription_expression
+                (generic_function
+                  (field_expression
+                    (identifier)
+                    (identifier))
+                  (type_arguments
+                    (type_identifier)))
+                (type_identifier)
+                (type_identifier)))
+            (identifier))
+          (arguments
+            (floating_point_literal))))
+      (val_definition
+        (identifier)
+        (call_expression
+          (identifier)
+          (arguments
+            (ascription_expression
+              (case_block
+                (case_clause
+                  (integer_literal)
+                  (integer_literal)))
+              (type_identifier)
+              (type_identifier)))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (postfix_expression
+              (integer_literal)
+              (identifier))
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (method_value
+              (identifier)
+              (wildcard))
+            (type_identifier)
+            (type_identifier))))
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (lambda_expression
+            (identifier)
+            (type_identifier)
+            (lambda_expression
+              (identifier)
+              (identifier))))))))
+
+================================================================================
+Ascribed match expression (`}: @unchecked`)
+================================================================================
+
+def f =
+  val (a, b) = info match {
+    case Poly(tps, cinfo) => (tps, cinfo)
+    case cinfo => (Nil, cinfo)
+  }: @unchecked
+  a
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (val_definition
+        (tuple_pattern
+          (identifier)
+          (identifier))
+        (ascription_expression
+          (match_expression
+            (identifier)
+            (case_block
+              (case_clause
+                (case_class_pattern
+                  (type_identifier)
+                  (identifier)
+                  (identifier))
+                (tuple_expression
+                  (identifier)
+                  (identifier)))
+              (case_clause
+                (identifier)
+                (tuple_expression
+                  (identifier)
+                  (identifier)))))
+          (annotation
+            (type_identifier))))
+      (identifier))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

`(f: Int => Int)` and `(1 second: Duration)` and `({ ... }: Any => Int)` were errors. `ascription_expression` gains an optional arrow tail after the ascribed type. A bare identifier parameter shares its `identifier '=>'` token path with the colon_argument lambda start. `match { ... }: @unchecked` works by admitting match_expression on the left. The infix colon-argument branch is removed.
It statically shadowed postfix ascriptions and postfix_expression plus call_expression already covers `a op:` bodies. The SIP-44 expected tree for a backquoted operator taking a colon argument changes accordingly.

Seen in akka [EventBus.scala ](https://github.com/akka/akka-core/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/akka-actor/src/main/scala/akka/event/EventBus.scala#L299-L300)and [DurationSpec.scala](https://github.com/akka/akka-core/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/akka-actor-tests/src/test/scala/akka/util/DurationSpec.scala#L90-L94), scalamock [OverloadedMethodsTest.scala](https://github.com/scalamock/scalamock/blob/4562f63e5b8ec8aecaa720652648e5157bb09fc6/core/shared/src/test/scala/com/paulbutcher/test/mock/OverloadedMethodsTest.scala#L51) and [NewApiSpec.scala](https://github.com/scalamock/scalamock/blob/4562f63e5b8ec8aecaa720652648e5157bb09fc6/core/shared/src/test/scala-3/newapi/NewApiSpec.scala#L566), and scala3 [Scala2Unpickler.scala](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala#L83-L86).