### PR TITLE
fix: keep an internal comma from closing an indented block

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -496,16 +496,46 @@ bool tree_sitter_scala_external_scanner_scan(void *payload, TSLexer *lexer,
     skip(lexer);
   }
 
-  // Separate from OUTDENT because the scanner cannot distinguish a comma that
-  // terminates an indented block (e.g. `map: x => f(x),`) from one that is
-  // internal to it (e.g. `case EnumCase1, EnumCase2`). By using a distinct
-  // token, tree-sitter only makes it valid in grammar contexts where comma
-  // termination is expected (colon_argument, _indentable_expression).
+  // COMMA_OUTDENT is a distinct token so tree-sitter only makes it valid
+  // where comma termination is expected (colon_argument,
+  // _indentable_expression). A comma terminates the indented block only when
+  // it ends its line. A comma with more code after it on the same line
+  // continues the statement and is internal to the block (`import a.b, c.d`,
+  // `extends A, B`, enum `case A, B`). A trailing comment still ends the line.
   if (valid_symbols[COMMA_OUTDENT] && lexer->lookahead == ',' && prev != -1) {
+    lexer->mark_end(lexer);
+    // Error recovery makes every symbol valid, so keep the eager pop there.
+    if (!valid_symbols[ERROR_SENTINEL]) {
+      advance(lexer);
+      bool ends_line = false;
+      for (;;) {
+        advance_past_blanks(lexer);
+        if (lexer->eof(lexer) || lexer->lookahead == '\n' ||
+            lexer->lookahead == '\r') {
+          ends_line = true;
+          break;
+        }
+        if (lexer->lookahead != '/') {
+          break;
+        }
+        advance(lexer);
+        if (lexer->lookahead == '/') {
+          ends_line = true;  // line comment runs to the line end
+          break;
+        }
+        if (lexer->lookahead != '*') {
+          break;  // a lone '/' is code
+        }
+        advance(lexer);
+        consume_block_comment_body(lexer);
+      }
+      if (!ends_line) {
+        return false;
+      }
+    }
     if (scanner->indents.size > 0) {
       array_pop(&scanner->indents);
     }
-    lexer->mark_end(lexer);
     lexer->result_symbol = COMMA_OUTDENT;
     return true;
   }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3129,3 +3129,49 @@ def f =
             (identifier)
             (identifier)))))))
 
+================================================================================
+Comma-separated parents in an extends clause inside an indented block
+================================================================================
+
+def transformType =
+  object reported extends TypeMap, IdentityCaptRefMap:
+    def apply(t: Type) = t
+  object toCapturing extends DeepTypeMap, SetupTypeMap {
+    override def toString = "x"
+  }
+  reported(tp)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (object_definition
+        (identifier)
+        (extends_clause
+          (type_identifier)
+          (type_identifier))
+        (template_body
+          (function_definition
+            (identifier)
+            (parameters
+              (parameter
+                (identifier)
+                (type_identifier)))
+            (identifier))))
+      (object_definition
+        (identifier)
+        (extends_clause
+          (type_identifier)
+          (type_identifier))
+        (template_body
+          (function_definition
+            (modifiers)
+            (identifier)
+            (string))))
+      (call_expression
+        (identifier)
+        (arguments
+          (identifier))))))
+


### PR DESCRIPTION
- spin-out from #547
- issue: None

A comma that continues its statement on the same line is internal to an indented block. Comma-separated parents, import lists, and enum cases all use one. The scanner now emits COMMA_OUTDENT only when the comma ends its line. A comma with code after it on the same line keeps the block open.

Seen in scala3 [Setup.scala](https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/compiler/src/dotty/tools/dotc/cc/Setup.scala#L446).