### PR TITLE
chore: reserve the floating point separators external token

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -83,6 +83,11 @@ module.exports = grammar({
     // existing external keeps its index.
     $._colon_eol,
     $._operator_eol,
+    // Reserved for the follow-up scanner PR that lexes a floating point literal
+    // whose integer part uses digit separators. Declared here first so the
+    // generation bot enlarges parser.c before the scanner reads this slot.
+    // Placed last so every existing external keeps its index.
+    $._floating_point_with_separators,
   ],
 
   inline: $ => [


### PR DESCRIPTION
Declare _floating_point_with_separators in the externals array, unreferenced for now. The follow-up scanner PR lexes a floating point literal whose integer part uses digit separators. Placed last so every existing external keeps its index. Behaviour is unchanged.

This will be used to parse `1_000.5` used in the Lila corpus.
