### PR TITLE
fix: annotation arguments and multiple argument lists in extends clauses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -887,8 +887,16 @@ module.exports = grammar({
           // but doing so increases the state of template_body to 4000
           $._structural_type,
           // This adds _simple_type, but not the above intentionally.
-          seq($._simple_type, field("arguments", $.arguments)),
-          seq($._annotated_type, field("arguments", $.arguments)),
+          // Constructor arguments attach only to a non-annotated simple type.
+          // After an annotation, argument lists belong to the annotation.
+          // scalac parses annotation arguments greedily in the same way.
+          seq(
+            $._simple_type,
+            field(
+              "arguments",
+              repeat1(prec("constructor_application", $.arguments)),
+            ),
+          ),
         ),
       ),
 
@@ -944,13 +952,7 @@ module.exports = grammar({
      * InheritClauses    ::=  ['extends' ConstrApps] ['derives' QualId {',' QualId}]
      */
     extends_clause: $ =>
-      prec.left(
-        seq(
-          "extends",
-          field("type", $._constructor_applications),
-          repeat($.arguments),
-        ),
-      ),
+      prec.left(seq("extends", field("type", $._constructor_applications))),
 
     derives_clause: $ =>
       prec.left(

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -85,3 +85,26 @@ trait Function0[@specialized(Unit, Int, Double) T] {
     (type_parameters
       (annotation (type_identifier) (arguments (identifier) (identifier) (identifier))) (identifier))
     (template_body (function_declaration (identifier) (type_identifier)))))
+
+================================================================================
+Annotated parent type with annotation arguments
+================================================================================
+
+case class B2(s: String) extends Base @Second(3, "e") @Third(4)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter (identifier) (type_identifier)))
+    (extends_clause
+      (annotated_type
+        (type_identifier)
+        (annotation
+          (type_identifier)
+          (arguments (integer_literal) (string)))
+        (annotation
+          (type_identifier)
+          (arguments (integer_literal)))))))

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -641,6 +641,10 @@ class MyClass extends Potato() with Tomato
 
 class A extends B(c)(d)(e)
 
+class G extends H(a, b)(c) with I[T]
+
+class J extends K(a)(using b), L[M]
+
 --------------------------------------------------------------------------------
 
 (compilation_unit
@@ -709,7 +713,32 @@ class A extends B(c)(d)(e)
       (arguments
         (identifier))
       (arguments
-        (identifier)))))
+        (identifier))))
+  (class_definition
+    (identifier)
+    (extends_clause
+      (type_identifier)
+      (arguments
+        (identifier)
+        (identifier))
+      (arguments
+        (identifier))
+      (generic_type
+        (type_identifier)
+        (type_arguments
+          (type_identifier)))))
+  (class_definition
+    (identifier)
+    (extends_clause
+      (type_identifier)
+      (arguments
+        (identifier))
+      (arguments
+        (identifier))
+      (generic_type
+        (type_identifier)
+        (type_arguments
+          (type_identifier))))))
 
 ================================================================================
 Subclass definitions (Scala 3 syntax)


### PR DESCRIPTION
- Spin-out from https://github.com/tree-sitter/tree-sitter-scala/pull/547

scalac reads annotation arguments greedily. In `extends B @Ann(x)` the `(x)` belongs to the annotation, not the constructor. The parser used to reduce the annotation empty and attach the arguments at the extends level. A following annotation such as `extends B @A(1) @B(2)` then broke.

Constructor argument lists now sit on _constructor_application as a repeat1 after a non-annotated simple type. extends_clause loses its own repeat(arguments). The repeat1 also fixes multiple argument lists followed by `with` or by comma-separated parents, as in `extends ValDef[T](a, b)(using NoSource) with W[T]`.

Annotation arguments seen in shapeless [annotation.scala](https://github.com/milessabin/shapeless/blob/99efca64f4f5/core/shared/src/test/scala/shapeless/annotation.scala#L50-L51). The multiple constructor argument lists are seen in scala3 [Trees.scala ](https://github.com/scala/scala3/blob/a036a3a/compiler/src/dotty/tools/dotc/ast/Trees.scala#L1089-L1090) and [untpd.scala](https://github.com/scala/scala3/blob/a036a3a/compiler/src/dotty/tools/dotc/ast/untpd.scala#L171).