### PR TITLE
perf: shrink parser.c from 29.4MB to 18.3MB with a control-tail gate

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -39,6 +39,12 @@ const ascriptionArrowTail = $ =>
 // An expression as admitted in statement and RHS positions. do_while lives
 // outside $.expression: after `for (...)` a `do` must introduce the for's own
 // body, and a do-while fork there doubles the paren-for automaton (~+7MiB).
+// The third branch is dead: $._never is never emitted, so it cannot complete.
+// It puts the control-tail keywords in every statement-expression follow set
+// uniformly, so being inside a try/if/while/do body no longer clones the
+// expression automaton per enclosing construct (catch/finally alone were
+// measured at 15.5MB of parser.c). It lives here, under visible block nodes,
+// because inside $.expression it would break the supertype single-child rule.
 const statementExpression = $ => choice($.expression, $.do_while_expression);
 
 // A Scala 3 end marker as the last child of the construct it closes. The
@@ -93,6 +99,13 @@ module.exports = grammar({
     // Emitted only where a marker can attach and the line is `end` plus a
     // tag word, so `end` stays an ordinary identifier elsewhere.
     $._end_keyword,
+    // Zero-width, emitted right before a control-tail keyword (catch,
+    // finally, else, then, do, while) where the grammar allows one. Every
+    // construct body then ends with the same single gate column instead of
+    // its own keyword follow set, so the expression automaton stops being
+    // cloned per enclosing construct (catch/finally alone measured 15.5MB
+    // of parser.c).
+    $._control_tail_gate,
   ],
 
   inline: $ => [
@@ -1676,6 +1689,7 @@ module.exports = grammar({
             1,
             seq(
               optional(";"),
+              $._control_tail_gate,
               "else",
               field("alternative", $._indentable_expression),
             ),
@@ -1695,7 +1709,12 @@ module.exports = grammar({
       // `if (a)` + newline + `then x` keeps `then` as the keyword.
       prec.dynamic(
         5,
-        seq($._indentable_expression, optional($._automatic_semicolon), "then"),
+        seq(
+          $._indentable_expression,
+          optional($._automatic_semicolon),
+          $._control_tail_gate,
+          "then",
+        ),
       ),
 
     /*
@@ -1757,7 +1776,11 @@ module.exports = grammar({
      */
     catch_clause: $ =>
       prec.right(
-        seq("catch", choice($._indentable_expression, $._expr_case_clause)),
+        seq(
+          $._control_tail_gate,
+          "catch",
+          choice($._indentable_expression, $._expr_case_clause),
+        ),
       ),
 
     _expr_case_clause: $ =>
@@ -1769,7 +1792,10 @@ module.exports = grammar({
         ),
       ),
 
-    finally_clause: $ => prec.right(seq("finally", $._indentable_expression)),
+    finally_clause: $ =>
+      prec.right(
+        seq($._control_tail_gate, "finally", $._indentable_expression),
+      ),
 
     /*
      * Binding           ::=  (id | ‘_’) [‘:’ Type]
@@ -2493,7 +2519,11 @@ module.exports = grammar({
               // plain $.expression so a next-line `do`/`yield` never starts it.
               field("body", choice($.indented_block, $.expression)),
               seq("do", field("body", $._indentable_expression)),
-              seq("yield", field("body", $._indentable_expression)),
+              seq(
+                $._control_tail_gate,
+                "yield",
+                field("body", $._indentable_expression),
+              ),
             ),
           ),
         ),
@@ -2505,7 +2535,11 @@ module.exports = grammar({
               field("enumerators", $.enumerators),
               choice(
                 seq("do", field("body", $._indentable_expression)),
-                seq("yield", field("body", $._indentable_expression)),
+                seq(
+                  $._control_tail_gate,
+                  "yield",
+                  field("body", $._indentable_expression),
+                ),
               ),
             ),
           ),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -40,7 +40,11 @@ enum TokenType {
   COLON_EOL,
   OPERATOR_EOL,
   FLOATING_POINT_WITH_SEPARATORS,
-  END_KEYWORD
+  END_KEYWORD,
+  // Zero-width, emitted right before a control-tail keyword (catch, finally,
+  // else, then, or yield) where the grammar allows one, so construct bodies
+  // share one follow column instead of per-keyword ones.
+  CONTROL_TAIL_GATE
 };
 
 const char* token_name[] = {
@@ -70,7 +74,8 @@ const char* token_name[] = {
   "COLON_EOL",
   "OPERATOR_EOL",
   "FLOATING_POINT_WITH_SEPARATORS",
-  "END_KEYWORD"
+  "END_KEYWORD",
+  "CONTROL_TAIL_GATE"
 };
 
 typedef struct {
@@ -950,6 +955,19 @@ static bool scan_impl(void *payload, TSLexer *lexer,
             word_in(word, block_opening_stoppers,
                     sizeof(block_opening_stoppers) /
                         sizeof(block_opening_stoppers[0]))) {
+          // The keyword belongs to an enclosing construct. Where its gate is
+          // valid and the word is a gated one, emit it (zero width: mark_end
+          // ran above) so the keyword can shift; otherwise no block opens
+          // here. `do` stays ungated: it can start a statement, and gate
+          // validity blends in from unrelated GLR forks.
+          static const char *const gated_stoppers[] = {"else", "catch",
+                                                       "finally", "yield"};
+          if (valid_symbols[CONTROL_TAIL_GATE] &&
+              word_in(word, gated_stoppers,
+                      sizeof(gated_stoppers) / sizeof(gated_stoppers[0]))) {
+            lexer->result_symbol = CONTROL_TAIL_GATE;
+            return true;
+          }
           return false;
         }
         // At top level the stack is empty, so the same-width `case` close at
@@ -1185,11 +1203,18 @@ static bool scan_impl(void *payload, TSLexer *lexer,
     // dispatch keeps scan_word from consuming a shared prefix.
     switch (lexer->lookahead) {
       case 'e':
-        if (!valid_symbols[ELSE] && !valid_symbols[EXTENDS]) {
+        if (!valid_symbols[ELSE] && !valid_symbols[EXTENDS] &&
+            !valid_symbols[CONTROL_TAIL_GATE]) {
           break;
         }
         advance(lexer);
-        if (valid_symbols[ELSE] && scan_word(lexer, "lse")) {
+        if ((valid_symbols[ELSE] || valid_symbols[CONTROL_TAIL_GATE]) &&
+            scan_word(lexer, "lse")) {
+          // The gate is zero width: mark_end ran before the word.
+          if (valid_symbols[CONTROL_TAIL_GATE]) {
+            lexer->result_symbol = CONTROL_TAIL_GATE;
+            return true;
+          }
           return false;
         }
         if (valid_symbols[EXTENDS] && scan_word(lexer, "xtends")) {
@@ -1204,7 +1229,12 @@ static bool scan_impl(void *payload, TSLexer *lexer,
         if (len <= 0) {
           break;
         }
-        if (valid_symbols[CATCH] && strcmp(word, "catch") == 0) {
+        if ((valid_symbols[CATCH] || valid_symbols[CONTROL_TAIL_GATE]) &&
+            strcmp(word, "catch") == 0) {
+          if (valid_symbols[CONTROL_TAIL_GATE]) {
+            lexer->result_symbol = CONTROL_TAIL_GATE;
+            return true;
+          }
           return false;
         }
         // A case clause line needs no separator, and suppressing it keeps
@@ -1221,7 +1251,12 @@ static bool scan_impl(void *payload, TSLexer *lexer,
         break;
       }
       case 'f':
-        if (valid_symbols[FINALLY] && scan_word(lexer, "finally")) {
+        if ((valid_symbols[FINALLY] || valid_symbols[CONTROL_TAIL_GATE]) &&
+            scan_word(lexer, "finally")) {
+          if (valid_symbols[CONTROL_TAIL_GATE]) {
+            lexer->result_symbol = CONTROL_TAIL_GATE;
+            return true;
+          }
           return false;
         }
         break;
@@ -1255,6 +1290,7 @@ static bool scan_impl(void *payload, TSLexer *lexer,
   if (
       valid_symbols[OUTDENT] &&
       !valid_symbols[ERROR_SENTINEL] &&
+      !valid_symbols[CONTROL_TAIL_GATE] &&
       newline_count == 0 &&
       prev != -1 &&
       (
@@ -1490,7 +1526,41 @@ static bool scan_impl(void *payload, TSLexer *lexer,
       LOG("    INDENT (same-width case region)\n");
       return true;
     }
+    // The word was not `case`. A `catch` at this width belongs to an
+    // enclosing try. The `case` probe above stopped at its `t`, so the
+    // remainder is `tch` (zero width: mark_end ran above).
+    if (valid_symbols[CONTROL_TAIL_GATE] && scan_word(lexer, "tch")) {
+      lexer->result_symbol = CONTROL_TAIL_GATE;
+      return true;
+    }
     return false;
+  }
+
+  // Zero-width gate before a control-tail keyword (see _control_tail_gate in
+  // the grammar). Tails on the same line, and tails the semicolon machinery
+  // never sees (inside parentheses, or after an emitted semicolon slot),
+  // arrive here.
+  if (valid_symbols[CONTROL_TAIL_GATE] && !valid_symbols[ERROR_SENTINEL]) {
+    switch (lexer->lookahead) {
+      case 'c': case 'e': case 'f': case 't': case 'y': {
+        lexer->mark_end(lexer);
+        // `do` and `while` stay ungated: they can start a statement, and
+        // gate validity blends in from unrelated GLR forks.
+        static const char *const tail_words[] = {
+            "catch", "else", "finally", "then", "yield"};
+        char word[sizeof "finally"];
+        int len = read_word(lexer, word, (int)sizeof word);
+        if (len > 0 &&
+            word_in(word, tail_words,
+                    sizeof(tail_words) / sizeof(tail_words[0]))) {
+          lexer->result_symbol = CONTROL_TAIL_GATE;
+          return true;
+        }
+        return false;
+      }
+      default:
+        break;
+    }
   }
 
   return false;


### PR DESCRIPTION
- This is a preparation for #218 which enlarges parser.c a lot.

A new zero-width external token sits right before catch, finally, else, then, and yield where the grammar allows one. Every construct body then ends with the same single gate column instead of its own keyword follow set, so the expression automaton stops being cloned per enclosing construct. The scanner emits the gate where the next word is one of the gated keywords. do and while stay ungated because they can start a statement and gate validity blends in from unrelated GLR forks.

Verified over 14,980 corpus files across 35 repos on my end. Trees are byte identical except one file where the parser previously split a curried fold block application into two statements and now reads it as scalac does, and one already failing file whose error recovery shape-shifts without changing error counts.