### PR TITLE
fix: close two polymorphic type gaps

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -514,6 +514,8 @@ module.exports = grammar({
     // 'if'  parenthesized_expression  •  '{'  …
     [$._if_condition_paren, $._simple_expression],
     [$.block, $._braced_template_body1],
+    // type_parameters  '=>'  '{'  '}'  •  '['  …
+    [$.block, $.capture_set],
     // '{'  identifier  •  ':' starts the braced typed lambda, the block
     // lambda param, and a statement alike.
     [$._simple_expression, $._braced_typed_lambda],
@@ -1611,6 +1613,17 @@ module.exports = grammar({
         $._structural_type,
         $.type_lambda,
         $.existential_type,
+        alias($._wildcard_bounded_type, $.infix_type),
+      ),
+
+    // SimpleType ::= '?' TypeBounds. The scanner hands over the `?` only where
+    // a type lambda bounds it, so the lambda stays out of every other operand
+    // position, where it would cost the whole type sublanguage a second copy.
+    _wildcard_bounded_type: $ =>
+      seq(
+        field("left", alias($._wildcard_bound_start, $.type_identifier)),
+        field("operator", wordOrOpName($)),
+        field("right", $.type_lambda),
       ),
 
     // Scala 2 existential type (SLS §3.2.12): `P[T] forSome { type T }`
@@ -2079,19 +2092,28 @@ module.exports = grammar({
         1,
         prec.right(
           "lambda",
-          seq(
-            optional(
-              seq(field("type_parameters", $.type_parameters), fatArrow()),
+          choice(
+            seq(
+              optional(
+                seq(field("type_parameters", $.type_parameters), fatArrow()),
+              ),
+              field(
+                "parameters",
+                // No unparenthesized typed parameter here. It is only legal
+                // inside braces, and `OWrites: c => body` must stay a colon
+                // argument.
+                choice($.bindings, $.wildcard, $._single_lambda_param),
+              ),
+              anyArrow(),
+              $._indentable_expression,
             ),
-            field(
-              "parameters",
-              // No unparenthesized typed parameter here. It is only legal
-              // inside braces, and `OWrites: c => body` must stay a colon
-              // argument.
-              choice($.bindings, $.wildcard, $._single_lambda_param),
+            // Neither of these can open a binding list, so the branch above
+            // stays reachable without lookahead.
+            seq(
+              field("type_parameters", $.type_parameters),
+              fatArrow(),
+              choice($.parenthesized_expression, $.block),
             ),
-            anyArrow(),
-            $._indentable_expression,
           ),
         ),
       ),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -71,7 +71,8 @@ enum TokenType {
   OP_NAME,
   USING_DIRECTIVE_START,
   CASE_DEFINITION_KEYWORD,
-  DEF_SEMICOLON
+  DEF_SEMICOLON,
+  WILDCARD_BOUND_START
 };
 
 // Mirrors enum TokenType above.
@@ -129,7 +130,8 @@ const char* token_name[] = {
   "OP_NAME",
   "USING_DIRECTIVE_START",
   "CASE_DEFINITION_KEYWORD",
-  "DEF_SEMICOLON"
+  "DEF_SEMICOLON",
+  "WILDCARD_BOUND_START"
 };
 
 typedef struct {
@@ -993,6 +995,36 @@ static bool scan_impl(void *payload, TSLexer *lexer,
     }
     lexer->result_symbol = USING_DIRECTIVE_START;
     LOG("    USING_DIRECTIVE_START\n");
+    return true;
+  }
+
+  // The grammar takes this `?` only in front of a type lambda, so the bracket
+  // has to be here before the word is handed over. The blanks are skipped
+  // rather than advanced, which keeps them out of the token.
+  if (valid_symbols[WILDCARD_BOUND_START] && !valid_symbols[ERROR_SENTINEL]) {
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+      skip(lexer);
+    }
+  }
+  if (valid_symbols[WILDCARD_BOUND_START] && !valid_symbols[ERROR_SENTINEL] &&
+      lexer->lookahead == '?') {
+    advance(lexer);
+    lexer->mark_end(lexer);
+    advance_past_blanks(lexer);
+    if (lexer->lookahead != '<' && lexer->lookahead != '>') {
+      return false;
+    }
+    advance(lexer);
+    if (lexer->lookahead != ':') {
+      return false;
+    }
+    advance(lexer);
+    advance_past_blanks(lexer);
+    if (lexer->lookahead != '[') {
+      return false;
+    }
+    lexer->result_symbol = WILDCARD_BOUND_START;
+    LOG("    WILDCARD_BOUND_START\n");
     return true;
   }
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -4935,3 +4935,75 @@ class C {
     (template_body
       (null_literal)
       (operator_identifier))))
+
+================================================================================
+Polymorphic function with a parenthesized or braced body
+================================================================================
+
+object O {
+  val a: [T] => T => T = [T] => ((x: T) => x)
+  val b: [T] => T => T = [T] => { (x: T) => x }
+  val c: [T] => T => T = [T] => (x: T) => x
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (function_type
+          (type_parameters
+            (identifier))
+          (function_type
+            (parameter_types
+              (type_identifier))
+            (type_identifier)))
+        (lambda_expression
+          (type_parameters
+            (identifier))
+          (parenthesized_expression
+            (lambda_expression
+              (bindings
+                (binding
+                  (identifier)
+                  (type_identifier)))
+              (identifier)))))
+      (val_definition
+        (identifier)
+        (function_type
+          (type_parameters
+            (identifier))
+          (function_type
+            (parameter_types
+              (type_identifier))
+            (type_identifier)))
+        (lambda_expression
+          (type_parameters
+            (identifier))
+          (block
+            (lambda_expression
+              (bindings
+                (binding
+                  (identifier)
+                  (type_identifier)))
+              (identifier)))))
+      (val_definition
+        (identifier)
+        (function_type
+          (type_parameters
+            (identifier))
+          (function_type
+            (parameter_types
+              (type_identifier))
+            (type_identifier)))
+        (lambda_expression
+          (type_parameters
+            (identifier))
+          (bindings
+            (binding
+              (identifier)
+              (type_identifier)))
+          (identifier))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1081,6 +1081,62 @@ class A[
         (type_identifier)))))
 
 ================================================================================
+Wildcard bounded by a type lambda (Scala 3)
+================================================================================
+
+type W = Map[?, ? <: [X, Y] =>> Map[X, Y], ?]
+type V = Map[? >: [X] =>> List[X]]
+type U = Map[? <: List[Int]]
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (type_definition
+    (type_identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_lambda
+            (identifier)
+            (identifier)
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier)
+                (type_identifier)))))
+        (type_identifier))))
+  (type_definition
+    (type_identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (type_lambda
+            (identifier)
+            (generic_type
+              (type_identifier)
+              (type_arguments
+                (type_identifier))))))))
+  (type_definition
+    (type_identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (infix_type
+          (type_identifier)
+          (operator_identifier)
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_identifier))))))))
+
+================================================================================
 Union and Intersection Types (Scala 3)
 ================================================================================
 


### PR DESCRIPTION
1. A polymorphic function body that is not a parameter clause did not parse. `[T] => ((x: T) => x)` and `[T] => { (x: T) => x }` both ended in an error node.
    - The reference grammar takes any expression after the type parameters, so a branch for the parenthesized and braced bodies is added. The braced one ties with a capture set and takes a conflict.
2. A wildcard bounded by a type lambda did not parse.
    - `? <: [X, Y] =>> Map[X, Y]` reaches the parser as an infix type, whose operand admits no type lambda. Admitting one in every operand position doubles the type sublanguage, so the scanner marks the `?` of a bounded wildcard instead and the lambda is reached only from that token. The tree keeps the infix type shape.

Measured over dotty 3.8.4 and a corpus of 52,236 files. Failures drop from 48 to 46. Five trees change, which are the two fixed files in both checkouts of the reference tests and one more that still fails and now recovers over a shorter region.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/run/polymorphic-functions.scala#L106
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/run/enum-values.scala#L87