### PR TITLE
feat: bind an indented block to a for comprehension enumerator

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2326,7 +2326,9 @@ module.exports = grammar({
           optional("case"),
           $._pattern,
           choice("<-", "←", "="),
-          $.expression,
+          // A generator or `=` binding can bind a braceless indented block, as
+          // the guard and the `for` body already do.
+          choice($.expression, $.indented_block),
           optional($.guard),
         ),
         repeat1($.guard),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1893,6 +1893,50 @@ def f() = {
               (identifier))))))))
 
 ================================================================================
+For comprehension enumerator with an indented block
+================================================================================
+
+def f =
+  for
+    u <-
+      val a = g()
+      a.h
+    _ =
+      p()
+      q()
+  yield u
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (indented_block
+              (val_definition
+                (identifier)
+                (call_expression
+                  (identifier)
+                  (arguments)))
+              (field_expression
+                (identifier)
+                (identifier))))
+          (enumerator
+            (wildcard)
+            (indented_block
+              (call_expression
+                (identifier)
+                (arguments))
+              (call_expression
+                (identifier)
+                (arguments)))))
+        (identifier)))))
+
+================================================================================
 For comprehensions (Scala 3 syntax)
 ================================================================================
 


### PR DESCRIPTION
A generator or `=` binding whose right side is a braceless multi-statement block failed to parse. Allow an indented block there, as the guard and the for body already do.

Seen in lila [MovePlayer.scala,](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/round/src/main/MovePlayer.scala#L94-L97), [AutoPairing.scala](https://github.com/lichess-org/lila/blob/cc7032e80ba7eae1b1b7640278513245d31c9e14/modules/tournament/src/main/AutoPairing.scala#L41) and etc.

Lila is now 100% covered 😎 

> ok, lila/modules/: 100.00%, expected at least 99%
