### PR TITLE
feat: parse type bindings in a quote type block

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2409,7 +2409,9 @@ module.exports = grammar({
           choice(
             // `'{}` is a quoted empty block, common in macro code.
             seq("{", optional($._block), "}"),
-            seq("[", $._type, "]"),
+            // TypeBlock ::= {TypeBlockStat semi} Type. The bindings let a
+            // quote name the type variables it matches on.
+            seq("[", repeat(seq($.type_definition, $._semicolon)), $._type, "]"),
             $.identifier,
             $.null_literal,
             $.boolean_literal,

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2739,6 +2739,67 @@ inline def e(inline m: String): Unit =
               (identifier))))))))
 
 ================================================================================
+Type bindings in a quote type block (Scala 3)
+================================================================================
+
+def types(t: Type[?])(using Quotes) = t match {
+  case '[type x <: AnyKind; x] =>
+  case '[ type t <: Tuple; *:[t, t] ] =>
+  case '[
+    type t
+    type u
+    Map[t, u]
+  ] =>
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier)))))
+    (parameters
+      (type_identifier))
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (quote_expression
+            (type_definition
+              (type_identifier)
+              (upper_bound
+                (type_identifier)))
+            (type_identifier)))
+        (case_clause
+          (quote_expression
+            (type_definition
+              (type_identifier)
+              (upper_bound
+                (type_identifier)))
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier)
+                (type_identifier)))))
+        (case_clause
+          (quote_expression
+            (type_definition
+              (type_identifier))
+            (type_definition
+              (type_identifier))
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier)
+                (type_identifier)))))))))
+
+================================================================================
 Empty statements before a statement
 ================================================================================
 


### PR DESCRIPTION
Dotty parses the body of `'[...]` as TypeBlock, which is a run of type definitions followed by the type itself. The rule took a bare type, so `'[type x <: AnyKind; x]` did not parse.

The separator is _semicolon rather than a literal `;` because dotty takes a newline there too, and a test in the corpus writes each binding on its own line. Requiring a literal `;` costs 105KB more and still misses that file. Leaving the separator optional costs 682KB more, because the context bound repetition stops closing on sight of the next `:`.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos-macros/multiline-quote-patterns.scala
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos-macros/i7264.scala