### PR TITLE
ci: bump the smoke test to the latest releases of Scala 2 and Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: scala/scala
-          ref: v2.13.14
+          ref: v2.13.18
           path: scala_scala
 
       - name: checkout scala/scala3
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: scala/scala3
-          ref: 3.5.2
+          ref: 3.8.4
           path: dotty
 
       - name: checkout lichess-org/lila


### PR DESCRIPTION
The pinned Scala 3 is old enough that its test suite still carries syntax the compiler has since rejected, e.g. nameless erased function parameter `(erased Int) => Int`, so the smoke test was reporting gaps that no longer exist.