### PR TITLE
fix: take the reach capability in a capture set

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1685,6 +1685,10 @@ module.exports = grammar({
     capture_ref: $ =>
       seq(
         choice($._identifier, $.stable_identifier, "cap"),
+        // The reach capability `xs*`, which stands for what the elements of
+        // `xs` capture. It comes before the narrowing suffixes. Right before
+        // the closing brace the star arrives as the external token instead.
+        optional(choice($._asterisk, $._postfix_star)),
         repeat(
           seq(
             ".",

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -547,6 +547,55 @@ def h(x: ->{any} I) = x
     (identifier)))
 
 ================================================================================
+Reach capability in a capture set (Scala 3 capture checking)
+================================================================================
+
+def add(fut: Future[T]^{futs*}) = ???
+
+type F = () ->{c.procs*} Unit
+
+type G = List[() ->{xs*} Unit]
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (capturing_type
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier)))
+          (capture_set
+            (capture_ref
+              (identifier))))))
+    (operator_identifier))
+  (type_definition
+    (type_identifier)
+    (function_type
+      (parameter_types)
+      (capture_set
+        (capture_ref
+          (stable_identifier
+            (identifier)
+            (identifier))))
+      (type_identifier)))
+  (type_definition
+    (type_identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (function_type
+          (parameter_types)
+          (capture_set
+            (capture_ref
+              (identifier)))
+          (type_identifier))))))
+
+================================================================================
 Compound types
 ================================================================================
 


### PR DESCRIPTION
A capture set member may carry a `*`, which stands for what the elements of that capability capture. The star arrives as two different tokens. Right before the closing brace it is the external one that the postfix reading uses, so `->{xs*}` needs that spelling while `->{x, xs*}` and `^{futs*}` get the shared string token.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos-custom-args/captures/reaches.scala#L31
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos-custom-args/captures/path-use.scala#L16
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos-custom-args/captures/boxed-use.scala#L4