### PR TITLE
feat: support XML literals and XML patterns 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -165,6 +165,9 @@ const fatArrow = () => choice("=>", alias("⇒", "=>"));
 // `=>` or the context-function arrow `?=>`.
 const anyArrow = () => choice(fatArrow(), "?=>");
 
+// XML Name (SLS §10 / XML spec), covering namespaced names like `x:ga`.
+const XML_NAME = /[_\p{L}][-.:_\p{L}\p{Nd}]*/;
+
 // Accepts a `:` in both spellings. The scanner lexes a line-final lone colon
 // as the external COLON_EOL token (scalac's COLONeol), so every consumer of
 // such a colon must handle it.
@@ -295,6 +298,11 @@ module.exports = grammar({
     $._non_null_literal,
     $._braced_template_body,
     $._indented_template_body,
+    // Inlined so the expression and pattern content variants never compete in
+    // a reduce, which they cannot be resolved out of.
+    $._xml_node,
+    $._xml_content,
+    $._xml_pattern_content,
     $._structural_type,
     $._refinement,
   ],
@@ -1636,6 +1644,7 @@ module.exports = grammar({
         $.quote_expression,
         $.literal,
         $.wildcard,
+        $.xml_pattern,
       ),
 
     case_class_pattern: $ =>
@@ -1755,6 +1764,7 @@ module.exports = grammar({
         $.field_expression,
         $.generic_function,
         $.call_expression,
+        $.xml_expression,
         $.method_value,
         alias($._dot_match_expression, $.match_expression),
       ),
@@ -2457,6 +2467,139 @@ module.exports = grammar({
      */
     operator_identifier: $ => choice($._asterisk, ...Object.values(OP_TOKEN)),
 
+    // XML literals (SLS §10). The external token $._xml_tag_start decides
+    // where markup starts. Comment, CDATA and processing instruction
+    // literals need no scanner support, since their tokens are longer than
+    // the operator tokens that could match the same text.
+
+    // XmlExpr ::= XmlContent {Element}
+    xml_expression: $ => repeat1($._xml_node),
+
+    _xml_node: $ =>
+      choice(
+        $.xml_element,
+        $.xml_comment,
+        $.xml_cdata,
+        $.xml_processing_instruction,
+      ),
+
+    xml_element: $ => xmlElementShape($, $._xml_content),
+
+    // Shared between expression elements and pattern elements so that GLR
+    // forks where both are viable shift the same states until the element
+    // body disambiguates them.
+    _xml_open_tag: $ =>
+      seq(
+        alias($._xml_tag_start, "<"),
+        field("name", alias(token.immediate(XML_NAME), $.xml_name)),
+        repeat($.xml_attribute),
+      ),
+
+    // The name is immediate, like scalac's xEndTag, which reads it right
+    // after the `</`. Trailing space before the `>` stays allowed.
+    _xml_end_tag: $ =>
+      seq("</", alias(token.immediate(XML_NAME), $.xml_name), ">"),
+
+    xml_attribute: $ =>
+      seq(
+        field("key", alias(token(XML_NAME), $.xml_name)),
+        "=",
+        field(
+          "value",
+          choice(
+            alias(token(choice(/"[^<"]*"/, /'[^<']*'/)), $.xml_string),
+            $.block,
+          ),
+        ),
+      ),
+
+    _xml_content: $ =>
+      choice(
+        ...xmlTextAlternatives($),
+        $.block,
+        $._xml_node,
+        // Dead alternative: `/*` in XML content is text, not a comment.
+        $._suppress_block_comment,
+      ),
+
+    // Outranks the comment and whitespace extras, which would otherwise win
+    // the same characters and drop markup text from the tree.
+    xml_text: _ => token(prec(PREC.comment + 1, /[^<{}]+/)),
+
+    // The bodies below stop at the first terminator: a run of the closing
+    // character can only be consumed when a character that cannot close the
+    // literal follows it.
+    xml_comment: _ =>
+      token(
+        seq(
+          "<!--",
+          repeat(choice(/[^-]/, seq(repeat1("-"), /[^->]/))),
+          repeat("-"),
+          "-->",
+        ),
+      ),
+
+    xml_cdata: _ =>
+      token(
+        seq(
+          "<![CDATA[",
+          repeat(choice(/[^\]]/, seq(repeat1("]"), /[^\]>]/))),
+          repeat("]"),
+          "]]>",
+        ),
+      ),
+
+    xml_processing_instruction: _ =>
+      token(
+        seq(
+          "<?",
+          repeat(choice(/[^?]/, seq(repeat1("?"), /[^?>]/))),
+          repeat("?"),
+          "?>",
+        ),
+      ),
+
+    // XmlPattern ::= ElemPattern. Embedded `{...}` blocks hold patterns.
+    xml_pattern: $ => xmlElementShape($, $._xml_pattern_content),
+
+    _xml_pattern_content: $ =>
+      choice(
+        ...xmlTextAlternatives($),
+        seq("{", commaSep1($._xml_embedded_pattern), "}"),
+        $.xml_pattern,
+        $.xml_comment,
+        $.xml_cdata,
+        $.xml_processing_instruction,
+        $._suppress_block_comment,
+      ),
+
+    // A restricted top-level pattern for XML embeds. Where an element and an
+    // element pattern both stay viable, $.block shares the state with this
+    // rule. An alternative whose leftmost symbol is the full $._pattern then
+    // drags given_pattern and ascriptions into the closure and the conflicts
+    // cascade past resolution, so only alternatives with a closed left edge
+    // belong here. Nested pattern positions still admit the full $._pattern.
+    _xml_embedded_pattern: $ =>
+      choice(
+        $._identifier,
+        $.stable_identifier,
+        $.interpolated_string_expression,
+        $.capture_pattern,
+        $.tuple_pattern,
+        $.named_tuple_pattern,
+        $.case_class_pattern,
+        $.quote_expression,
+        $.literal,
+        $.wildcard,
+        alias($._xml_repeat_pattern, $.repeat_pattern),
+        $.xml_pattern,
+      ),
+
+    // `_*` / `x*` at the top of an XML embed, without the $._pattern left
+    // recursion of $.repeat_pattern.
+    _xml_repeat_pattern: $ =>
+      seq(field("pattern", choice($.wildcard, $._identifier)), $._asterisk),
+
     _non_null_literal: $ =>
       choice(
         $.integer_literal,
@@ -2859,4 +3002,19 @@ function trailingSep1(delimiter, rule) {
 
 function sep1(delimiter, rule) {
   return seq(rule, repeat(seq(delimiter, rule)));
+}
+
+// Plain text and the `{{` / `}}` escaped literal braces, shared between XML
+// elements and XML patterns.
+function xmlTextAlternatives($) {
+  return [$.xml_text, alias("{{", $.xml_text), alias("}}", $.xml_text)];
+}
+
+// Element skeleton (self-closing, or open tag + content + end tag), shared
+// between xml_element and xml_pattern, which differ only in their content.
+function xmlElementShape($, content) {
+  return seq(
+    $._xml_open_tag,
+    choice("/>", seq(">", repeat(content), $._xml_end_tag)),
+  );
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -265,3 +265,12 @@
 ;; Scala CLI using directives
 (using_directive_key) @parameter
 (using_directive_value) @string
+
+;; XML literals
+(xml_name) @tag
+(xml_attribute key: (xml_name) @tag.attribute)
+(xml_string) @string
+(xml_text) @spell
+(xml_comment) @spell @comment
+(xml_cdata) @string
+(xml_processing_instruction) @keyword.directive

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -47,7 +47,8 @@ enum TokenType {
   // Zero-width, emitted right before a control-tail keyword (catch, finally,
   // else, then, or yield) where the grammar allows one, so construct bodies
   // share one follow column instead of per-keyword ones.
-  CONTROL_TAIL_GATE
+  CONTROL_TAIL_GATE,
+  XML_TAG_START
 };
 
 // Mirrors enum TokenType above.
@@ -80,7 +81,8 @@ const char* token_name[] = {
   "POSTFIX_STAR",
   "FLOATING_POINT_WITH_SEPARATORS",
   "END_KEYWORD",
-  "CONTROL_TAIL_GATE"
+  "CONTROL_TAIL_GATE",
+  "XML_TAG_START"
 };
 
 typedef struct {
@@ -205,6 +207,13 @@ static bool is_op_char(int32_t c) {
     default:
       return false;
   }
+}
+
+// Mirrors the start class of XML_NAME in grammar.js. Every non-ASCII
+// character is accepted, since iswalpha is ASCII-only under the C locale and
+// the internal lexer rejects the name if it is not a letter after all.
+static bool is_xml_name_start(int32_t c) {
+  return iswalpha(c) || c == '_' || c > 127;
 }
 
 // An operator directly before one of these ends its expression, so no right
@@ -1332,6 +1341,20 @@ static bool scan_impl(void *payload, TSLexer *lexer,
       newline_count++;
     }
     skip(lexer);
+  }
+
+  // XML mode (SLS §10) starts only where the grammar makes XML_TAG_START
+  // valid and the `<` is immediately followed by a name-start character, so
+  // `< b` and `<-`, `<:`, `<=` fall through to the regular operator tokens.
+  if (valid_symbols[XML_TAG_START] && !valid_symbols[ERROR_SENTINEL] &&
+      lexer->lookahead == '<') {
+    advance(lexer);
+    if (is_xml_name_start(lexer->lookahead)) {
+      lexer->mark_end(lexer);
+      lexer->result_symbol = XML_TAG_START;
+      return true;
+    }
+    return false;
   }
 
   // A floating point literal whose integer part uses digit separators.

--- a/test/corpus/xml.txt
+++ b/test/corpus/xml.txt
@@ -1,0 +1,269 @@
+================================================================================
+XML literal: simple element
+================================================================================
+
+val a = <b>hi</b>
+val b = <x/>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_text)
+        (xml_name))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)))))
+
+================================================================================
+XML literal: attributes
+================================================================================
+
+val a = <x y="1" z='2'/>
+val b = <link xmlns=""/>
+val c = <elem key={x1} />
+val d = <z:hello foo="bar" xmlns:z="z">text</z:hello>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_attribute
+          (xml_name)
+          (xml_string)))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string)))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (block
+            (identifier))))))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_attribute
+          (xml_name)
+          (xml_string))
+        (xml_text)
+        (xml_name)))))
+
+================================================================================
+XML literal: nested elements and embedded expressions
+================================================================================
+
+val a =
+  <bks>
+    <book><title>{name}</title></book>
+    {{escaped}}
+  </bks>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (indented_block
+      (xml_expression
+        (xml_element
+          (xml_name)
+          (xml_element
+            (xml_name)
+            (xml_element
+              (xml_name)
+              (block
+                (identifier))
+              (xml_name))
+            (xml_name))
+          (xml_text)
+          (xml_text)
+          (xml_text)
+          (xml_text)
+          (xml_text)
+          (xml_name))))))
+
+================================================================================
+XML literal: comment, CDATA, processing instruction
+================================================================================
+
+val a = <!-- thissa comment -->.toString
+val b = <?pi foo bar?>.toString
+val c = <![CDATA[ "quoted" ]]>.toString
+val d = <a><!-- inner --><![CDATA[x]]><?p q?></a>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_comment))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_processing_instruction))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (field_expression
+      (xml_expression
+        (xml_cdata))
+      (identifier)))
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name)
+        (xml_comment)
+        (xml_cdata)
+        (xml_processing_instruction)
+        (xml_name)))))
+
+================================================================================
+XML literal: element sequence
+================================================================================
+
+val ns = <a/><b/>
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (xml_expression
+      (xml_element
+        (xml_name))
+      (xml_element
+        (xml_name)))))
+
+================================================================================
+XML literal: `<` operators are unaffected
+================================================================================
+
+val cmp = a < b
+val cmpParen = if (x <y) x else y
+val shift = 1 << 2
+val leadingInfix = a
+  < b
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (if_expression
+      (parenthesized_expression
+        (infix_expression
+          (identifier)
+          (operator_identifier)
+          (identifier)))
+      (identifier)
+      (identifier)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (integer_literal)
+      (operator_identifier)
+      (integer_literal)))
+  (val_definition
+    (identifier)
+    (infix_expression
+      (identifier)
+      (operator_identifier)
+      (identifier))))
+
+================================================================================
+XML patterns
+================================================================================
+
+def m(x: Node) = x match {
+  case <hello/> => true
+  case <x:ga/> => true
+  case <t>{_*}</t> => false
+  case <a>{ns @ _*}</a> => ns
+  case <bks><book/>{rest @ _*}</bks> => rest
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (xml_pattern
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (repeat_pattern
+              (wildcard))
+            (xml_name))
+          (boolean_literal))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (capture_pattern
+              (identifier)
+              (repeat_pattern
+                (wildcard)))
+            (xml_name))
+          (identifier))
+        (case_clause
+          (xml_pattern
+            (xml_name)
+            (xml_pattern
+              (xml_name))
+            (capture_pattern
+              (identifier)
+              (repeat_pattern
+                (wildcard)))
+            (xml_name))
+          (identifier))))))


