### PR TITLE
fix: annotate a literal type and every annotation of an ascription

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1589,7 +1589,12 @@ module.exports = grammar({
 
     _annotated_type: $ => prec.right(choice($.annotated_type, $._simple_type)),
 
-    annotated_type: $ => prec.right(seq($._simple_type, repeat1($.annotation))),
+    // A literal type carries annotations too (`val x: "abc" @deprecated`), and
+    // it is not one of the simple types.
+    annotated_type: $ =>
+      prec.right(
+        seq(choice($._simple_type, $.literal_type), repeat1($.annotation)),
+      ),
 
     _simple_type: $ =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -2452,7 +2452,8 @@ module.exports = grammar({
                 repeat1(ascriptionArrowTail($)),
               ),
             ),
-            $.annotation,
+            // SLS 6.13: `Ascription ::= ':' Annotation {Annotation}`.
+            repeat1($.annotation),
           ),
         ),
       ),

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -136,3 +136,33 @@ object A:
           (identifier)
           (annotation (type_identifier))
           (annotation (type_identifier)))))))
+
+================================================================================
+Annotated literal type
+================================================================================
+
+object A:
+  val a: "abc" @deprecated = "abc"
+  val b: List[7 @Ann] = ???
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (annotated_type
+          (literal_type (string))
+          (annotation (type_identifier)))
+        (string))
+      (val_definition
+        (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (annotated_type
+              (literal_type (integer_literal))
+              (annotation (type_identifier)))))
+        (operator_identifier)))))

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -108,3 +108,31 @@ case class B2(s: String) extends Base @Second(3, "e") @Third(4)
         (annotation
           (type_identifier)
           (arguments (integer_literal)))))))
+
+================================================================================
+Ascription with several annotations
+================================================================================
+
+object A:
+  val a = (1: @unchecked @switch)
+  val b = c: @nowarn @unchecked
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (parenthesized_expression
+          (ascription_expression
+            (integer_literal)
+            (annotation (type_identifier))
+            (annotation (type_identifier)))))
+      (val_definition
+        (identifier)
+        (ascription_expression
+          (identifier)
+          (annotation (type_identifier))
+          (annotation (type_identifier)))))))


### PR DESCRIPTION
`ascription_expression` took a single annotation. SLS 6.13 reads
`Ascription ::= ':' Annotation {Annotation}`, so `(c: @switch @unchecked)`
failed to parse.

`annotated_type` wanted a simple type on its left, and a literal type is not
one of those, so `val x: "abc" @deprecated` failed as well.

