### PR TITLE
fix: add bounds check before memcpy in array.h

### DIFF
--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -197,6 +197,7 @@ extern "C" {
 static inline void _array__erase(void* self_contents, uint32_t *size,
                                 size_t element_size, uint32_t index) {
   assert(index < *size);
+  if (index >= *size) return;
   char *contents = (char *)self_contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
           (*size - index - 1) * element_size);
@@ -257,10 +258,11 @@ static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t
                                  size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = *size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
   assert(old_end <= *size);
+  if (old_end > *size) return self_contents;
+  uint32_t new_size = *size - old_count + new_count;
 
   void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/tree_sitter/array.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `src/tree_sitter/array.h:196` |
| **Assessment** | Likely exploitable |

**Description**: Array manipulation functions use assert() for bounds checking, which is disabled in release builds (NDEBUG defined). Without these assertions, invalid indices or sizes can cause memmove/memcpy to access memory outside allocated buffers. The _array__splice function calculates new_size as '*size + new_count - old_count' which can underflow if old_count > *size + new_count.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-004` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/tree_sitter/array.h`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `src/tree_sitter/array.h:202`, `src/tree_sitter/array.h:227`, `src/tree_sitter/array.h:271`, `src/tree_sitter/array.h:279`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
