### PR TITLE
feat: lex floating point literals with digit separators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -77,16 +77,8 @@ module.exports = grammar({
     // dead alternative and the scanner skips block comments there.
     $._suppress_block_comment,
     $.error_sentinel,
-    // Reserved for the follow-up scanner PR (a line-final `:` and a line-final
-    // symbolic operator). Declared here first so the generation bot enlarges
-    // parser.c before the scanner reads these slots. Placed last so every
-    // existing external keeps its index.
     $._colon_eol,
     $._operator_eol,
-    // Reserved for the follow-up scanner PR that lexes a floating point literal
-    // whose integer part uses digit separators. Declared here first so the
-    // generation bot enlarges parser.c before the scanner reads this slot.
-    // Placed last so every existing external keeps its index.
     $._floating_point_with_separators,
   ],
 
@@ -2053,6 +2045,7 @@ module.exports = grammar({
       choice(
         $.integer_literal,
         $.floating_point_literal,
+        alias($._floating_point_with_separators, $.floating_point_literal),
         $.boolean_literal,
         $.character_literal,
         $.string,
@@ -2075,15 +2068,20 @@ module.exports = grammar({
       token(
         seq(
           optional(/[-]/),
+          // Digit separators ('_') in the integer part are lexed by the
+          // scanner (_floating_point_with_separators); the internal regex
+          // cannot, because its DFA drops the `.` transition after an
+          // underscore-containing group. The fraction and exponent keep their
+          // separators here since the group sits at the end of the pattern.
           choice(
             // digit {digit} ‘.’ digit {digit} [exponentPart] [floatType]
-            seq(/[\d]+\.[\d]+/, optional(/[eE][+-]?[\d]+/), optional(/[dfDF]/)),
+            seq(/[\d]+\.[\d](_?\d)*/, optional(/[eE][+-]?[\d](_?\d)*/), optional(/[dfDF]/)),
             // ‘.’ digit {digit} [exponentPart] [floatType]
-            seq(/\.[\d]+/, optional(/[eE][+-]?[\d]+/), optional(/[dfDF]/)),
+            seq(/\.[\d](_?\d)*/, optional(/[eE][+-]?[\d](_?\d)*/), optional(/[dfDF]/)),
             // digit {digit} exponentPart [floatType]
-            seq(/[\d]+/, /[eE][+-]?[\d]+/, optional(/[dfDF]/)),
+            seq(/[\d]+/, /[eE][+-]?[\d](_?\d)*/, optional(/[dfDF]/)),
             // digit {digit} [exponentPart] floatType
-            seq(/[\d]+/, optional(/[eE][+-]?[\d]+/), /[dfDF]/),
+            seq(/[\d]+/, optional(/[eE][+-]?[\d](_?\d)*/), /[dfDF]/),
           ),
         ),
       ),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -38,7 +38,8 @@ enum TokenType {
   SUPPRESS_BLOCK_COMMENT,
   ERROR_SENTINEL,
   COLON_EOL,
-  OPERATOR_EOL
+  OPERATOR_EOL,
+  FLOATING_POINT_WITH_SEPARATORS
 };
 
 const char* token_name[] = {
@@ -66,7 +67,8 @@ const char* token_name[] = {
   "SUPPRESS_BLOCK_COMMENT",
   "ERROR_SENTINEL",
   "COLON_EOL",
-  "OPERATOR_EOL"
+  "OPERATOR_EOL",
+  "FLOATING_POINT_WITH_SEPARATORS"
 };
 
 typedef struct {
@@ -657,6 +659,75 @@ static LineScan scan_rest_of_line(TSLexer *lexer) {
   return r;
 }
 
+// Consumes `digit (digit | '_' digit)*`. Sets *saw_sep if a separator appears.
+static bool consume_digit_group(TSLexer *lexer, bool *saw_sep) {
+  if (lexer->lookahead < '0' || lexer->lookahead > '9') {
+    return false;
+  }
+  advance(lexer);
+  for (;;) {
+    if (lexer->lookahead >= '0' && lexer->lookahead <= '9') {
+      advance(lexer);
+    } else if (lexer->lookahead == '_') {
+      advance(lexer);
+      if (lexer->lookahead < '0' || lexer->lookahead > '9') {
+        return false;
+      }
+      if (saw_sep) {
+        *saw_sep = true;
+      }
+      advance(lexer);
+    } else {
+      return true;
+    }
+  }
+}
+
+// Lexes a floating point literal whose integer part uses digit separators, e.g.
+// `1_000.5`. The internal regex cannot. After an underscore-containing group
+// its DFA loses the transition to the following `.`.
+static bool scan_float_with_separator(TSLexer *lexer) {
+  bool int_sep = false;
+  if (!consume_digit_group(lexer, &int_sep)) {
+    return false;
+  }
+  // Only the integer-part separator is ours. Without one the internal lexer
+  // lexes the number, so bail before walking the fraction and exponent.
+  if (!int_sep) {
+    return false;
+  }
+  bool is_float = false;
+  if (lexer->lookahead == '.') {
+    advance(lexer);
+    if (!consume_digit_group(lexer, NULL)) {
+      return false;
+    }
+    is_float = true;
+  }
+  if (lexer->lookahead == 'e' || lexer->lookahead == 'E') {
+    advance(lexer);
+    if (lexer->lookahead == '+' || lexer->lookahead == '-') {
+      advance(lexer);
+    }
+    if (!consume_digit_group(lexer, NULL)) {
+      return false;
+    }
+    is_float = true;
+  }
+  if (lexer->lookahead == 'd' || lexer->lookahead == 'D' ||
+      lexer->lookahead == 'f' || lexer->lookahead == 'F') {
+    advance(lexer);
+    is_float = true;
+  }
+  // A bare integer with separators (`1_000`) is the internal lexer's job.
+  if (!is_float) {
+    return false;
+  }
+  lexer->mark_end(lexer);
+  lexer->result_symbol = FLOATING_POINT_WITH_SEPARATORS;
+  return true;
+}
+
 static inline void debug_indents(Scanner *scanner) {
   LOG("    indents(%d): ", scanner->indents.size);
   for (unsigned i = 0; i < scanner->indents.size; i++) {
@@ -1118,6 +1189,13 @@ static bool scan_impl(void *payload, TSLexer *lexer,
       newline_count++;
     }
     skip(lexer);
+  }
+
+  // A floating point literal whose integer part uses digit separators.
+  if (valid_symbols[FLOATING_POINT_WITH_SEPARATORS] &&
+      !valid_symbols[ERROR_SENTINEL] && lexer->lookahead >= '0' &&
+      lexer->lookahead <= '9') {
+    return scan_float_with_separator(lexer);
   }
 
   // A symbolic infix operator that ends its line continues the expression on

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -460,6 +460,39 @@ val d1 = .314D
     (floating_point_literal)))
 
 ================================================================================
+Floating point literals with digit separators
+================================================================================
+
+val a = 1_000.5
+val b = 1_000.000_1
+val c = 3.14_159
+val d = 1_000.5e1_0
+val e = 1_000.5f
+val f = 1_000e10
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal))
+  (val_definition
+    (identifier)
+    (floating_point_literal)))
+
+================================================================================
 Boolean literals
 ================================================================================
 


### PR DESCRIPTION
> [!WARNING]
> This requires a parser genration to include #585

A digit separator in the integer part of a float such as `99_999.9999` could not be lexed. The internal number regex drops the dot transition after an underscore, so the scanner lexes that shape as _floating_point_with_separators. The fraction and exponent gain separators through the regex.

Seen in lila [PlanPricingTest.scala](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/plan/src/test/PlanPricingTest.scala#L35-L36).