### PR TITLE
feat(scala3): attach end markers to the construct they close

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -41,6 +41,16 @@ const ascriptionArrowTail = $ =>
 // body, and a do-while fork there doubles the paren-for automaton (~+7MiB).
 const statementExpression = $ => choice($.expression, $.do_while_expression);
 
+// A Scala 3 end marker as the last child of the construct it closes. The
+// leading semicolon keeps `end` out of every expression follow set, and
+// the weight beats the statement reading of the marker line. The tails are
+// shared rules so every construct reuses the same post-semicolon states.
+const endMarkerTail = ($, marker, weight) =>
+  prec.dynamic(
+    weight,
+    seq($._automatic_semicolon, alias(marker, $.end_marker)),
+  );
+
 module.exports = grammar({
   name: "scala",
 
@@ -112,8 +122,6 @@ module.exports = grammar({
   // These names can be used in the prec functions to define precedence relative only to other names in the array, rather than globally.
   precedences: $ => [
     ["mod", "soft_id"],
-    ["end", "soft_id"],
-    ["end", "this_id"],
     ["new", "structural_type"],
     ["self_type", "lambda"],
     ["annotation", "applied_constructor_type"],
@@ -140,11 +148,33 @@ module.exports = grammar({
     [$._type_identifier, $.ascription_expression],
     [$._given_constructor, $._type_identifier],
     [$.instance_expression],
+    // `end` after a new-with-template closes either the instance or an
+    // enclosing construct.
+    [$._constructor_application, $.instance_expression],
+    // A semicolon after a body is either a statement separator or the one
+    // in front of an end marker. Fork until the tag decides.
+    [$.try_expression],
+    [$._if_body],
+    // Same separator-or-marker fork as above.
+    [$.function_definition],
+    [$.val_definition],
+    [$._dot_match_expression],
+    [$.var_definition],
+    [$.package_clause],
+    [$._object_definition],
+    [$.given_definition],
+    [$.extension_definition],
+    [$.while_expression],
+    [$.for_expression],
+    [$.enum_definition],
     // In case of: 'extension'  _indent  '{'  'case'  operator_identifier  'if'  operator_identifier  •  '=>'  …
     // we treat `operator_identifier` as `simple_expression`
     [$._simple_expression, $.lambda_expression],
-    // operator_identifier  •  ':'  …
     [$._simple_expression, $._single_lambda_param],
+    // '['  identifier  ':'  '{'  identifier. A braced context bound reuses
+    // the template machinery, so self type and statement readings coexist.
+    [$._single_lambda_param, $.self_type, $._type_identifier],
+    [$._single_lambda_param, $._type_identifier],
     // 'class'  _class_constructor  •  _automatic_semicolon  …
     [$._class_definition],
     // 'class'  operator_identifier  •  _automatic_semicolon  …
@@ -169,26 +199,14 @@ module.exports = grammar({
     [$.name_and_type, $.parameter],
     [$._simple_expression, $._type_identifier],
     // 'if'  parenthesized_expression  •  '{'  …
-    [$._if_condition, $._simple_expression],
+    [$._if_condition_paren, $._simple_expression],
     [$.block, $._braced_template_body1],
     [$._simple_expression, $._type_identifier],
-    // '['  operator_identifier  ':'  '{'  operator_identifier  •  '=>'  …
-    [$._single_lambda_param, $.self_type, $._type_identifier],
-    // '['  operator_identifier  ':'  '{'  operator_identifier  •  '?=>'  …
-    [$._single_lambda_param, $._type_identifier],
-    // '('  operator_identifier  •  ':'  …
-    [$._simple_expression, $._single_lambda_param, $.binding],
-    // 'given'  '{'  operator_identifier  •  ':'  …
-    [$._simple_expression, $._single_lambda_param, $.self_type],
-    // '['  operator_identifier  ':'  '{'  operator_identifier  •  ':'  …
-    [
-      $._simple_expression,
-      $._single_lambda_param,
-      $.self_type,
-      $._type_identifier,
-    ],
-    // 'given'  '{'  operator_identifier  ':'  _type  •  '=>'  …
-    [$._single_lambda_param, $._self_type_ascription],
+    // '{'  identifier  •  ':' starts the braced typed lambda, the block
+    // lambda param, and a statement alike.
+    [$._simple_expression, $._braced_typed_lambda],
+    [$.self_type, $._simple_expression, $._braced_typed_lambda],
+    [$._self_type_ascription, $._braced_typed_lambda],
     [$.binding, $._simple_expression, $._type_identifier],
     [$.class_parameter, $._type_identifier],
     // '{'  _single_lambda_param  '=>'  expression  •  '}'  …
@@ -209,6 +227,9 @@ module.exports = grammar({
     [$.named_tuple_type, $._colon_bindings],
     // _simple_expression  ':'  '('  wildcard  •  ','  …
     [$._annotated_type, $.binding],
+    // '['  identifier  ':'  '{'  identifier  •  ':'  — a braced context
+    // bound reuses the self-type head shapes.
+    [$.self_type, $._type_identifier, $._simple_expression],
     // '['  identifier  ':'  '{'  wildcard  •  ':'  …
     [$.self_type, $._annotated_type, $._simple_expression],
     // '['  identifier  ':'  '{'  '('  wildcard  •  ':'  …
@@ -292,8 +313,7 @@ module.exports = grammar({
         optional(trailingSep1($._semicolon, $._top_level_definition)),
       ),
 
-    _top_level_definition: $ =>
-      choice($._definition, $._end_marker, statementExpression($)),
+    _top_level_definition: $ => choice($._definition, statementExpression($)),
 
     _definition: $ =>
       choice(
@@ -325,6 +345,7 @@ module.exports = grammar({
         field("extend", optional($.extends_clause)),
         field("derive", optional($.derives_clause)),
         field("body", $.enum_body),
+        optional($._end_marker_named_tail),
       ),
 
     _enum_block: $ =>
@@ -380,16 +401,19 @@ module.exports = grammar({
       ),
 
     package_clause: $ =>
-      prec.right(
-        seq(
-          "package",
-          field("name", $.package_identifier),
-          // This is slightly more permissive than the EBNF in that it allows any
-          // kind of declaration inside of the package blocks. As we're more
-          // concerned with the structure rather than the validity of the program
-          // we'll allow it.
-          field("body", optional($.template_body)),
+      seq(
+        prec.right(
+          seq(
+            "package",
+            field("name", $.package_identifier),
+            // This is slightly more permissive than the EBNF in that it allows
+            // any kind of declaration inside of the package blocks. As we're
+            // more concerned with the structure rather than the validity of
+            // the program we'll allow it.
+            field("body", optional($.template_body)),
+          ),
         ),
+        optional($._end_marker_named_tail),
       ),
 
     package_identifier: $ => prec.right(sep1(".", $._identifier)),
@@ -485,13 +509,16 @@ module.exports = grammar({
       ),
 
     _object_definition: $ =>
-      prec.left(
-        seq(
-          field("name", $._identifier),
-          field("extend", optional($.extends_clause)),
-          field("derive", optional($.derives_clause)),
-          field("body", optional($._definition_body)),
+      seq(
+        prec.left(
+          seq(
+            field("name", $._identifier),
+            field("extend", optional($.extends_clause)),
+            field("derive", optional($.derives_clause)),
+            field("body", optional($._definition_body)),
+          ),
         ),
+        optional($._end_marker_named_tail),
       ),
 
     class_definition: $ =>
@@ -509,10 +536,16 @@ module.exports = grammar({
         field("extend", optional($.extends_clause)),
         field("derive", optional($.derives_clause)),
         field("body", optional($._definition_body)),
+        optional($._end_marker_named_tail),
       ),
 
+    // The weight keeps a next-line braced template attached to its
+    // definition instead of becoming a block statement.
     _definition_body: $ =>
-      seq(optional($._automatic_semicolon), field("body", $.template_body)),
+      prec.dynamic(
+        1,
+        seq(optional($._automatic_semicolon), field("body", $.template_body)),
+      ),
 
     /**
      * ClassConstr       ::=  [ClsTypeParamClause] [ConstrMods] ClsParamClauses
@@ -663,34 +696,38 @@ module.exports = grammar({
         seq("{", optional($._block), "}"),
       ),
 
-    _end_marker: $ =>
-      prec.left(
-        "end",
-        seq(
-          "end",
-          choice(
-            "if",
-            "while",
-            "for",
-            "match",
-            "try",
-            "new",
-            "this",
-            "given",
-            "extension",
-            "val",
-            // Only alphanumeric (or back-quoted) names: allowing operator
-            // identifiers here would swallow `end` used as a plain
-            // identifier before an infix operator (`${end - start}`).
-            alias(choice($._alpha_identifier, $._backquoted_id), "_end_ident"),
-          ),
+    // One hidden variant per tag set, both shown as (end_marker). Real
+    // rules because an alias around a token-only seq shows nothing.
+    _end_marker_named: $ =>
+      seq(
+        $._end_keyword,
+        choice(
+          "val",
+          "given",
+          "this",
+          // No operator identifiers. They would swallow `end` used as a
+          // plain identifier (`${end - start}`).
+          alias(choice($._alpha_identifier, $._backquoted_id), "_end_ident"),
         ),
+      ),
+    _end_marker_named_tail: $ => endMarkerTail($, $._end_marker_named, 1),
+
+    // The extra weight sends `end extension` to the extension itself
+    // rather than naming a definition inside it.
+    _end_marker_kw_tail: $ => endMarkerTail($, $._end_marker_kw, 2),
+
+    _end_marker_kw: $ =>
+      seq(
+        $._end_keyword,
+        choice("extension", "if", "while", "for", "match", "try", "new"),
       ),
 
     // Dynamic precedences added here to win over $.call_expression
     self_type: $ =>
+      // 2 beats the block lambda reading of `{ this: I => ... }`, which
+      // carries dynamic 1.
       prec.dynamic(
-        1,
+        2,
         prec(
           "self_type",
           seq(
@@ -744,6 +781,7 @@ module.exports = grammar({
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
+        optional($._end_marker_named_tail),
       ),
 
     val_declaration: $ =>
@@ -771,6 +809,7 @@ module.exports = grammar({
         optional(seq(":", field("type", $._type))),
         "=",
         field("value", $._indentable_expression),
+        optional($._end_marker_named_tail),
       ),
 
     _start_var: $ => seq(repeat($.annotation), optional($.modifiers), "var"),
@@ -806,6 +845,7 @@ module.exports = grammar({
           seq("=", field("body", $._indentable_expression)),
           field("body", $.block),
         ),
+        optional($._end_marker_named_tail),
       ),
 
     function_declaration: $ => $._function_declaration,
@@ -845,20 +885,28 @@ module.exports = grammar({
      *   Extension         ::=  'extension' [DefTypeParamClause] {UsingParamClause}
      *                          '(' DefParam ')' {UsingParamClause} ExtMethods
      */
+    // The weight beats the reading of `extension (x)` as a call of the
+    // soft identifier `extension`.
     extension_definition: $ =>
-      prec.left(
+      prec.dynamic(
+        1,
         seq(
-          "extension",
-          field("type_parameters", optional($.type_parameters)),
-          field("parameters", repeat($.parameters)),
-          field(
-            "body",
-            choice(
-              $._extension_template_body,
-              $.function_definition,
-              $.function_declaration,
+          prec.left(
+            seq(
+              "extension",
+              field("type_parameters", optional($.type_parameters)),
+              field("parameters", repeat($.parameters)),
+              field(
+                "body",
+                choice(
+                  $._extension_template_body,
+                  $.function_definition,
+                  $.function_declaration,
+                ),
+              ),
             ),
           ),
+          optional($._end_marker_kw_tail),
         ),
       ),
 
@@ -867,21 +915,24 @@ module.exports = grammar({
      * GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ':'
      */
     given_definition: $ =>
-      prec.left(
-        seq(
-          repeat($.annotation),
-          optional($.modifiers),
-          "given",
-          optional($._given_constructor),
-          repeat($._given_sig),
-          choice(
-            field("return_type", $._structural_instance),
-            seq(
-              field("return_type", $._annotated_type),
-              optional(seq("=", field("body", $._indentable_expression))),
+      seq(
+        prec.left(
+          seq(
+            repeat($.annotation),
+            optional($.modifiers),
+            "given",
+            optional($._given_constructor),
+            repeat($._given_sig),
+            choice(
+              field("return_type", $._structural_instance),
+              seq(
+                field("return_type", $._annotated_type),
+                optional(seq("=", field("body", $._indentable_expression))),
+              ),
             ),
           ),
         ),
+        optional($._end_marker_named_tail),
       ),
 
     _given_sig: $ => seq($._given_conditional, fatArrow()),
@@ -1115,10 +1166,7 @@ module.exports = grammar({
     _block_statements: $ =>
       prec.left(
         seq(
-          sep1(
-            $._semis,
-            choice(statementExpression($), $._definition, $._end_marker),
-          ),
+          sep1($._semis, choice(statementExpression($), $._definition)),
           optional($._semis),
         ),
       ),
@@ -1143,12 +1191,7 @@ module.exports = grammar({
     indented_block: $ =>
       prec.left(
         PREC.control,
-        seq(
-          $._indent,
-          $._block,
-          choice($._outdent, $._comma_outdent),
-          optional($._end_marker),
-        ),
+        seq($._indent, $._block, choice($._outdent, $._comma_outdent)),
       ),
 
     indented_cases: $ =>
@@ -1328,14 +1371,8 @@ module.exports = grammar({
         -1,
         prec.left(
           choice(
-            seq(
-              field("type_parameters", $.type_parameters),
-              $._arrow_then_type,
-            ),
-            seq(
-              field("parameter_types", $.parameter_types),
-              $._arrow_then_type,
-            ),
+            seq(field("type_parameters", $.type_parameters), $._arrow_then_type),
+            seq(field("parameter_types", $.parameter_types), $._arrow_then_type),
           ),
         ),
       ),
@@ -1526,9 +1563,7 @@ module.exports = grammar({
       prec.left(PREC.call, seq($._simple_expression, $.wildcard)),
 
     _single_lambda_param: $ =>
-      prec.right(
-        seq(optional("implicit"), $._identifier, optional(seq(":", $._type))),
-      ),
+      prec.right(seq(optional("implicit"), $._identifier)),
 
     // Keeps a braced `{ x: T => ... }` a lambda instead of a fewer-braces colon
     // argument on `x`.
@@ -1543,6 +1578,9 @@ module.exports = grammar({
             ),
             field(
               "parameters",
+              // No unparenthesized typed parameter here. It is only legal
+              // inside braces, and `OWrites: c => body` must stay a colon
+              // argument.
               choice($.bindings, $.wildcard, $._single_lambda_param),
             ),
             anyArrow(),
@@ -1562,13 +1600,43 @@ module.exports = grammar({
     _block_lambda_expression: $ =>
       prec.right(
         "lambda",
-        seq(
-          field(
-            "parameters",
-            choice($.bindings, $.wildcard, $._single_lambda_param),
+        choice(
+          seq(
+            field(
+              "parameters",
+              choice($.bindings, $.wildcard, $._single_lambda_param),
+            ),
+            anyArrow(),
+            optional(
+              choice(
+                $._block,
+                // Curried form ending in a typed lambda, as in
+                // `{ _ => source: Source[ByteString, Any] => body }`.
+                alias($._braced_typed_lambda, $.lambda_expression),
+              ),
+            ),
           ),
-          anyArrow(),
-          optional($._block),
+          $._braced_typed_lambda,
+        ),
+      ),
+
+    // `{ x: T => body }` is legal only as a block result. The weight beats
+    // the reading of `x: T` as a statement taking a colon argument.
+    _braced_typed_lambda: $ =>
+      prec.dynamic(
+        1,
+        prec.right(
+          "lambda",
+          seq(
+            field(
+              "parameters",
+              prec.right(
+                seq(optional("implicit"), $._identifier, ":", $._type),
+              ),
+            ),
+            anyArrow(),
+            $._indentable_expression,
+          ),
         ),
       ),
 
@@ -1580,28 +1648,54 @@ module.exports = grammar({
       seq(
         optional($.inline_modifier),
         "if",
-        field("condition", $._if_condition),
-        field("consequence", $._indentable_expression),
-        optional(
+        choice(
+          // No marker slot here. Paren-if marker heads multiply the block
+          // lambda forks over the GLR version limit in brace-heavy files,
+          // and real code only marks then-style ifs.
           seq(
-            optional(";"),
-            "else",
-            field("alternative", $._indentable_expression),
+            field("condition", $._if_condition_paren),
+            // The then-form twin makes the scanner emit a semicolon here.
+            optional($._automatic_semicolon),
+            $._if_body,
+          ),
+          seq(
+            field("condition", $._if_condition_then),
+            $._if_body,
+            optional($._end_marker_kw_tail),
           ),
         ),
       ),
 
-    // NOTE(susliko): _if_condition and its magic dynamic precedence were introduced as a fix to
+    _if_body: $ =>
+      seq(
+        field("consequence", $._indentable_expression),
+        optional(
+          // The weight keeps the else attached to this if when a losing
+          // statement reading of the else line ties with it.
+          prec.dynamic(
+            1,
+            seq(
+              optional(";"),
+              "else",
+              field("alternative", $._indentable_expression),
+            ),
+          ),
+        ),
+      ),
+
+    // NOTE(susliko): the magic dynamic precedence was introduced as a fix to
     // https://github.com/tree-sitter/tree-sitter-scala/issues/263 and
     // https://github.com/tree-sitter/tree-sitter-scala/issues/342
     // Neither do I understand why this works, nor have I found a better solution
-    _if_condition: $ =>
+    _if_condition_paren: $ => prec.dynamic(4, $.parenthesized_expression),
+
+    _if_condition_then: $ =>
+      // A marker slot of a construct inside the condition may emit a
+      // semicolon before the `then`. The weight beats the paren form, so
+      // `if (a)` + newline + `then x` keeps `then` as the keyword.
       prec.dynamic(
-        4,
-        choice(
-          $.parenthesized_expression,
-          seq($._indentable_expression, "then"),
-        ),
+        5,
+        seq($._indentable_expression, optional($._automatic_semicolon), "then"),
       ),
 
     /*
@@ -1618,7 +1712,16 @@ module.exports = grammar({
           optional($.inline_modifier),
           field("value", $.expression),
           "match",
-          field("body", choice($.case_block, $.indented_cases)),
+          // A braced case block takes no marker. Real code never writes
+          // one, and the marker heads it would add after every `}` of a
+          // case block press on the GLR version limit in map-heavy code.
+          choice(
+            field("body", $.case_block),
+            seq(
+              field("body", $.indented_cases),
+              optional($._end_marker_kw_tail),
+            ),
+          ),
         ),
         $._dot_match_expression,
       ),
@@ -1629,17 +1732,24 @@ module.exports = grammar({
         ".",
         token.immediate("match"),
         field("body", choice($.case_block, $.indented_cases)),
+        optional($._end_marker_kw_tail),
       ),
 
+    // The marker tail sits outside the precedence wrapper. Inside it, the
+    // right associativity would force `end f` onto the try instead of the
+    // enclosing definition.
     try_expression: $ =>
-      prec.right(
-        PREC.control,
-        seq(
-          "try",
-          field("body", $._indentable_expression),
-          optional($.catch_clause),
-          optional($.finally_clause),
+      seq(
+        prec.right(
+          PREC.control,
+          seq(
+            "try",
+            field("body", $._indentable_expression),
+            optional($.catch_clause),
+            optional($.finally_clause),
+          ),
         ),
+        optional($._end_marker_kw_tail),
       ),
 
     /*
@@ -1771,9 +1881,7 @@ module.exports = grammar({
         3,
         seq(
           "(",
-          trailingCommaSep(
-            choice($.binding, alias($.name_and_type, $.binding)),
-          ),
+          trailingCommaSep(choice($.binding, alias($.name_and_type, $.binding))),
           ")",
         ),
       ),
@@ -1795,12 +1903,21 @@ module.exports = grammar({
      */
     instance_expression: $ =>
       choice(
-        // This is weakened so ascription wins for new Array: Array
+        // 1 beats the colon-argument reading of `new C:` and still loses
+        // to the ascription of `new Array: Array`.
         prec.dynamic(
-          0,
-          seq("new", $._constructor_application, $.template_body),
+          1,
+          seq(
+            "new",
+            $._constructor_application,
+            $.template_body,
+            optional($._end_marker_kw_tail),
+          ),
         ),
-        prec("new", seq("new", $.template_body)),
+        prec(
+          "new",
+          seq("new", $.template_body, optional($._end_marker_kw_tail)),
+        ),
         prec(
           "new",
           seq(
@@ -1995,7 +2112,7 @@ module.exports = grammar({
         $._super_identifier,
       ),
 
-    _this_identifier: $ => prec("this_id", "this"),
+    _this_identifier: $ => "this",
     _super_identifier: $ => "super",
 
     // https://docs.scala-lang.org/scala3/reference/soft-modifier.html
@@ -2306,19 +2423,36 @@ module.exports = grammar({
       prec(
         PREC.while,
         choice(
+          // No marker slot here. It lets a trailing `match` capture the
+          // whole loop as its value in `while (c) e match { ... }`.
           prec.right(
             seq(
               "while",
               field("condition", $.parenthesized_expression),
+              // The do-form branch makes the scanner emit a semicolon
+              // here.
+              optional($._automatic_semicolon),
               field("body", $.expression),
             ),
           ),
-          prec.right(
-            seq(
-              "while",
-              field("condition", seq($._indentable_expression, "do")),
-              field("body", $._indentable_expression),
+          seq(
+            prec.right(
+              seq(
+                "while",
+                field(
+                  "condition",
+                  // A marker slot inside the condition may emit a
+                  // semicolon before the `do`.
+                  seq(
+                    $._indentable_expression,
+                    optional($._automatic_semicolon),
+                    "do",
+                  ),
+                ),
+                field("body", $._indentable_expression),
+              ),
             ),
+            optional($._end_marker_kw_tail),
           ),
         ),
       ),
@@ -2340,6 +2474,8 @@ module.exports = grammar({
      */
     for_expression: $ =>
       choice(
+        // No marker slot on the bracketed heads, for the same reason as the
+        // parenthesized while.
         prec.right(
           PREC.control,
           seq(
@@ -2361,16 +2497,19 @@ module.exports = grammar({
             ),
           ),
         ),
-        prec.right(
-          PREC.control,
-          seq(
-            "for",
-            field("enumerators", $.enumerators),
-            choice(
-              seq("do", field("body", $._indentable_expression)),
-              seq("yield", field("body", $._indentable_expression)),
+        seq(
+          prec.right(
+            PREC.control,
+            seq(
+              "for",
+              field("enumerators", $.enumerators),
+              choice(
+                seq("do", field("body", $._indentable_expression)),
+                seq("yield", field("body", $._indentable_expression)),
+              ),
             ),
           ),
+          optional($._end_marker_kw_tail),
         ),
       ),
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -39,7 +39,8 @@ enum TokenType {
   ERROR_SENTINEL,
   COLON_EOL,
   OPERATOR_EOL,
-  FLOATING_POINT_WITH_SEPARATORS
+  FLOATING_POINT_WITH_SEPARATORS,
+  END_KEYWORD
 };
 
 const char* token_name[] = {
@@ -68,7 +69,8 @@ const char* token_name[] = {
   "ERROR_SENTINEL",
   "COLON_EOL",
   "OPERATOR_EOL",
-  "FLOATING_POINT_WITH_SEPARATORS"
+  "FLOATING_POINT_WITH_SEPARATORS",
+  "END_KEYWORD"
 };
 
 typedef struct {
@@ -581,11 +583,12 @@ static bool is_leading_infix_continuation(TSLexer *lexer) {
 typedef struct {
   bool ends_conditional;
   bool has_case_arrow;
+  bool closes_bracket;
 } LineScan;
 
 static LineScan scan_rest_of_line(TSLexer *lexer) {
   int depth = 0;
-  LineScan r = {false, false};
+  LineScan r = {false, false, false};
   while (!lexer->eof(lexer) && lexer->lookahead != '\n' &&
          lexer->lookahead != '\r') {
     int32_t c = lexer->lookahead;
@@ -597,6 +600,9 @@ static LineScan scan_rest_of_line(TSLexer *lexer) {
       advance(lexer);
     } else if (c == ')' || c == ']' || c == '}') {
       depth--;
+      if (depth < 0) {
+        r.closes_bracket = true;
+      }
       r.ends_conditional = false;
       advance(lexer);
     } else if (c == '"' || c == '`') {
@@ -1056,6 +1062,35 @@ static bool scan_impl(void *payload, TSLexer *lexer,
   }
   scanner->last_newline_count = 0;
 
+  // END_KEYWORD is only valid right after the semicolon the grammar puts
+  // in front of a marker. Emit it when the tag word confirms the marker
+  // shape.
+  if (valid_symbols[END_KEYWORD] && !valid_symbols[ERROR_SENTINEL] &&
+      lexer->lookahead == 'e') {
+    if (scan_word(lexer, "end")) {
+      for (;;) {
+        advance_past_blanks(lexer);
+        if (lexer->lookahead != '/') {
+          break;
+        }
+        advance(lexer);
+        if (lexer->lookahead != '*') {
+          break;
+        }
+        advance(lexer);
+        consume_block_comment_body(lexer);
+      }
+      if (iswalpha(lexer->lookahead) || lexer->lookahead == '_' ||
+          lexer->lookahead == '$' || lexer->lookahead == '`' ||
+          lexer->lookahead > 127) {
+        lexer->mark_end(lexer);
+        lexer->result_symbol = END_KEYWORD;
+        return true;
+      }
+    }
+    return false;
+  }
+
   if (valid_symbols[AUTOMATIC_SEMICOLON] && newline_count > 0) {
     // AUTOMATIC_SEMICOLON should not be issued in the middle of expressions
     // Thus, we exit this branch when encountering comments, else/catch clauses, etc.
@@ -1069,6 +1104,46 @@ static bool scan_impl(void *payload, TSLexer *lexer,
     //  .c
     if (lexer->lookahead == '.') {
       return false;
+    }
+
+    // A statement never ends right before a closing bracket, and marker
+    // slots would otherwise ask for a semicolon here.
+    if (lexer->lookahead == ')' || lexer->lookahead == ']' ||
+        lexer->lookahead == ',') {
+      return false;
+    }
+
+    // Same, and it keeps a braced else-if chain from forking one marker
+    // head per nested if. A `}` line that continues with more code
+    // (`} | Mate`) keeps the semicolon and the old reading of its tail. A
+    // trailing comment counts as the line end.
+    if (lexer->lookahead == '}') {
+      advance(lexer);
+      for (;;) {
+        advance_past_blanks(lexer);
+        if (lexer->lookahead == '}' || lexer->lookahead == ')' ||
+            lexer->lookahead == ']') {
+          advance(lexer);
+          continue;
+        }
+        if (lexer->lookahead == '/') {
+          advance(lexer);
+          if (lexer->lookahead == '/') {
+            return false;
+          }
+          if (lexer->lookahead == '*') {
+            advance(lexer);
+            consume_block_comment_body(lexer);
+            continue;
+          }
+        }
+        break;
+      }
+      if (lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
+          lexer->eof(lexer)) {
+        return false;
+      }
+      return true;
     }
 
     // Single-line and multi-line comments
@@ -1121,11 +1196,30 @@ static bool scan_impl(void *payload, TSLexer *lexer,
           return false;
         }
         break;
-      case 'c':
-        if (valid_symbols[CATCH] && scan_word(lexer, "catch")) {
+      case 'c': {
+        // Read the word whole: `catch` and `case` share a prefix that
+        // chained scan_word calls cannot rewind.
+        char word[sizeof "catch"];
+        int len = read_word(lexer, word, (int)sizeof word);
+        if (len <= 0) {
+          break;
+        }
+        if (valid_symbols[CATCH] && strcmp(word, "catch") == 0) {
           return false;
         }
+        // A case clause line needs no separator, and suppressing it keeps
+        // a long else-if chain from forking one marker head per nested if
+        // right before it. A case definition keeps its separator, and so
+        // does a clause line that closes an enclosing bracket, whose
+        // separator belongs to the surrounding expression.
+        if (strcmp(word, "case") == 0 && !is_case_definition_word(lexer)) {
+          LineScan line = scan_rest_of_line(lexer);
+          if (line.has_case_arrow && !line.closes_bracket) {
+            return false;
+          }
+        }
         break;
+      }
       case 'f':
         if (valid_symbols[FINALLY] && scan_word(lexer, "finally")) {
           return false;

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -270,7 +270,8 @@ end d
       (identifier))
     (template_body
       (object_definition
-        (identifier)))))
+        (identifier)))
+    (end_marker)))
 
 ================================================================================
 Package object
@@ -757,7 +758,8 @@ end A
       (type_identifier)
       (type_identifier))
     (template_body
-      (integer_literal))))
+      (integer_literal))
+    (end_marker)))
 
 ================================================================================
 Class definitions with parameters
@@ -2058,7 +2060,123 @@ end Test
     (template_body
       (function_definition
         (identifier)
-        (integer_literal)))))
+        (integer_literal)))
+    (end_marker)))
+
+================================================================================
+End markers nested in definitions (Scala 3 syntax)
+================================================================================
+
+object C:
+  given C =
+    new C:
+      def f = "!"
+      end f
+    end new
+  end given
+end C
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (given_definition
+        (type_identifier)
+        (indented_block
+          (instance_expression
+            (type_identifier)
+            (template_body
+              (function_definition
+                (identifier)
+                (string)
+                (end_marker)))
+            (end_marker)))
+        (end_marker)))
+    (end_marker)))
+
+================================================================================
+End marker tags pick their construct (Scala 3 syntax)
+================================================================================
+
+def f = xs match
+  case a => a
+end f
+
+val m = xs match
+  case a => a
+end match
+
+extension (x: Int)
+  def inc = x + 1
+end extension
+
+var w =
+  1
+end val
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (match_expression
+      (identifier)
+      (indented_cases
+        (case_clause
+          (identifier)
+          (identifier))))
+    (end_marker))
+  (val_definition
+    (identifier)
+    (match_expression
+      (identifier)
+      (indented_cases
+        (case_clause
+          (identifier)
+          (identifier)))
+      (end_marker)))
+  (extension_definition
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (function_definition
+      (identifier)
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (integer_literal)))
+    (end_marker))
+  (var_definition
+    (identifier)
+    (indented_block
+      (integer_literal))
+    (end_marker)))
+
+================================================================================
+End marker after a single-line extension body (Scala 3 syntax)
+================================================================================
+
+extension (x: Int) def inc = x + 1
+end extension
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (extension_definition
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (function_definition
+      (identifier)
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (integer_literal)))
+    (end_marker)))
 
 ================================================================================
 Traits (Scala 3)
@@ -2400,3 +2518,79 @@ val f = (x:
           (identifier)
           (type_identifier)))
       (identifier))))
+
+================================================================================
+End marker for a secondary constructor (Scala 3 syntax)
+================================================================================
+
+class A(val x: Int):
+  def this() =
+    this(0)
+  end this
+end A
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier)))
+    (template_body
+      (function_definition
+        (identifier)
+        (parameters)
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments
+              (integer_literal))))
+        (end_marker)))
+    (end_marker)))
+
+================================================================================
+End marker after a dot match (Scala 3 syntax)
+================================================================================
+
+val n = x.match
+  case 2 => b
+end match
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (match_expression
+      (identifier)
+      (indented_cases
+        (case_clause
+          (integer_literal)
+          (identifier)))
+      (end_marker))))
+
+================================================================================
+End marker after a body-less multiline class (Scala 3 syntax)
+================================================================================
+
+class Wide(
+  val a: Int,
+  val b: Int
+)
+end Wide
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier))
+      (class_parameter
+        (identifier)
+        (type_identifier)))
+    (end_marker)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -561,6 +561,27 @@ def another() {
         (identifier)))))
 
 ================================================================================
+If with a parenthesized condition and a next-line then (Scala 3 syntax)
+================================================================================
+
+def g =
+  if (a)
+  then x
+  else y
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (if_expression
+        (parenthesized_expression
+          (identifier))
+        (identifier)
+        (identifier)))))
+
+================================================================================
 If expressions (Scala 3 syntax)
 ================================================================================
 
@@ -606,7 +627,8 @@ class C:
             (identifier)
             (call_expression
               (identifier)
-              (arguments)))
+              (arguments))
+            (end_marker))
           (if_expression
             (indented_block
               (val_definition
@@ -2447,6 +2469,116 @@ def f = {
         (identifier)))))
 
 ================================================================================
+End markers on control expressions (Scala 3 syntax)
+================================================================================
+
+def p() =
+  if a then
+    b
+  end if
+  while a do
+    b
+  end while
+  for x <- xs do
+    x
+  end for
+  try
+    a
+  catch
+    case e => b
+  end try
+end p
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters)
+    (indented_block
+      (if_expression
+        (identifier)
+        (indented_block
+          (identifier))
+        (end_marker))
+      (while_expression
+        (identifier)
+        (indented_block
+          (identifier))
+        (end_marker))
+      (for_expression
+        (enumerators
+          (enumerator
+            (identifier)
+            (identifier)))
+        (indented_block
+          (identifier))
+        (end_marker))
+      (try_expression
+        (indented_block
+          (identifier))
+        (catch_clause
+          (indented_cases
+            (case_clause
+              (identifier)
+              (identifier))))
+        (end_marker)))
+    (end_marker)))
+
+================================================================================
+Braced typed lambda and a colon-argument lambda
+================================================================================
+
+val a = forAll { int: Int =>
+  int.asJson
+}
+
+val b = OWrites: c =>
+  Json.obj(c)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (block
+        (lambda_expression
+          (identifier)
+          (type_identifier)
+          (indented_block
+            (field_expression
+              (identifier)
+              (identifier)))))))
+  (val_definition
+    (identifier)
+    (call_expression
+      (identifier)
+      (colon_argument
+        (identifier)
+        (indented_block
+          (call_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (arguments
+              (identifier))))))))
+
+================================================================================
+Standalone end is not a marker (Scala 3 syntax)
+================================================================================
+
+end Foo
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (postfix_expression
+    (identifier)
+    (identifier)))
+
+================================================================================
 Soft keyword `inline` as identifier in expressions
 ================================================================================
 
@@ -2822,12 +2954,11 @@ object A {
       (val_definition
         (identifier)
         (parenthesized_expression
-          (lambda_expression
+          (ascription_expression
             (identifier)
             (type_identifier)
-            (lambda_expression
-              (identifier)
-              (identifier))))))))
+            (type_identifier)
+            (type_identifier)))))))
 
 ================================================================================
 Ascribed match expression (`}: @unchecked`)
@@ -4114,3 +4245,118 @@ val cond =
           (identifier))
         (operator_identifier)
         (identifier)))))
