### PR TITLE
feat: parse the erased modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -350,6 +350,9 @@ module.exports = grammar({
     [$._infix_operand, $.vararg],
     [$.tuple_type, $.parameter_types],
     [$.inline_modifier, $._soft_identifier],
+    // 'erased' at a parameter start is the modifier when a name follows and the
+    // name itself when a colon does, which only the next token settles.
+    [$.erased_modifier, $._soft_identifier],
     // 'extension' • '{' is either an extension definition with a braced body
     // or the soft identifier `extension` (a Scala 2 id) called with a block.
     [$.extension_definition, $._soft_identifier],
@@ -1231,6 +1234,7 @@ module.exports = grammar({
               "override",
               $.access_modifier,
               $.inline_modifier,
+              $.erased_modifier,
               $.infix_modifier,
               $.into_modifier,
               $.open_modifier,
@@ -1252,6 +1256,10 @@ module.exports = grammar({
     // so a static "mod" win would misparse `inline || x`; fork instead and
     // prefer the modifier only when both readings complete (`inline if`).
     inline_modifier: $ => prec.dynamic(1, "inline"),
+    // No "mod" precedence, unlike its neighbours. `erased` is also a plain name
+    // (`def f(erased: Int)`), and a static win would take the modifier every
+    // time; the declared conflict lets the next token pick instead.
+    erased_modifier: $ => "erased",
     infix_modifier: $ => prec("mod", "infix"),
     into_modifier: $ => prec("mod", "into"),
     open_modifier: $ => prec("mod", "open"),
@@ -1341,6 +1349,7 @@ module.exports = grammar({
         seq(
           repeat($.annotation),
           optional($.inline_modifier),
+          optional($.erased_modifier),
           field("name", $._identifier),
           ":",
           field("type", $._param_type),
@@ -1358,6 +1367,7 @@ module.exports = grammar({
         // it, so the typed reading must accept both spellings. Keep in sync
         // with $.binding, whose token path this rule shares.
         seq(
+          optional($.erased_modifier),
           field("name", $._identifier),
           colonEol($),
           field("type", $._param_type),
@@ -2052,6 +2062,7 @@ module.exports = grammar({
      */
     binding: $ =>
       seq(
+        optional($.erased_modifier),
         choice(field("name", operandName($)), $.wildcard),
         // colonEol here mirrors name_and_type, the shared-token twin of this rule.
         optional(seq(colonEol($), field("type", $._param_type))),
@@ -2442,6 +2453,7 @@ module.exports = grammar({
       prec(
         "soft_id",
         choice(
+          "erased",
           "infix",
           "inline",
           "opaque",

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2724,3 +2724,113 @@ object T:
             pattern: (identifier)
             value: (integer_literal))
           (identifier))))))
+
+================================================================================
+Erased definitions and parameters (Scala 3)
+================================================================================
+
+erased def d1: Int = 1
+
+def f1(x: Int, erased y: Int) = 0
+
+def f2(using erased y: Int) = 0
+
+infix type throws[R, E] = (erased ct: CanThrow[E]) ?=> R
+
+val l1: (erased e: Ev, i: Int) => Int = (erased ev, x) => x + 2
+
+def f3(x: Int, erased: Int) = 0
+
+def f4(x: Int, erased inline: Int) = 0
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (modifiers
+      (erased_modifier))
+    (identifier)
+    (type_identifier)
+    (integer_literal))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier))
+      (parameter
+        (erased_modifier)
+        (identifier)
+        (type_identifier)))
+    (integer_literal))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (erased_modifier)
+        (identifier)
+        (type_identifier)))
+    (integer_literal))
+  (type_definition
+    (modifiers
+      (infix_modifier))
+    (type_identifier)
+    (type_parameters
+      (identifier)
+      (identifier))
+    (function_type
+      (parameter_types
+        (named_tuple_type
+          (name_and_type
+            (erased_modifier)
+            (identifier)
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier))))))
+      (type_identifier)))
+  (val_definition
+    (identifier)
+    (function_type
+      (parameter_types
+        (named_tuple_type
+          (name_and_type
+            (erased_modifier)
+            (identifier)
+            (type_identifier))
+          (name_and_type
+            (identifier)
+            (type_identifier))))
+      (type_identifier))
+    (lambda_expression
+      (bindings
+        (binding
+          (erased_modifier)
+          (identifier))
+        (binding
+          (identifier)))
+      (infix_expression
+        (identifier)
+        (operator_identifier)
+        (integer_literal))))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier))
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (integer_literal))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier))
+      (parameter
+        (erased_modifier)
+        (identifier)
+        (type_identifier)))
+    (integer_literal)))


### PR DESCRIPTION
> [!NOTE]
> This is one of a series of PRs that gets the dotty codebase to 100% parse coverage.

`erased` marks a definition or a parameter whose value is dropped after type checking. It reaches four places. modifiers covers `erased def` and `erased val`, parameter covers `def f(erased x: Int)`, name_and_type covers the function type `(erased ct: CanThrow[E]) ?=> R`, and binding covers the lambda `(erased ev, x) => x + 2`.

The rule carries no "mod" precedence, unlike its neighbours, because `erased` is also a plain name. A static win would take the modifier in `def f(erased: Int)` and never recover. The declared conflict against _soft_identifier lets the token after it decide, which is what dotty does with its lookahead for a colon.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/erased-soft-keyword.scala
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/erased-lambda.scala