### PR TITLE
fix: rest-of-block lambdas and comma-closed templates in indented blocks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1191,7 +1191,16 @@ module.exports = grammar({
     indented_block: $ =>
       prec.left(
         PREC.control,
-        seq($._indent, $._block, choice($._outdent, $._comma_outdent)),
+        seq(
+          $._indent,
+          choice(
+            $._block,
+            // A lambda statement takes the rest of the enclosing block as
+            // its body (SLS ResultExpr), exactly as in braces.
+            alias($._indented_block_lambda, $.lambda_expression),
+          ),
+          choice($._outdent, $._comma_outdent),
+        ),
       ),
 
     indented_cases: $ =>
@@ -1617,6 +1626,22 @@ module.exports = grammar({
             ),
           ),
           $._braced_typed_lambda,
+        ),
+      ),
+
+    // The indented twin of _block_lambda_expression, without the typed
+    // branches. A typed head there (`x: T =>`) must stay a fewer-braces
+    // colon argument on `x`.
+    _indented_block_lambda: $ =>
+      prec.right(
+        "lambda",
+        seq(
+          field(
+            "parameters",
+            choice($.bindings, $.wildcard, $._single_lambda_param),
+          ),
+          anyArrow(),
+          optional($._block),
         ),
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -642,7 +642,10 @@ module.exports = grammar({
             // variant in _braced_template_body1.
             $.self_type,
           ),
-          $._outdent,
+          // The comma close lets a dedented `,` end a `new:` template used
+          // as an argument (`f(adapter = new: ...` + `    ,`) instead of
+          // leaving that reading to a losing GLR fork.
+          choice($._outdent, $._comma_outdent),
         ),
       ),
 

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2594,3 +2594,133 @@ end Wide
         (identifier)
         (type_identifier)))
     (end_marker)))
+
+================================================================================
+A dedented comma closes an indented template argument (Scala 3 syntax)
+================================================================================
+
+object T:
+  def a = Paginator(
+    adapter = new:
+      def slice(offset: Int): Int =
+        coll
+          .aggregateList(offset): framework =>
+            compute(framework)
+    ,
+    currentPage = 2
+  )
+
+  object inactive:
+    def apply(page: Int): Int =
+      Paginator(
+        adapter = new:
+          def slice(offset: Int): Int =
+            if offset == 0 then cache.get({})
+            else inactive.slice(offset)
+        ,
+        currentPage = page
+      )
+
+  def search(query: String): Int =
+
+    val day = 1
+    day
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    name: (identifier)
+    body: (template_body
+      (function_definition
+        name: (identifier)
+        body: (call_expression
+          function: (identifier)
+          arguments: (arguments
+            (assignment_expression
+              left: (identifier)
+              right: (instance_expression
+                (template_body
+                  (function_definition
+                    name: (identifier)
+                    parameters: (parameters
+                      (parameter
+                        name: (identifier)
+                        type: (type_identifier)))
+                    return_type: (type_identifier)
+                    body: (indented_block
+                      (call_expression
+                        function: (call_expression
+                          function: (field_expression
+                            value: (identifier)
+                            field: (identifier))
+                          arguments: (arguments
+                            (identifier)))
+                        arguments: (colon_argument
+                          lambda_start: (identifier)
+                          (indented_block
+                            (call_expression
+                              function: (identifier)
+                              arguments: (arguments
+                                (identifier)))))))))))
+            (assignment_expression
+              left: (identifier)
+              right: (integer_literal)))))
+      (object_definition
+        name: (identifier)
+        body: (template_body
+          (function_definition
+            name: (identifier)
+            parameters: (parameters
+              (parameter
+                name: (identifier)
+                type: (type_identifier)))
+            return_type: (type_identifier)
+            body: (indented_block
+              (call_expression
+                function: (identifier)
+                arguments: (arguments
+                  (assignment_expression
+                    left: (identifier)
+                    right: (instance_expression
+                      (template_body
+                        (function_definition
+                          name: (identifier)
+                          parameters: (parameters
+                            (parameter
+                              name: (identifier)
+                              type: (type_identifier)))
+                          return_type: (type_identifier)
+                          body: (indented_block
+                            (if_expression
+                              condition: (infix_expression
+                                left: (identifier)
+                                operator: (operator_identifier)
+                                right: (integer_literal))
+                              consequence: (call_expression
+                                function: (field_expression
+                                  value: (identifier)
+                                  field: (identifier))
+                                arguments: (arguments
+                                  (block)))
+                              alternative: (call_expression
+                                function: (field_expression
+                                  value: (identifier)
+                                  field: (identifier))
+                                arguments: (arguments
+                                  (identifier)))))))))
+                  (assignment_expression
+                    left: (identifier)
+                    right: (identifier))))))))
+      (function_definition
+        name: (identifier)
+        parameters: (parameters
+          (parameter
+            name: (identifier)
+            type: (type_identifier)))
+        return_type: (type_identifier)
+        body: (indented_block
+          (val_definition
+            pattern: (identifier)
+            value: (integer_literal))
+          (identifier))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -4360,3 +4360,40 @@ val h = { x: Int => y: Int => x + y }
             (type_identifier)
             (operator_identifier)
             (type_identifier)))))))
+
+================================================================================
+Lambda takes the rest of an indented block (Scala 3 syntax)
+================================================================================
+
+object T:
+  def f =
+    run(x):
+      implicit b =>
+      import G.*
+      compute(b)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    name: (identifier)
+    body: (template_body
+      (function_definition
+        name: (identifier)
+        body: (indented_block
+          (call_expression
+            function: (call_expression
+              function: (identifier)
+              arguments: (arguments
+                (identifier)))
+            arguments: (colon_argument
+              (indented_block
+                (lambda_expression
+                  parameters: (identifier)
+                  (import_declaration
+                    path: (identifier)
+                    (namespace_wildcard))
+                  (call_expression
+                    function: (identifier)
+                    arguments: (arguments
+                      (identifier))))))))))))


### PR DESCRIPTION
Two gaps where indented bodies lagged behind braces.
1. A lambda statement in an indented block now takes the remaining statements as its body. Seen in Akka
2. A dedented comma can close an indented `new:` template used as anargument. Seen in Lila