+
+================================================================================
+Then condition holding a match (Scala 3 syntax)
+================================================================================
+
+val r =
+  if xs match
+    case Nil => false
+    case _ => true
+  then "y"
+  else "n"
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (indented_block
+      (if_expression
+        (match_expression
+          (identifier)
+          (indented_cases
+            (case_clause
+              (identifier)
+              (boolean_literal))
+            (case_clause
+              (wildcard)
+              (boolean_literal))))
+        (string)
+        (string)))))
+
+================================================================================
+While with a match condition and a line-leading do (Scala 3 syntax)
+================================================================================
+
+def w() =
+  while (sArr(last): @switch) match
+      case Sym => true
+      case _ => false
+  do last -= 1
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters)
+    (indented_block
+      (while_expression
+        (match_expression
+          (parenthesized_expression
+            (ascription_expression
+              (call_expression
+                (identifier)
+                (arguments
+                  (identifier)))
+              (annotation
+                (type_identifier))))
+          (indented_cases
+            (case_clause
+              (identifier)
+              (boolean_literal))
+            (case_clause
+              (wildcard)
+              (boolean_literal))))
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (integer_literal))))))
+
+================================================================================
+Parenthesized while with a next-line body
+================================================================================
+
+def g() = {
+  while (c)
+    step()
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters)
+    (block
+      (while_expression
+        (parenthesized_expression
+          (identifier))
+        (call_expression
+          (identifier)
+          (arguments))))))
+
+================================================================================
+Curried typed lambda in braces (Scala 3 syntax)
+================================================================================
+
+val h = { x: Int => y: Int => x + y }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (block
+      (lambda_expression
+        (identifier)
+        (type_identifier)
+        (ascription_expression
+          (identifier)
+          (type_identifier)
+          (infix_type
+            (type_identifier)
+            (operator_identifier)
+            (type_identifier)))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1060,5 +1060,9 @@ end Merge
           (class_parameter
             (identifier)
             (type_identifier)))
-        (template_body)))))
+        (template_body
+          (postfix_expression
+            (identifier)
+            (identifier)))))
+    (end_marker)))
 


