### PR TITLE
chore: reserve _colon_eol and _operator_eol external tokens

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -72,6 +72,12 @@ module.exports = grammar({
     // dead alternative and the scanner skips block comments there.
     $._suppress_block_comment,
     $.error_sentinel,
+    // Reserved for the follow-up scanner PR (a line-final `:` and a line-final
+    // symbolic operator). Declared here first so the generation bot enlarges
+    // parser.c before the scanner reads these slots. Placed last so every
+    // existing external keeps its index.
+    $._colon_eol,
+    $._operator_eol,
   ],
 
   inline: $ => [


### PR DESCRIPTION
First of two PRs.
Closes no issue.

Declares two external tokens (`_colon_eol` for #329), `_operator_eol` for #541 / #358 / #539) without using them yet. A follow-up scanner PR emits and consumes them.

Declaring them first lets the sync workflow enlarge `parser.c` before the scanner reads the new slots. Otherwise a single scanner PR runs its new scanner against the stale checked-in `parser.c`, and the fuzz job hits an out-of-bounds read on `valid_symbols`. Appended at the end so existing token indices are unchanged.

Behavior-neutral (dead alternatives, like `error_sentinel`): `generate` raises `EXTERNAL_TOKEN_COUNT` 23→25 with order unchanged, tests pass 192/192, and parse trees are byte-identical to master across the smoke corpus.