### PR TITLE
chore: reserve the using directive start external token

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -362,6 +362,10 @@ module.exports = grammar({
     // one so the lexer falls back to the grammar definition.
     ...OP_LEFT.map(key => opLeft($, key)),
     $._op_name,
+    // The `>` of `//>`. A regex would have to swallow the `using` after it to
+    // see it, and highlighting needs that keyword as a token of its own, so
+    // the scanner looks ahead instead and declines the `>` of a plain comment.
+    $._using_directive_start,
   ],
 
   inline: $ => [


### PR DESCRIPTION
The `//>` comment fix needs a new external token. It arrives in its own change so that the fuzz job stays green. That job links the checked in parser.c with the scanner.c of the pull request, so a scanner that reads one more valid_symbols slot than the committed parser.c knows about would read past the end of the array.

The token is unreferenced, so the grammar and the parse trees are unchanged. Verified by parsing 30,252 files from 35 repositories with both parsers and comparing every tree.