### PR TITLE
fix: end an indented argument at the comma before the next one

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -420,6 +420,50 @@ static bool consume_block_comment_body_on_line(TSLexer *lexer) {
   return consume_block_comment_body_ex(lexer, true);
 }
 
+// Whether the rest of the line closes a bracket that was already open. Such a
+// comma separates the arguments of a call, so it also ends any block that one
+// of them opened. A comma with more code after it and no closer continues the
+// statement it is in instead (`import a.b, c.d`, `extends A, B`, `case A, B`).
+static bool line_closes_bracket(TSLexer *lexer) {
+  int16_t depth = 0;
+  for (;;) {
+    if (lexer->eof(lexer) || lexer->lookahead == '\n' ||
+        lexer->lookahead == '\r') {
+      return false;
+    }
+    switch (lexer->lookahead) {
+      case '(':
+      case '[':
+      case '{':
+        depth++;
+        break;
+      case ')':
+      case ']':
+      case '}':
+        if (depth == 0) {
+          return true;
+        }
+        depth--;
+        break;
+      case '/':
+        advance(lexer);
+        if (lexer->lookahead == '/') {
+          return false;
+        }
+        if (lexer->lookahead == '*') {
+          advance(lexer);
+          if (!consume_block_comment_body_on_line(lexer)) {
+            return false;
+          }
+        }
+        continue;  // a lone '/' is code
+      default:
+        break;
+    }
+    advance(lexer);
+  }
+}
+
 static bool finish_block_comment(TSLexer *lexer) {
   lexer->mark_end(lexer);
   lexer->result_symbol = BLOCK_COMMENT;
@@ -1011,10 +1055,10 @@ static bool scan_impl(void *payload, TSLexer *lexer,
 
   // COMMA_OUTDENT is a distinct token so tree-sitter only makes it valid
   // where comma termination is expected (colon_argument,
-  // _indentable_expression). A comma terminates the indented block only when
-  // it ends its line. A comma with more code after it on the same line
-  // continues the statement and is internal to the block (`import a.b, c.d`,
-  // `extends A, B`, enum `case A, B`). A trailing comment still ends the line.
+  // _indentable_expression). A comma terminates the indented block when it
+  // ends its line, a trailing comment included, or when the rest of the line
+  // closes a bracket that was already open. Otherwise it is internal to the
+  // statement and leaves the block alone.
   if (valid_symbols[COMMA_OUTDENT] && lexer->lookahead == ',' && prev != -1) {
     lexer->mark_end(lexer);
     // Error recovery makes every symbol valid, so keep the eager pop there.
@@ -1042,7 +1086,7 @@ static bool scan_impl(void *payload, TSLexer *lexer,
         advance(lexer);
         consume_block_comment_body(lexer);
       }
-      if (!ends_line) {
+      if (!ends_line && !line_closes_bracket(lexer)) {
         return false;
       }
     }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3514,6 +3514,67 @@ def transformType =
           (identifier))))))
 
 ================================================================================
+Comma-separated imports in an indented body
+================================================================================
+
+final class A:
+  import B.*, C.*
+  def f = 1
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (modifiers)
+    (identifier)
+    (template_body
+      (import_declaration
+        (identifier)
+        (namespace_wildcard)
+        (identifier)
+        (namespace_wildcard))
+      (function_definition
+        (identifier)
+        (integer_literal)))))
+
+================================================================================
+Indented argument block closed by the comma before the next argument
+================================================================================
+
+def f(xs: List[Int]) =
+  assert(
+    if xs.isEmpty then
+      true
+    else
+      false, "fail")
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier)))))
+    (indented_block
+      (call_expression
+        (identifier)
+        (arguments
+          (if_expression
+            (field_expression
+              (identifier)
+              (identifier))
+            (indented_block
+              (boolean_literal))
+            (indented_block
+              (boolean_literal)))
+          (string))))))
+
+================================================================================
 Backquoted then on a leading infix continuation line
 ================================================================================
 


### PR DESCRIPTION
A comma only ended an indented block when it ended its line, so an argument written as an indented block failed to parse when the next argument followed on the same line. The comma now also ends the block when the rest of the line closes a bracket that was already open. `import a.b, c.d` and `extends A, B` reach no such closer and keep the old reading.

Seen in https://github.com/slick/slick/blob/a9756aa9e12730a1e8660a6f39bba53c3c58d302/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala#L237
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/pos/indent-in-parens.scala#L30