### PR TITLE
feat: parse a type with more than one refinement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1465,7 +1465,14 @@ module.exports = grammar({
             repeat1(seq("with", field("extra", $._annotated_type))),
           ),
         ),
-        prec.left(seq(field("base", $._annotated_type), $._refinement)),
+        // Dotty's refinedTypeRest recurses on itself, so a type takes any
+        // number of refinements. `C { type U = T } { type T = String }`.
+        prec.left(
+          seq(
+            field("base", choice($._annotated_type, $.compound_type)),
+            $._refinement,
+          ),
+        ),
         prec.left(
           -1,
           seq(

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1066,3 +1066,64 @@ end Merge
             (identifier)))))
     (end_marker)))
 
+================================================================================
+Chained refinements
+================================================================================
+
+type X = C { type U = T; def u: U } { type T = String }
+
+type T1 = C { type T <: A } { type T <: B }
+
+var xx: (Lambda { type Apply = Arg } { type Arg = Int }) # Apply = uninitialized
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (type_definition
+    (type_identifier)
+    (compound_type
+      (compound_type
+        (type_identifier)
+        (refinement
+          (type_definition
+            (type_identifier)
+            (type_identifier))
+          (function_declaration
+            (identifier)
+            (type_identifier))))
+      (refinement
+        (type_definition
+          (type_identifier)
+          (type_identifier)))))
+  (type_definition
+    (type_identifier)
+    (compound_type
+      (compound_type
+        (type_identifier)
+        (refinement
+          (type_definition
+            (type_identifier)
+            (upper_bound
+              (type_identifier)))))
+      (refinement
+        (type_definition
+          (type_identifier)
+          (upper_bound
+            (type_identifier))))))
+  (var_definition
+    (identifier)
+    (projected_type
+      (tuple_type
+        (compound_type
+          (compound_type
+            (type_identifier)
+            (refinement
+              (type_definition
+                (type_identifier)
+                (type_identifier))))
+          (refinement
+            (type_definition
+              (type_identifier)
+              (type_identifier)))))
+      (type_identifier))
+    (identifier)))


### PR DESCRIPTION
> [!NOTE]
> This is one of a series of PRs that gets the dotty codebase to 100% parse coverage.

Dotty's refinedTypeRest calls itself on the tree it just built, so a type takes any number of refinements. The grammar allowed only one, so `C { type U = T } { type T = String }` did not parse.

The rule recurses on compound_type instead of repeating the refinement. That nests the tree the way dotty nests RefinedTypeTree, and it costs 33KB less in parser.c than a repeat does.

A `#` projection still needs the parens that dotty needs, because dotty reads `#` in simpleTypeRest, which sits below refinement.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/lookuprefined.scala Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/projections.scala