### PR TITLE
fix: capture patterns and free escapes inside interpolated strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2059,7 +2059,18 @@ module.exports = grammar({
       alias($._interpolation_identifier, $.identifier),
 
     interpolation: $ =>
-      seq("$", choice($._aliased_interpolation_identifier, $.block)),
+      seq(
+        "$",
+        choice(
+          $._aliased_interpolation_identifier,
+          $.block,
+          // In pattern position an interpolation may hold a capture pattern,
+          // e.g. `case q"${name @ Ident(_)}" =>`. Restricted to
+          // capture_pattern to keep the pattern grammar out of expression
+          // interpolations.
+          prec.dynamic(-1, seq("{", $.capture_pattern, "}")),
+        ),
+      ),
 
     interpolated_string: $ =>
       choice(
@@ -2133,6 +2144,10 @@ module.exports = grammar({
             // language, so I think it makes sense to allow them. Maybe in the future we
             // should move them to a `deprecated` syntax node?
             /[0-3]?[0-7]{1,2}/,
+            // Any other escaped character. scalac accepts these at the lexer
+            // level in interpolated strings (their validity depends on the
+            // interpolator, e.g. quasiquotes accept a plain `\`).
+            /[^\r\n]/,
           ),
         ),
       ),

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -386,3 +386,73 @@ yield ()
           (arguments
             (integer_literal)))))
     (unit)))
+
+================================================================================
+Capture patterns inside string interpolation patterns
+================================================================================
+
+object A {
+  def f = t match {
+    case q"${name0 @ CompanianAliases(Name(_))}.$_" => 1
+    case p"/items/${idString @ int(id)}" => 2
+  }
+  val t = q"$JsPath \ $cn"
+  val s"${RootPackageName @ _}/" = RootPackage
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (match_expression
+          (identifier)
+          (case_block
+            (case_clause
+              (interpolated_string_expression
+                (identifier)
+                (interpolated_string
+                  (interpolation
+                    (capture_pattern
+                      (identifier)
+                      (case_class_pattern
+                        (type_identifier)
+                        (case_class_pattern
+                          (type_identifier)
+                          (wildcard)))))
+                  (interpolation
+                    (identifier))))
+              (integer_literal))
+            (case_clause
+              (interpolated_string_expression
+                (identifier)
+                (interpolated_string
+                  (interpolation
+                    (capture_pattern
+                      (identifier)
+                      (case_class_pattern
+                        (type_identifier)
+                        (identifier))))))
+              (integer_literal)))))
+      (val_definition
+        (identifier)
+        (interpolated_string_expression
+          (identifier)
+          (interpolated_string
+            (interpolation
+              (identifier))
+            (escape_sequence)
+            (interpolation
+              (identifier)))))
+      (val_definition
+        (interpolated_string_expression
+          (identifier)
+          (interpolated_string
+            (interpolation
+              (capture_pattern
+                (identifier)
+                (wildcard)))))
+        (identifier)))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

Quasiquote patterns like `case q"${name @ Ident(_)}" =>` were errors. `interpolation` gains a capture_pattern branch with a dynamic penalty. The penalty keeps the pattern grammar out of expression interpolations. The branch also covers val definition patterns like `val s"${name @ _}/" = x`. `escape_sequence` also accepts any other escaped character like `\ `.
scalac accepts those at the lexer level and leaves validity to the interpolator.

Seen in zio [Zio2Upgrade.scala](https://github.com/zio/zio/blob/13a1ac1af36cfdb0bd7231c073f94ea0f239c0ea/scalafix/rules/src/main/scala/fix/Zio2Upgrade.scala#L646), playframework ScalaSirdRouter.scala, play-json [JsMacroImpl.scala ](https://github.com/playframework/playframework/blob/0fbcf712635e1f3fa84d6a6e97521efc39e13f84/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala#L189-L190)and scala3 [Scala3.scala](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala#L187-L188).