### PR TITLE
feat: start a colon argument with a context function lambda

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1710,7 +1710,9 @@ module.exports = grammar({
                   $._identifier,
                   $.wildcard,
                 ),
-                fatArrow(),
+                // anyArrow so a context-function lambda `x ?=>` also starts a
+                // colon argument, not only the plain `=>` form.
+                anyArrow(),
               ),
             ),
           ),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -249,6 +249,61 @@ class C:
             (identifier)))))))
 
 ================================================================================
+Colon argument with a context function lambda
+================================================================================
+
+class C:
+  me.foldUse(g): _ ?=>
+    xs.filter(h)
+  .topN(max)
+
+  xs.foldUse(g): ctx ?=>
+    val t = 1
+    t
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (call_expression
+        (field_expression
+          (call_expression
+            (call_expression
+              (field_expression
+                (identifier)
+                (identifier))
+              (arguments
+                (identifier)))
+            (colon_argument
+              (wildcard)
+              (indented_block
+                (call_expression
+                  (field_expression
+                    (identifier)
+                    (identifier))
+                  (arguments
+                    (identifier))))))
+          (identifier))
+        (arguments
+          (identifier)))
+      (call_expression
+        (call_expression
+          (field_expression
+            (identifier)
+            (identifier))
+          (arguments
+            (identifier)))
+        (colon_argument
+          (identifier)
+          (indented_block
+            (val_definition
+              (identifier)
+              (integer_literal))
+            (identifier)))))))
+
+================================================================================
 Trailing comma after for comprehension in lambda parameter of a function
 ================================================================================
 


### PR DESCRIPTION
A colon argument could start with a plain `x =>` lambda but not a context function `x ?=>` lambda. Use anyArrow so both forms open the argument. Without this the `?=>` fell into the block body and a dedented method chain after it failed to parse.

Seen in lila [Spotlight.scala,](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/tournament/src/main/Spotlight.scala#L28-L29) [SwissApi.scala](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/swiss/src/main/SwissApi.scala#L172-L173), [PuzzleBatch.scala ](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/puzzle/src/main/PuzzleBatch.scala#L28-L30)and [TournamentApi.scala](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/tournament/src/main/TournamentApi.scala#L293-L295).