### PR TITLE
perf: inline small hidden rules to shrink parser.c

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -93,6 +93,16 @@ module.exports = grammar({
     $._param_value_type,
     $._simple_type,
     $.literal,
+    // Small hidden rules that reduce to a token almost immediately. Inlining
+    // removes the reduce step and merges states, shrinking parser.c by ~2MB.
+    $._asterisk,
+    $._super_identifier,
+    $._this_identifier,
+    $._non_null_literal,
+    $._braced_template_body,
+    $._indented_template_body,
+    $._structural_type,
+    $._refinement,
   ],
 
   // Doc: https://tree-sitter.github.io/tree-sitter/creating-parsers, search "precedences"
@@ -1764,7 +1774,7 @@ module.exports = grammar({
           "new",
           seq(
             "new",
-            field("early_defs", $._early_defs),
+            field("early_defs", $.early_defs),
             "with",
             $._constructor_application,
           ),
@@ -1772,7 +1782,17 @@ module.exports = grammar({
         seq("new", $._constructor_application),
       ),
 
-    _early_defs: $ => alias($._braced_template_body, $.early_defs),
+    // A visible copy of _braced_template_body. It cannot alias that rule
+    // because the rule is inlined, which would empty the aliased node.
+    early_defs: $ =>
+      prec.left(
+        PREC.control,
+        seq(
+          "{",
+          optional(choice($._braced_template_body1, $._braced_template_body2)),
+          "}",
+        ),
+      ),
 
     /**
      * PostfixExpr [Ascription]


### PR DESCRIPTION
- spin-out from #547 

Add eight small hidden rules to the inline list. Each reduces to a token almost at once, so inlining removes the reduce step and merges states. This drops parser.c by about 2MB and LARGE_STATE_COUNT from 4182 to 2910. The tree is unchanged (node-types.json identical). early_defs becomes a visible rule because it can no longer alias the now-inlined _braced_template_body.

- parser.c: 30.34 MiB -> 28.28 MiB (-2.06 MiB, -6.8%)
- LARGE_STATE_COUNT: 4182 -> 2910 (-1272, -30%)
- No speed change

This creates a room for new big features (capture checking ? maybe).