### PR TITLE
feat: take a refinement as an intersection operand

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -352,6 +352,8 @@ module.exports = grammar({
     // ascribed argument or shift the colon of a Scala 2 vararg `x: _*`.
     [$._infix_operand, $.vararg],
     [$.tuple_type, $.parameter_types],
+    // Both spell a braced body, so the reduce after `}` is ambiguous.
+    [$._structural_body, $.template_body],
     [$.inline_modifier, $._soft_identifier],
     // 'erased' at a parameter start is the modifier when a name follows and the
     // name itself when a colon does, which only the next token settles.
@@ -1527,8 +1529,14 @@ module.exports = grammar({
         ),
       ),
 
+    // Braced only, as dotty's refinement(indentOK = false) is. The indented
+    // spelling belongs to the refinement suffix, which keeps template_body.
     _structural_type: $ =>
-      prec("structural_type", alias($.template_body, $.structural_type)),
+      prec("structural_type", alias($._structural_body, $.structural_type)),
+
+    // The dynamic weight keeps `new { "ok" }` an instance expression, which
+    // shares this body and would otherwise tie with it.
+    _structural_body: $ => prec.dynamic(-1, $._braced_template_body),
 
     _refinement: $ => alias($.template_body, $.refinement),
 
@@ -1546,9 +1554,10 @@ module.exports = grammar({
     infix_type: $ =>
       prec.left(
         seq(
-          field("left", $._infix_type_choice),
+          // SimpleType1 admits a bare Refinement: `A & { type X = Int }`.
+          field("left", choice($._infix_type_choice, $._structural_type)),
           field("operator", wordOrOpName($)),
-          field("right", $._infix_type_choice),
+          field("right", choice($._infix_type_choice, $._structural_type)),
         ),
       ),
 

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -323,6 +323,74 @@ type Indented = X match
         (type_identifier)))))
 
 ================================================================================
+Refinement as an intersection operand (Scala 3 syntax)
+================================================================================
+
+val c: Cont[Int] & { type A = Int } = ???
+
+val x: this.type & { type UX = Int } = ???
+
+type M = { type T[+A] } & { type T[-A] }
+
+type Q = A & { type X = Int } & C
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_type
+      (generic_type
+        (type_identifier)
+        (type_arguments
+          (type_identifier)))
+      (operator_identifier)
+      (structural_type
+        (type_definition
+          (type_identifier)
+          (type_identifier))))
+    (operator_identifier))
+  (val_definition
+    (identifier)
+    (infix_type
+      (singleton_type
+        (identifier))
+      (operator_identifier)
+      (structural_type
+        (type_definition
+          (type_identifier)
+          (type_identifier))))
+    (operator_identifier))
+  (type_definition
+    (type_identifier)
+    (infix_type
+      (structural_type
+        (type_definition
+          (type_identifier)
+          (type_parameters
+            (covariant_type_parameter
+              (identifier)))))
+      (operator_identifier)
+      (structural_type
+        (type_definition
+          (type_identifier)
+          (type_parameters
+            (contravariant_type_parameter
+              (identifier)))))))
+  (type_definition
+    (type_identifier)
+    (infix_type
+      (infix_type
+        (type_identifier)
+        (operator_identifier)
+        (structural_type
+          (type_definition
+            (type_identifier)
+            (type_identifier))))
+      (operator_identifier)
+      (type_identifier))))
+
+================================================================================
 Compound types
 ================================================================================
 


### PR DESCRIPTION
SimpleType1 admits a bare Refinement, so `{ type A = Int }` is a type of its own and belongs on either side of an infix type operator. The operands left that case out, so `A & { type X = Int }` did not parse. It covers 40 files in the corpus, most of them capture-checking sources.

The operand takes the braced spelling only, the way simpleType1 calls refinement(indentOK = false). Admitting the indented one costs 1.3MB of parser.c instead of 438KB.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/i2858.scala
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/i5699.scala