### PR DESCRIPTION
The `<` that opens a literal is lexed by the new external token XML_TAG_START. The scanner returns it only where the grammar admits a literal and the `<` is immediately followed by a name start character, so `a < b`, a leading infix `< b`, `<-` and `<:` keep lexing as operators. Comment, CDATA and processing instruction literals need no scanner support because their tokens beat the operator tokens by length.

Expression elements and pattern elements share the open tag rule, so a position where both are viable shifts the same states until the element body decides. Top level patterns inside an embed are a restricted list. An alternative whose left edge is the full pattern rule drags given patterns and ascriptions into the same closure as the statement grammar of a block, and the conflicts then cascade beyond resolution. `_*` is kept through a restricted repeat pattern alias, and nested pattern positions still take any pattern.


- Seen in [scala-xml](https://github.com/scala/scala-xml/blob/a4c4e52e88ea92fb019650208984170942407db4/shared/src/test/scala/scala/xml/PatternMatchingTest.scala#L28)
- Seen in [akka](https://github.com/akka/akka/blob/e75e809380ee16a18b12007d69bb46c30b9230e7/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CoupledTerminationFlowSpec.scala#L35)
- Seen in [play](https://github.com/playframework/playframework/blob/aed7df209fc4074147408b7ea16b5259ec3faed8/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala#L45)
- Seen in [kamon](https://github.com/kamon-io/Kamon/blob/a376f39873921a1b2def82942e06950756522307/project/Build.scala#L239)

----
This is the last PR in the series for the new features.
Publishing new version is appreciated.