### PR TITLE
chore: reserve the XML tag start external token

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -266,6 +266,9 @@ module.exports = grammar({
     // cloned per enclosing construct (catch/finally alone measured 15.5MB
     // of parser.c).
     $._control_tail_gate,
+    // The `<` that opens an XML literal. Only valid where the grammar admits
+    // a literal, so the operator `<` is untouched everywhere else.
+    $._xml_tag_start,
   ],
 
   inline: $ => [


### PR DESCRIPTION
This might be a controversial PR.
XML support had been decoupled from Scala compiler and standard library, but [scala-xml](https://github.com/scala/scala-xml) is still a thing and used in Scala ecosystem. For example, [pekko](https://github.com/apache/pekko/blob/4fe1f4a2d98c43469b196123f032daf1da9e0410/stream-tests/src/test/scala/org/apache/pekko/stream/scaladsl/CoupledTerminationFlowSpec.scala#L46-L48), [playframework](https://github.com/playframework/playframework/blob/d5f0341457a339beef5a9803a3e4650b9456ed9e/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala#L45), and [kamon](https://github.com/kamon-io/Kamon/blob/a376f39873921a1b2def82942e06950756522307/project/Build.scala#L239).
So I think it is worth adding XML support, until Scala adds a general way to embed external languages.

This PR reserves 
