### PR TITLE
feat: parse binary integer literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2618,7 +2618,13 @@ module.exports = grammar({
       token(
         seq(
           optional(/[-]/),
-          choice(/[\d](_?\d)*/, /0[xX][\da-fA-F](_?[\da-fA-F])*/),
+          choice(
+            /[\d](_?\d)*/,
+            /0[xX][\da-fA-F](_?[\da-fA-F])*/,
+            // Dotty's scanner loops over separators, so `0b0001__0000` is legal
+            // and only a trailing `_` is an error.
+            /0[bB][01](_*[01])*/,
+          ),
           optional(/[lL]/),
         ),
       ),

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -399,10 +399,22 @@ val l3 = 0xF23l
 val l4 = 0XA03L
 val l5 = 150_000_000
 val l6 = 0xFF_FF_FF
+val b1 = 0b1
+val b2 = 0B0000
+val b3 = 0b1000_0000_0000_0000__0000_0000_0000_0000L
 
 --------------------------------------------------------------------------------
 
 (compilation_unit
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
+  (val_definition
+    (identifier)
+    (integer_literal))
   (val_definition
     (identifier)
     (integer_literal))


### PR DESCRIPTION
> [!NOTE]
> This is one of a series of PRs that gets the dotty codebase to 100% parse coverage.

Dotty's scanner reads `0b` and `0B` as a base 2 prefix. The grammar only had the hex prefix, so `0B0000` lexed as `0` followed by an identifier. The scanner loops over separators and rejects only a trailing one, so `0b0001__0000` is legal and the rule allows repeated underscores.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/run/binaryLiterals.scala