### PR TITLE
fix: take an nameless erased parameter

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1416,7 +1416,9 @@ module.exports = grammar({
               "using",
               choice(
                 trailingCommaSep1($.class_parameter),
-                trailingCommaSep1($._param_type),
+                // `erased` sits once after `using`. The named parameters carry
+                // their own, so only the unnamed types take it here.
+                seq(optional(erasedMod($)), trailingCommaSep1($._param_type)),
               ),
             ),
             seq(optional("implicit"), trailingCommaSep($.class_parameter)),
@@ -1449,7 +1451,7 @@ module.exports = grammar({
         "using",
         choice(
           trailingCommaSep1($.parameter),
-          trailingCommaSep1($._param_type),
+          seq(optional(erasedMod($)), trailingCommaSep1($._param_type)),
         ),
         ")",
       ),
@@ -1826,7 +1828,18 @@ module.exports = grammar({
         $._annotated_type,
         $.capturing_type,
         // Prioritize a parenthesized param list over a single tuple_type.
-        prec.dynamic(1, seq("(", trailingCommaSep($._param_type), ")")),
+        // The reference parser reads `erased` once, right after the paren, and
+        // it applies to a parameter that has no name. Keeping it out of the
+        // comma repeat leaves the tuple reading of the same parens alone.
+        prec.dynamic(
+          1,
+          seq(
+            "(",
+            optional(erasedMod($)),
+            trailingCommaSep($._param_type),
+            ")",
+          ),
+        ),
         $.compound_type,
         $.infix_type,
       ),

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -3004,6 +3004,47 @@ def f4(x: Int, erased inline: Int) = 0
     (integer_literal)))
 
 ================================================================================
+Erased parameter with no name (Scala 3)
+================================================================================
+
+def f(g: (erased Int) => Int) = 1
+
+type T = (erased C[E]) ?=> R
+
+def h(using erased Int) = 0
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (function_type
+          (parameter_types
+            (erased_modifier)
+            (type_identifier))
+          (type_identifier))))
+    (integer_literal))
+  (type_definition
+    (type_identifier)
+    (function_type
+      (parameter_types
+        (erased_modifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier))))
+      (type_identifier)))
+  (function_definition
+    (identifier)
+    (parameters
+      (erased_modifier)
+      (type_identifier))
+    (integer_literal)))
+
+================================================================================
 Uses clause (Scala 3 capture checking)
 ================================================================================
 


### PR DESCRIPTION
The reference parser reads `erased` once, right after the paren of a function type or of a using clause, and it applies to a parameter written as a bare type. Only the named spelling was accepted, so `(erased Int) => Int` and `(using erased Int)` failed to parse.

Keeping the modifier out of the comma repeat matters. Inside it the tuple reading of the same parens loses its GLR version and a match type written as a tuple element stops parsing.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/i6009a.scala#L4 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/CanThrow.scala#L6 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/erased-soft-keyword.scala#L14