### PR TITLE
perf: read the soft modifiers in the scanner, shrink parser.c by 2.76 MiB

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -206,8 +206,16 @@ const nameChoice = $ =>
     alias("super", $.identifier),
   );
 
-// The scanner-lexed `erased`, keeping the keyword token's node name.
+// The scanner-lexed soft modifiers, each keeping its keyword token's node name.
 const erasedMod = $ => alias($._erased_modifier, $.erased_modifier);
+const openMod = $ => alias($._open_modifier, $.open_modifier);
+const opaqueMod = $ => alias($._opaque_modifier, $.opaque_modifier);
+const infixMod = $ => alias($._infix_modifier, $.infix_modifier);
+const trackedMod = $ => alias($._tracked_modifier, $.tracked_modifier);
+const transparentMod = $ =>
+  alias($._transparent_modifier, $.transparent_modifier);
+const intoMod = $ => alias($._into_modifier, $.into_modifier);
+const inlineMod = $ => alias($._inline_modifier, $.inline_modifier);
 
 // The union operator token as a name (see OP_ID_UNION).
 const opName = $ => alias(OP_ID_UNION, $.operator_identifier);
@@ -292,12 +300,9 @@ module.exports = grammar({
     // The `<` that opens an XML literal. Only valid where the grammar admits
     // a literal, so the operator `<` is untouched everywhere else.
     $._xml_tag_start,
-    // `erased` is a name too (`nme.erased`), so lexing it as a keyword costs a
+    // Each of these is a name as well, so a keyword token would cost a
     // soft-identifier alternative in every name position.
     $._erased_modifier,
-    // Reserved for the rest of the soft modifiers, which cost the same
-    // soft-identifier alternative that `erased` used to. The scanner does not
-    // emit these yet, so the keyword tokens still lex every occurrence.
     $._open_modifier,
     $._opaque_modifier,
     $._infix_modifier,
@@ -375,7 +380,6 @@ module.exports = grammar({
     [$.tuple_type, $.parameter_types],
     // Both spell a braced body, so the reduce after `}` is ambiguous.
     [$._structural_body, $.template_body],
-    [$.inline_modifier, $._soft_identifier],
     // 'extension' • '{' is either an extension definition with a braced body
     // or the soft identifier `extension` (a Scala 2 id) called with a block.
     [$.extension_definition, $._soft_identifier],
@@ -1058,7 +1062,7 @@ module.exports = grammar({
         seq(
           repeat($.annotation),
           optional($.modifiers),
-          optional($.opaque_modifier),
+          optional(opaqueMod($)),
           "type",
           $._type_constructor,
           optional(seq("=", field("type", $._type))),
@@ -1117,8 +1121,6 @@ module.exports = grammar({
           optional($._automatic_semicolon),
         ),
       ),
-
-    opaque_modifier: $ => prec("mod", "opaque"),
 
     /**
      *   Extension         ::=  'extension' [DefTypeParamClause] {UsingParamClause}
@@ -1314,13 +1316,13 @@ module.exports = grammar({
               "lazy",
               "override",
               $.access_modifier,
-              $.inline_modifier,
+              inlineMod($),
               erasedMod($),
-              $.infix_modifier,
-              $.into_modifier,
-              $.open_modifier,
-              $.tracked_modifier,
-              $.transparent_modifier,
+              infixMod($),
+              intoMod($),
+              openMod($),
+              trackedMod($),
+              transparentMod($),
             ),
           ),
         ),
@@ -1332,16 +1334,6 @@ module.exports = grammar({
       ),
 
     access_qualifier: $ => seq("[", $._identifier, "]"),
-
-    // Unlike other soft modifiers `inline` is also valid at expression start,
-    // so a static "mod" win would misparse `inline || x`; fork instead and
-    // prefer the modifier only when both readings complete (`inline if`).
-    inline_modifier: $ => prec.dynamic(1, "inline"),
-    infix_modifier: $ => prec("mod", "infix"),
-    into_modifier: $ => prec("mod", "into"),
-    open_modifier: $ => prec("mod", "open"),
-    tracked_modifier: $ => prec("mod", "tracked"),
-    transparent_modifier: $ => prec("mod", "transparent"),
 
     /**
      * InheritClauses    ::=  ['extends' ConstrApps] ['derives' QualId {',' QualId}]
@@ -1425,10 +1417,10 @@ module.exports = grammar({
         PREC.control,
         seq(
           repeat($.annotation),
-          optional($.inline_modifier),
+          optional(inlineMod($)),
           optional(erasedMod($)),
           // A given conditional clause takes `tracked val`.
-          optional($.tracked_modifier),
+          optional(trackedMod($)),
           optional(choice("val", "var")),
           field("name", $._identifier),
           ":",
@@ -2013,7 +2005,7 @@ module.exports = grammar({
      */
     if_expression: $ =>
       seq(
-        optional($.inline_modifier),
+        optional(inlineMod($)),
         "if",
         choice(
           // No marker slot here. Paren-if marker heads multiply the block
@@ -2082,7 +2074,7 @@ module.exports = grammar({
     match_expression: $ =>
       choice(
         seq(
-          optional($.inline_modifier),
+          optional(inlineMod($)),
           field("value", $.expression),
           "match",
           // A braced case block takes no marker. Real code never writes
@@ -2549,20 +2541,7 @@ module.exports = grammar({
     _super_identifier: $ => "super",
 
     // https://docs.scala-lang.org/scala3/reference/soft-modifier.html
-    _soft_identifier: $ =>
-      prec(
-        "soft_id",
-        choice(
-          "infix",
-          "inline",
-          "opaque",
-          "open",
-          "tracked",
-          "transparent",
-          "end",
-          "extension",
-        ),
-      ),
+    _soft_identifier: $ => prec("soft_id", "extension"),
 
     /**
      * alphaid          ::=  upper idrest

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -165,10 +165,12 @@
   "with"
   "given"
   "using"
-  "end"
   "implicit"
   "with"
 ] @keyword
+
+; `end` is scanner-lexed, so the marker node is the only thing to match.
+(end_marker) @keyword
 
 ; `extension` is a soft keyword. Highlight it only where it starts an
 ; extension definition, not when used as a plain identifier.

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -21,7 +21,7 @@
 
 "}" @indent.end
 
-"end" @indent.end
+(end_marker) @indent.end
 
 [
   ")"

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,7 +48,14 @@ enum TokenType {
   // share one follow column instead of per-keyword ones.
   CONTROL_TAIL_GATE,
   XML_TAG_START,
-  ERASED_MODIFIER
+  ERASED_MODIFIER,
+  OPEN_MODIFIER,
+  OPAQUE_MODIFIER,
+  INFIX_MODIFIER,
+  TRACKED_MODIFIER,
+  TRANSPARENT_MODIFIER,
+  INLINE_MODIFIER,
+  INTO_MODIFIER
 };
 
 // Mirrors enum TokenType above.
@@ -83,7 +90,14 @@ const char* token_name[] = {
   "END_KEYWORD",
   "CONTROL_TAIL_GATE",
   "XML_TAG_START",
-  "ERASED_MODIFIER"
+  "ERASED_MODIFIER",
+  "OPEN_MODIFIER",
+  "OPAQUE_MODIFIER",
+  "INFIX_MODIFIER",
+  "TRACKED_MODIFIER",
+  "TRANSPARENT_MODIFIER",
+  "INLINE_MODIFIER",
+  "INTO_MODIFIER"
 };
 
 typedef struct {
@@ -415,24 +429,62 @@ static bool word_in(const char *word, const char *const words[],
 }
 
 // Whether a name follows the word just read, which is what makes an `end`
-// tag a marker and an `erased` a modifier. Block comments in between are
+// tag a marker and an `open` a modifier. Block comments in between are
 // transparent, as they are to the parser.
-static bool name_follows_word(TSLexer *lexer) {
+static void skip_blanks_and_block_comments(TSLexer *lexer) {
   for (;;) {
     advance_past_blanks(lexer);
     if (lexer->lookahead != '/') {
-      break;
+      return;
     }
     advance(lexer);
     if (lexer->lookahead != '*') {
-      break;
+      return;
     }
     advance(lexer);
     consume_block_comment_body(lexer);
   }
+}
+
+static bool name_follows_word(TSLexer *lexer) {
+  skip_blanks_and_block_comments(lexer);
   return is_alpha(lexer->lookahead) || lexer->lookahead == '_' ||
          lexer->lookahead == '$' || lexer->lookahead == '`' ||
          lexer->lookahead > 127;
+}
+
+// `inline` also prefixes the scrutinee of `inline 1 match`, and it can end a
+// modifier line whose definition is on the next one.
+static bool inline_modifier_follows(TSLexer *lexer) {
+  if (name_follows_word(lexer)) {
+    return true;
+  }
+  // A scrutinee starts an expression. See canStartExprTokens in the
+  // reference parser.
+  if ((lexer->lookahead >= '0' && lexer->lookahead <= '9') ||
+      lexer->lookahead == '"' || lexer->lookahead == '\'' ||
+      lexer->lookahead == '(' || lexer->lookahead == '{' ||
+      lexer->lookahead == '-') {
+    return true;
+  }
+  if (lexer->lookahead != '\n' && lexer->lookahead != '\r') {
+    return false;
+  }
+  while (is_space(lexer->lookahead)) {
+    advance(lexer);
+  }
+  // Across a line break only a reserved word counts. A soft modifier there
+  // would be a name too, and `val b = inline` followed by such a line is a
+  // value rather than a modifier list.
+  static const char *const definition_starts[] = {
+      "def",     "val",       "var",    "type",     "given",    "class",
+      "object",  "trait",     "enum",   "final",    "lazy",     "override",
+      "private", "protected", "sealed", "abstract", "implicit"};
+  char word[sizeof "transparent"];
+  int len = read_word(lexer, word, (int)sizeof word);
+  return len > 0 &&
+         word_in(word, definition_starts,
+                 sizeof(definition_starts) / sizeof(definition_starts[0]));
 }
 
 // True when `class` or `object` follows `case`, marking a definition not a
@@ -1345,25 +1397,64 @@ static bool scan_impl(void *payload, TSLexer *lexer,
         (lexer->lookahead == 'c' && !valid_symbols[CATCH]) ||
         (lexer->lookahead == 'f' && !valid_symbols[FINALLY])
       );
-  // Character first: it rules out 98% of positions without the array load.
-  bool erased_arm = lexer->lookahead == 'e' && valid_symbols[ERASED_MODIFIER];
-  if (!valid_symbols[ERROR_SENTINEL] && (outdent_arm || erased_arm)) {
+  // These are names too, and an alternative for each in every name position
+  // cost the parse tables about 150KB per word. Lexing them here means the
+  // parser only sees one where a modifier can stand.
+  static const struct {
+    char first;
+    const char *word;
+    TSSymbol symbol;
+  } soft_modifiers[] = {
+    {'e', "erased", ERASED_MODIFIER},
+    {'o', "open", OPEN_MODIFIER},
+    {'o', "opaque", OPAQUE_MODIFIER},
+    {'i', "infix", INFIX_MODIFIER},
+    {'t', "tracked", TRACKED_MODIFIER},
+    {'t', "transparent", TRANSPARENT_MODIFIER},
+    {'i', "inline", INLINE_MODIFIER},
+    {'i', "into", INTO_MODIFIER},
+  };
+  const unsigned soft_modifier_count =
+      sizeof(soft_modifiers) / sizeof(soft_modifiers[0]);
+  // Character first: it rules out most positions without the array load.
+  bool modifier_arm = false;
+  for (unsigned i = 0; i < soft_modifier_count; i++) {
+    if (lexer->lookahead == soft_modifiers[i].first &&
+        valid_symbols[soft_modifiers[i].symbol]) {
+      modifier_arm = true;
+      break;
+    }
+  }
+  if (!valid_symbols[ERROR_SENTINEL] && (outdent_arm || modifier_arm)) {
     if (outdent_arm) {
       // OUTDENT is zero-width at the word, and the lexer cannot rewind once
       // read_word has consumed it.
       lexer->mark_end(lexer);
     }
     // Sized for the longest word above.
-    char word[sizeof "finally"];
+    char word[sizeof "transparent"];
     int len = read_word(lexer, word, (int)sizeof word);
     // read_word returns -1 when the word overflows the buffer, which would
     // otherwise leave a truncated prefix to compare against.
     if (len > 0) {
-      if (erased_arm && strcmp(word, "erased") == 0) {
+      TSSymbol modifier = 0;
+      for (unsigned i = 0; i < soft_modifier_count; i++) {
+        if (valid_symbols[soft_modifiers[i].symbol] &&
+            strcmp(word, soft_modifiers[i].word) == 0) {
+          modifier = soft_modifiers[i].symbol;
+          break;
+        }
+      }
+      if (modifier != 0) {
         // The modifier spans the word, unlike the zero-width OUTDENT.
         lexer->mark_end(lexer);
-        if (name_follows_word(lexer)) {
-          lexer->result_symbol = ERASED_MODIFIER;
+        // A name follows a modifier, so `def open(p)` and `a.infix` keep
+        // reading as plain identifiers.
+        bool follows = modifier == INLINE_MODIFIER
+                           ? inline_modifier_follows(lexer)
+                           : name_follows_word(lexer);
+        if (follows) {
+          lexer->result_symbol = modifier;
           return true;
         }
         return false;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -4580,3 +4580,46 @@ def a =
             (case_clause
               (identifier)
               (identifier))))))))
+
+================================================================================
+Inline modifier at the end of its line (Scala 3)
+================================================================================
+
+object O:
+  private[O] inline
+  def isolated[T](inline op: Boolean) = op
+
+  inline (a + b) match
+    case _ => 3
+
+--------------------------------------------------------------------------------
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (function_definition
+        (modifiers
+          (access_modifier
+            (access_qualifier
+              (identifier)))
+          (inline_modifier))
+        (identifier)
+        (type_parameters
+          (identifier))
+        (parameters
+          (parameter
+            (inline_modifier)
+            (identifier)
+            (type_identifier)))
+        (identifier))
+      (match_expression
+        (inline_modifier)
+        (parenthesized_expression
+          (infix_expression
+            (identifier)
+            (operator_identifier)
+            (identifier)))
+        (indented_cases
+          (case_clause
+            (wildcard)
+            (integer_literal)))))))


### PR DESCRIPTION
`open`, `opaque`, `infix`, `tracked`, `transparent`, `inline` and `into` are names as well as modifiers, so each one needed a soft-identifier alternative in every name position. The tables were paying about 150KB per word, and far more for `inline`, which also stands at the start of an expression and made the parser fork on every occurrence.

They join the scanner arm that already reads `erased`, which is now a table rather than a chain of comparisons. `inline` needs a follow test of its own, the way the reference parser uses canStartExprTokens. A name, a literal or an open bracket makes it the modifier. Across a line break only a reserved word counts, since a line starting with a soft modifier would otherwise capture a preceding bare `inline` that is really a value.

The soft identifier rule is left holding `extension` alone. The stale `end` alternative goes with the rest, since `end` has been scanner-lexed for a while and nothing matched it as a literal any more. Both queries asked for an `end` token that therefore never existed, so end markers were never highlighted. They ask for the marker node now.