### PR TITLE
fix: soft keyword `extension` and Scala 3 keywords in import paths

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -95,6 +95,9 @@ module.exports = grammar({
   conflicts: $ => [
     [$.tuple_type, $.parameter_types],
     [$.inline_modifier, $._soft_identifier],
+    // 'extension' • '{' is either an extension definition with a braced body
+    // or the soft identifier `extension` (a Scala 2 id) called with a block.
+    [$.extension_definition, $._soft_identifier],
     [$.binding, $._simple_expression],
     [$.binding, $._type_identifier],
     [$.while_expression, $._simple_expression],
@@ -367,7 +370,7 @@ module.exports = grammar({
       prec.left(
         choice(
           seq(
-            field("path", sep1(".", $._identifier)),
+            field("path", sep1(".", $._namespace_path_segment)),
             optional(
               seq(
                 ".",
@@ -385,6 +388,11 @@ module.exports = grammar({
           $.as_renamed_identifier,
         ),
       ),
+
+    // Scala 3 keywords that are valid identifiers in Scala 2 sources and thus
+    // may appear as package names in import/export paths (e.g. `import io.circe.export.Exported`).
+    _namespace_path_segment: $ =>
+      choice($._identifier, alias(choice("enum", "export"), $.identifier)),
 
     namespace_wildcard: $ => prec.left(1, choice("*", "_", "given")),
 
@@ -1893,6 +1901,7 @@ module.exports = grammar({
           "tracked",
           "transparent",
           "end",
+          "extension",
         ),
       ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -167,9 +167,12 @@
   "using"
   "end"
   "implicit"
-  "extension"
   "with"
 ] @keyword
+
+; `extension` is a soft keyword. Highlight it only where it starts an
+; extension definition, not when used as a plain identifier.
+(extension_definition "extension" @keyword)
 
 [
   "abstract"

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2328,3 +2328,27 @@ object A {
             (identifier)
             (arguments
               (identifier))))))))
+
+================================================================================
+Scala 3 keywords as import path segments
+================================================================================
+
+import io.circe.export.Exported
+import sttp.tapir.generated.reuse.enum.TapirGeneratedEndpoints.Status
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (import_declaration
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)
+    (identifier)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2724,3 +2724,59 @@ def f =
           (annotation
             (type_identifier))))
       (identifier))))
+
+================================================================================
+Soft keyword extension used as an identifier
+================================================================================
+
+object A {
+  def journal: ActorRef =
+    extension.journalFor(null)
+  def f = x match {
+    case 1 =>
+      extension.remove(name)
+      Behaviors.same
+  }
+  val s = s"snapshot-${extension}"
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (type_identifier)
+        (indented_block
+          (call_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (arguments
+              (null_literal)))))
+      (function_definition
+        (identifier)
+        (match_expression
+          (identifier)
+          (case_block
+            (case_clause
+              (integer_literal)
+              (call_expression
+                (field_expression
+                  (identifier)
+                  (identifier))
+                (arguments
+                  (identifier)))
+              (field_expression
+                (identifier)
+                (identifier))))))
+      (val_definition
+        (identifier)
+        (interpolated_string_expression
+          (identifier)
+          (interpolated_string
+            (interpolation
+              (block
+                (identifier)))))))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.
 
`extension.journalFor(null)` and `import io.circe.export.Exported` were errors. `extension` joins the soft identifier list with a GLR conflict against extension_definition. Import and export paths accept `enum` and `export` segments through a new `_namespace_path_segment` rule. Those are valid identifiers in Scala 2 sources and appear as package names. The highlight query now marks `extension` as a keyword only in extension definitions.

Seen in akka [JournalSpec.scala](https://github.com/akka/akka-core/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalSpec.scala#L82), circe [ExportMacros.scala](https://github.com/circe/circe/blob/2fb611bb49619e4287b6ac048d2283c2781f4943/modules/generic-simple/src/main/scala/io/circe/generic/simple/util/macros/ExportMacros.scala#L4) and tapir [Main.scala](http://github.com/softwaremill/tapir/blob/6a0d3c349046c4357e9d53126ef4e7f0ac5dbee5/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/src/main/scala/Main.scala#L6).