### PR TITLE
feat: allow a semicolon after a match type case

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1590,7 +1590,14 @@ module.exports = grammar({
     type_case_clause: $ =>
       prec.left(
         PREC.control,
-        seq("case", $._infix_type_choice, field("body", $._arrow_then_type)),
+        // Dotty's typeCaseClause takes one optional `;` after the body, so a
+        // separator is allowed after every clause including the last.
+        seq(
+          "case",
+          $._infix_type_choice,
+          field("body", $._arrow_then_type),
+          optional(";"),
+        ),
       ),
 
     // A plain type wins where both readings are legal (ascription, pattern,

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -278,6 +278,51 @@ type Elem[A] = A match {
         (type_identifier)))))
 
 ================================================================================
+Match type cases separated by a semicolon (Scala 3 syntax)
+================================================================================
+
+type Choice[A] = A match { case Int => Long ; case Long => Int }
+
+type Trailing = X match { case Int => String; }
+
+type Indented = X match
+  case Int => String;
+  case String => Int
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (type_definition
+    (type_identifier)
+    (type_parameters
+      (identifier))
+    (match_type
+      (type_identifier)
+      (type_case_clause
+        (type_identifier)
+        (type_identifier))
+      (type_case_clause
+        (type_identifier)
+        (type_identifier))))
+  (type_definition
+    (type_identifier)
+    (match_type
+      (type_identifier)
+      (type_case_clause
+        (type_identifier)
+        (type_identifier))))
+  (type_definition
+    (type_identifier)
+    (match_type
+      (type_identifier)
+      (type_case_clause
+        (type_identifier)
+        (type_identifier))
+      (type_case_clause
+        (type_identifier)
+        (type_identifier)))))
+
+================================================================================
 Compound types
 ================================================================================
 


### PR DESCRIPTION
> [!NOTE]
> This is one of a series of PRs that gets the dotty codebase to 100% parse coverage.

Dotty's typeCaseClause takes one optional `;` after the case body, which its grammar comment spells as `[semi]`. The rule had no separator, so `X match { case Int => Long ; case Long => Int }` did not parse.

The separator sits inside type_case_clause the way dotty consumes it, so a trailing `;` before the closing brace works too. Dotty reads at most one, and `;;` stays a syntax error here as well.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/case-semi.scala Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/i13331.scala