### PR DESCRIPTION
- Fixes #275
- Fixes #511

An `end` marker was a hidden standalone statement. Nested markers became siblings of the definition they close. A lone `end` marker parsed silently anywhere.
Now the marker is the named `end_marker` node. It is the last child of the definition or expression it closes. Each construct admits only the tags that can close it. So `end match` goes to the match expression and `end foo` goes to the enclosing definition. A standalone `end` marker stays an ordinary expression.

A naive slot would let the `end` keyword directly follow any expression. The parse table then duplicates the expression and type states for those contexts.
To avoid this, a slot starts with the automatic semicolon. The scanner emits the `end` keyword only right after that semicolon, and only when the line looks like a marker. So the `end` keyword never directly follows an expression. The scanner also stops offering the semicolon where no statement can end. Parenthesized `if` and loop heads and braced match bodies take no marker. Real code (34 Scala OSSs on my end) only marks the indentation forms, and the extra forks could exceed the GLR version limit. The new states re-roll some GLR ties. Explicit dynamic precedences pin them.

Three side effects.

1. A `case` clause now ends at its content instead of at the next clause.
2. The `while` condition tolerates the new semicolon before its `do`.
3. The state changes re-rolled GLR ties that had hidden real misreadings in the lambda rules. Fixing those needed a split of the lambda parameter rules. A braced lambda keeps its unparenthesized typed parameter, which dotty itself only accepts in block position, and an expression keeps the colon argument reading. parser.c ends up smaller than on master (-300KB).
