### PR TITLE
feat: Unicode math symbols as single-character type operators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1966,7 +1966,7 @@ module.exports = grammar({
             // Technically speaking, Sm (Math symbols https://www.compart.com/en/unicode/category/Sm)
             // should be allowed as a single-character opchar, however, it includes `=`,
             // so we should to avoid that to prevent bad parsing of `=` as infix term or type.
-            /[\-!#%&*+\/\\<>?\u005e\u007c~\u00ac\u00b1\u00d7\u00f7\u2190-\u2194\p{So}]/,
+            /[\-!#%&*+\/\\<>?\u005e\u007c~\u00ac\u00b1\u00d7\u00f7\u2190-\u2194\u2200-\u22ff\p{So}]/,
             seq(
               // opchar minus slash
               /[\-!#%&*+\\:<=>?@\u005e\u007c~\p{Sm}\p{So}]/,

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -809,6 +809,148 @@ val c: C(42)
         (integer_literal)))))
 
 ================================================================================
+Unicode math symbols as type operators
+================================================================================
+
+object P {
+  type ¬[T] = T => Nothing
+  type ∨[T, U] = ¬[¬[T] ∧ ¬[U]]
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (type_definition
+        (type_identifier)
+        (type_parameters
+          (identifier))
+        (function_type
+          (parameter_types
+            (type_identifier))
+          (type_identifier)))
+      (type_definition
+        (type_identifier)
+        (type_parameters
+          (identifier)
+          (identifier))
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (infix_type
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier)))
+              (operator_identifier)
+              (generic_type
+                (type_identifier)
+                (type_arguments
+                  (type_identifier))))))))))
+
+================================================================================
+Common math symbols as operator identifiers
+================================================================================
+
+object Q {
+  type ∃[P[_]] = P[Int]
+  def ∅ : Set[Int] = Set.empty
+  def ∈(x: Int): Boolean = false
+  val u = a ∪ b
+  val i = a ∩ b
+  val c = f ∘ g
+  val e = x ≡ y
+  val q = x ≟ y
+  val s = m ⊕ n
+  val t = m ⊗ n
+  val l = m ⊸ n
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (type_definition
+        (type_identifier)
+        (type_parameters
+          (identifier)
+          (type_parameters
+            (wildcard)))
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier))))
+      (function_definition
+        (operator_identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier)))
+        (field_expression
+          (identifier)
+          (identifier)))
+      (function_definition
+        (operator_identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (type_identifier)
+        (boolean_literal))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (val_definition
+        (identifier)
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier))))))
+
+================================================================================
 Existential types (Scala 2)
 ================================================================================
 


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

Type operators like `∧` and `∨` were errors.
SLS 1.1 admits [Unicode math symbols (Sm) as opchars.](https://github.com/scala/scala3/blob/4dae25087df0ba25b8f1b05a4337fe9d73f79aa2/docs/_docs/internals/syntax.md#L43) The single-character opchar class gains the Mathematical Operators block `U+2200-U+22FF`. The full `Sm` category stays excluded because it contains `=`.

Seen in shapeless [package.scala](https://github.com/milessabin/shapeless/blob/99efca64f4f5fe27c7b1c3391403fed1ba3f3320/core/shared/src/main/scala/shapeless/package.scala#L30-L36).