### PR TITLE
fix: take the type arguments of an extractor pattern

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1890,9 +1890,12 @@ module.exports = grammar({
         $.xml_pattern,
       ),
 
+    // The type arguments are the ones an extractor takes explicitly
+    // (`case Foo[Int](x)`), which SLS 8.1.8 admits before the patterns.
     case_class_pattern: $ =>
       seq(
         field("type", choice($._type_identifier, $.stable_type_identifier)),
+        optional(field("type_arguments", $.type_arguments)),
         "(",
         choice(
           field("pattern", trailingCommaSep($._pattern)),

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -484,3 +484,37 @@ val x = y match {
               (type_identifier)
               (unit)))
           (identifier))))))
+
+================================================================================
+Case class pattern with explicit type arguments
+================================================================================
+
+val x = a match {
+  case Foo[Int](y) => y
+  case Typeable.instanceOf[T](y) => y
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (match_expression
+      (identifier)
+      (case_block
+        (case_clause
+          (case_class_pattern
+            (type_identifier)
+            (type_arguments
+              (type_identifier))
+            (identifier))
+          (identifier))
+        (case_clause
+          (case_class_pattern
+            (stable_type_identifier
+              (identifier)
+              (type_identifier))
+            (type_arguments
+              (type_identifier))
+            (identifier))
+          (identifier))))))


### PR DESCRIPTION
Type arguments are allowed between the extractor and its patterns, so `case Foo[Int](x)` is a pattern.

Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/run/unapply-tparam.scala#L26 
Seen in https://github.com/scala/scala3/blob/a036a3a74024d97cc70b8d51f2612c05ec7ff881/tests/run/Typeable.scala#L45