### PR TITLE
feat: parse a given import selector outside braces

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -658,6 +658,9 @@ module.exports = grammar({
               seq(
                 ".",
                 choice(
+                  // A bound given selector is a WildCardSelector, so it stands
+                  // on its own as well as inside braces.
+                  $._namespace_given_by_type,
                   $.namespace_wildcard,
                   $.namespace_selectors,
                   // Only allowed in Scala 3

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -431,6 +431,31 @@ import tools.nsc.classpath.{given Test, given Test2, Test3}
       (identifier))))
 
 ================================================================================
+Imports: Given by type without braces (Scala 3 syntax)
+================================================================================
+
+import bar.given Foo
+import Ordering.Implicits.given Ordering[?]
+import bar.given
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (import_declaration
+    (identifier)
+    (type_identifier))
+  (import_declaration
+    (identifier)
+    (identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier))))
+  (import_declaration
+    (identifier)
+    (namespace_wildcard)))
+
+================================================================================
 Imports: Rename (Scala 3 Syntax)
 ================================================================================
 


### PR DESCRIPTION
A bound given selector is a WildCardSelector in dotty, so it stands alone as well as inside braces. The rule for it was only wired into the braced form, so `import bar.given Foo` did not parse while `import a.{given Foo}` did. The grammar comment already carried the right definition.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/run/i18183.given.scala
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/warn/i20860.scala