### PR TITLE
fix: bare `$` identifier called with arguments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1844,17 +1844,15 @@ module.exports = grammar({
     // ExprsInParens     ::=  ExprInParens {‘,’ ExprInParens}
     _exprs_in_parens: $ => trailingCommaSep1($.expression),
 
+    // The opening is a single two-character token so that a bare `$` used as
+    // an ordinary identifier (e.g. `$(selector)`) still lexes as an
+    // identifier. A `$ident` splice already lexes as one identifier anyway.
     splice_expression: $ =>
       prec.left(
         PREC.macro,
-        seq(
-          "$",
-          choice(
-            seq("{", $._block, "}"),
-            seq("[", $._type, "]"),
-            // TODO: This would never hit, since identifier permits $ sign
-            $.identifier,
-          ),
+        choice(
+          seq("${", $._block, "}"),
+          seq("$[", $._type, "]"),
         ),
       ),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2780,3 +2780,49 @@ object A {
             (interpolation
               (block
                 (identifier)))))))))
+
+================================================================================
+Bare dollar identifier called with arguments
+================================================================================
+
+object A {
+  def f = {
+    $(s"$selector *[name=$fieldName]").fill.`with`(fieldValue)
+    $(selector).submit()
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (identifier)
+        (block
+          (call_expression
+            (field_expression
+              (field_expression
+                (call_expression
+                  (identifier)
+                  (arguments
+                    (interpolated_string_expression
+                      (identifier)
+                      (interpolated_string
+                        (interpolation
+                          (identifier))
+                        (interpolation
+                          (identifier))))))
+                (identifier))
+              (identifier))
+            (arguments
+              (identifier)))
+          (call_expression
+            (field_expression
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier)))
+              (identifier))
+            (arguments)))))))


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547
- Corresponding issue: None.

`$(selector).submit()` misread the `$` as the start of a splice. The splice opening becomes the two-character tokens `${` and `$[`. A bare `$` before a parenthesis then lexes as an ordinary identifier. The dead `$ident` branch of splice_expression is removed because a `$ident` splice already lexes as one identifier.

Seen in playframework [Selenium.scala](https://github.com/playframework/playframework/blob/0fbcf712635e1f3fa84d6a6e97521efc39e13f84/testkit/play-test/src/main/scala/play/api/test/Selenium.scala#L41-L43)