### PR TITLE
fix: close seven indentation and Scala 2 gaps

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -211,6 +211,11 @@ const XML_NAME = /[_\p{L}][-.:_\p{L}\p{Nd}]*/;
 // such a colon must handle it.
 const colonEol = $ => choice(":", alias($._colon_eol, ":"));
 
+// Inside a case clause body the parser cannot tell this `case` from the one
+// that opens the next clause. The scanner reads past the word and can.
+const caseKeyword = $ =>
+  choice("case", alias($._case_definition_keyword, "case"));
+
 const ascriptionArrowTail = $ =>
   seq(anyArrow(), field("return_type", $._param_type));
 
@@ -669,7 +674,15 @@ module.exports = grammar({
             $._outdent,
           ),
         ),
-        seq("{", optional($.self_type), optional($._enum_block), "}"),
+        // Unlike _definition_body this needs no dynamic weight, since the
+        // enum body is not optional and so ties with nothing.
+        seq(
+          optional($._automatic_semicolon),
+          "{",
+          optional($.self_type),
+          optional($._enum_block),
+          "}",
+        ),
       ),
 
     enum_case_definitions: $ =>
@@ -804,7 +817,7 @@ module.exports = grammar({
       seq(
         repeat($.annotation),
         optional($.modifiers),
-        optional("case"),
+        optional(caseKeyword($)),
         "object",
         $._object_definition,
       ),
@@ -826,7 +839,7 @@ module.exports = grammar({
       seq(
         repeat($.annotation),
         optional($.modifiers),
-        optional("case"),
+        optional(caseKeyword($)),
         "class",
         $._class_definition,
       ),
@@ -1163,7 +1176,6 @@ module.exports = grammar({
           optional($.modifiers),
           "def",
           $._function_constructor,
-          optional(seq(":", field("return_type", $._type))),
         ),
       ),
 
@@ -1176,12 +1188,17 @@ module.exports = grammar({
             "parameters",
             repeat(
               seq(
-                optional($._automatic_semicolon),
+                optional($._def_semicolon),
                 choice($.parameters, $.type_parameters),
               ),
             ),
           ),
-          optional($._automatic_semicolon),
+          // The return type lives here rather than in _function_declaration so
+          // that no reduction separates it from the clauses. Across a reduce
+          // the parser cannot see which of the two a break precedes.
+          optional(
+            seq(optional($._def_semicolon), ":", field("return_type", $._type)),
+          ),
         ),
       ),
 
@@ -2595,7 +2612,9 @@ module.exports = grammar({
         ")",
       ),
 
-    parenthesized_expression: $ => seq("(", $.expression, ")"),
+    // The reference compiler drops the trailing comma, so the parens keep
+    // holding the value rather than turning into a tuple.
+    parenthesized_expression: $ => seq("(", $.expression, optional(","), ")"),
 
     // NamedTypeArg ::= id '=' Type. Scala 3 takes named type arguments the
     // way it takes named term arguments.
@@ -3108,10 +3127,13 @@ module.exports = grammar({
 
     unit: $ => prec(PREC.unit, seq("(", ")")),
 
+    // Not _indentable_expression like throw below. The value is optional, and
+    // an empty indent stack counts any width as deeper, so a bare `return`
+    // would swallow the next definition.
     return_expression: $ =>
       prec.left(seq("return", optional(statementExpression($)))),
 
-    throw_expression: $ => prec.left(seq("throw", $.expression)),
+    throw_expression: $ => prec.left(seq("throw", $._indentable_expression)),
 
     /*
      *   Expr1             ::=  'while' '(' Expr ')' {nl} Expr
@@ -3130,7 +3152,9 @@ module.exports = grammar({
               // The do-form branch makes the scanner emit a semicolon
               // here.
               optional($._automatic_semicolon),
-              field("body", $.expression),
+              // Matches the paren form of `if`, which already wraps an
+              // indented body in an indented_block.
+              field("body", $._indentable_expression),
             ),
           ),
           seq(
@@ -3161,7 +3185,9 @@ module.exports = grammar({
           "do",
           field("body", $.expression),
           "while",
-          field("condition", $.parenthesized_expression),
+          // Scala 2 wants parens here. Taking any expression, the way the
+          // migration mode does, would collide with `while cond do body`.
+          field("condition", choice($.parenthesized_expression, $.block)),
         ),
       ),
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -69,7 +69,9 @@ enum TokenType {
   OP_LEFT_MUL,
   OP_LEFT_OTHER,
   OP_NAME,
-  USING_DIRECTIVE_START
+  USING_DIRECTIVE_START,
+  CASE_DEFINITION_KEYWORD,
+  DEF_SEMICOLON
 };
 
 // Mirrors enum TokenType above.
@@ -125,7 +127,9 @@ const char* token_name[] = {
   "OP_LEFT_MUL",
   "OP_LEFT_OTHER",
   "OP_NAME",
-  "USING_DIRECTIVE_START"
+  "USING_DIRECTIVE_START",
+  "CASE_DEFINITION_KEYWORD",
+  "DEF_SEMICOLON"
 };
 
 typedef struct {
@@ -1039,10 +1043,11 @@ static bool scan_impl(void *payload, TSLexer *lexer,
         advance(lexer);
         consume_block_comment_body(lexer);
       }
-      // A comma that ends its line closes the block. So does one whose line
-      // goes on to close an enclosing bracket, since that comma separates
-      // arguments. `import a.b, c.d` and `extends A, B` reach no such closer.
-      if (!ends_line && !scan_rest_of_line(lexer).closes_bracket) {
+      // POSTFIX_OP is offered only where an operand just ended, so the comma
+      // separates arguments rather than continuing a list of names. The closer
+      // catches what is left, where no operand ended before the comma.
+      if (!ends_line && !valid_symbols[POSTFIX_OP] &&
+          !scan_rest_of_line(lexer).closes_bracket) {
         return false;
       }
     }
@@ -1304,6 +1309,18 @@ static bool scan_impl(void *payload, TSLexer *lexer,
     return false;
   }
 
+  // Runs before the plain semicolon below, so the header break wins where the
+  // parser offers it.
+  if (valid_symbols[DEF_SEMICOLON] && !valid_symbols[ERROR_SENTINEL] &&
+      newline_count > 0 &&
+      (lexer->lookahead == '(' || lexer->lookahead == '[' ||
+       lexer->lookahead == ':')) {
+    lexer->mark_end(lexer);
+    lexer->result_symbol = DEF_SEMICOLON;
+    LOG("    DEF_SEMICOLON\n");
+    return true;
+  }
+
   if (valid_symbols[AUTOMATIC_SEMICOLON] && newline_count > 0) {
     // AUTOMATIC_SEMICOLON should not be issued in the middle of expressions
     // Thus, we exit this branch when encountering comments, else/catch clauses, etc.
@@ -1531,7 +1548,12 @@ static bool scan_impl(void *payload, TSLexer *lexer,
       break;
     }
   }
-  if (!valid_symbols[ERROR_SENTINEL] && (outdent_arm || modifier_arm)) {
+  // The reader below cannot rewind, so `case` compares there rather than
+  // scanning on its own and eating the start of another word.
+  bool case_definition_arm =
+      valid_symbols[CASE_DEFINITION_KEYWORD] && lexer->lookahead == 'c';
+  if (!valid_symbols[ERROR_SENTINEL] &&
+      (outdent_arm || modifier_arm || case_definition_arm)) {
     if (outdent_arm) {
       // OUTDENT is zero-width at the word, and the lexer cannot rewind once
       // read_word has consumed it.
@@ -1543,6 +1565,15 @@ static bool scan_impl(void *payload, TSLexer *lexer,
     // read_word returns -1 when the word overflows the buffer, which would
     // otherwise leave a truncated prefix to compare against.
     if (len > 0) {
+      if (case_definition_arm && strcmp(word, "case") == 0) {
+        lexer->mark_end(lexer);
+        if (is_case_definition_word(lexer)) {
+          lexer->result_symbol = CASE_DEFINITION_KEYWORD;
+          LOG("    CASE_DEFINITION_KEYWORD\n");
+          return true;
+        }
+        return false;
+      }
       TSSymbol modifier = 0;
       for (unsigned i = 0; i < soft_modifier_count; i++) {
         if (valid_symbols[soft_modifiers[i].symbol] &&

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -2616,6 +2616,49 @@ enum SymbolKind derives CanEqual:
           (identifier))))))
 
 ================================================================================
+Enum body opening on the next line
+================================================================================
+
+enum Bomb
+{
+  case Kaboom
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (enum_definition
+    (identifier)
+    (enum_body
+      (enum_case_definitions
+        (simple_enum_case
+          (identifier))))))
+
+================================================================================
+Declarations with no result type, one after another (Scala 2)
+================================================================================
+
+trait Message {
+  def first(x: Int)
+  def second
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (trait_definition
+    (identifier)
+    (template_body
+      (function_declaration
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier))))
+      (function_declaration
+        (identifier)))))
+
+================================================================================
 Unicode arrow in for comprehension generators
 ================================================================================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -330,6 +330,129 @@ foo(o =>
             body: (identifier)))))))
 
 ================================================================================
+Trailing comma after the only element in parens
+================================================================================
+
+val g = (
+  23,
+  )
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (parenthesized_expression
+      (integer_literal))))
+
+================================================================================
+Thrown value as an indented block
+================================================================================
+
+def foo =
+  throw
+    val ex = E()
+    ex
+  x
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (throw_expression
+        (indented_block
+          (val_definition
+            (identifier)
+            (call_expression
+              (identifier)
+              (arguments)))
+          (identifier)))
+      (identifier))))
+
+================================================================================
+Comma closing an indented argument when the paren closes on a later line
+================================================================================
+
+def raise =
+  assert(
+    throw
+      null, "ok"
+  )
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (call_expression
+        (identifier)
+        (arguments
+          (throw_expression
+            (indented_block
+              (null_literal)))
+          (string))))))
+
+================================================================================
+Case class definition opening a case clause body
+================================================================================
+
+object T {
+  1 match {
+    case 1 =>
+      case class C()
+      case object D
+      Nil
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (match_expression
+        (integer_literal)
+        (case_block
+          (case_clause
+            (integer_literal)
+            (class_definition
+              (identifier)
+              (class_parameters))
+            (object_definition
+              (identifier))
+            (identifier)))))))
+
+================================================================================
+Do while with a braced condition (Scala 2)
+================================================================================
+
+class T {
+  do {
+    val x = 1
+  } while {
+    true
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (template_body
+      (do_while_expression
+        (block
+          (val_definition
+            (identifier)
+            (integer_literal)))
+        (block
+          (boolean_literal))))))
+
+================================================================================
 Leading infix operator at lower indent continues the expression across dedent
 ================================================================================
 
@@ -4510,9 +4633,37 @@ def g() = {
       (while_expression
         (parenthesized_expression
           (identifier))
-        (call_expression
-          (identifier)
-          (arguments))))))
+        (indented_block
+          (call_expression
+            (identifier)
+            (arguments)))))))
+
+================================================================================
+Parenthesized while with an indented body of several statements
+================================================================================
+
+def f =
+  while (false)
+    val x = 1
+    println(x)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (function_definition
+    (identifier)
+    (indented_block
+      (while_expression
+        (parenthesized_expression
+          (boolean_literal))
+        (indented_block
+          (val_definition
+            (identifier)
+            (integer_literal))
+          (call_expression
+            (identifier)
+            (arguments
+              (identifier))))))))
 
 ================================================================================
 Curried typed lambda in braces (Scala 3 syntax)


### PR DESCRIPTION
Each of these reads a construct that the reference parser accepts. The added tests show the shapes.

Three of them need more lookahead than the parser has. Each is answered by giving the scanner a way to see what the parser cannot.

A comma that ends an indented argument asks whether an operand just ended. Only then does it separate arguments and close the block. A list of names offers no operator there, so it is left alone. The closer on the rest of the line settles what remains, where no operand ended before the comma.

The `case` that opens a definition, and the line break Scala disables inside a def header, arrive as tokens of their own. The two readings then reach the parser as different tokens rather than as one it has to guess about.

Measured over dotty 3.8.4 and a corpus of 35 repositories. Failures drop from 60 to 48 and from 430 to 412, no file parses worse, and the parse tables lose 27 states.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/run/i6664/Bomb_1.scala#L2 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/indent4.scala#L8 Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/trailingCommas/trailingCommas.scala#L64 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/indent.scala#L96 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/i22527.scala#L51 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/i21749.scala#L6 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos-scala2/i871.scala#L3
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos-scala2/doWhile.scala#L5