### PR TITLE
fix: read a constructor annotation the way Dotty does

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -514,6 +514,10 @@ module.exports = grammar({
     // 'if'  parenthesized_expression  •  '{'  …
     [$._if_condition_paren, $._simple_expression],
     [$.block, $._braced_template_body1],
+    // 'class'  identifier  '@'  _type_identifier  •  '('  …
+    [$._constructor_annotation],
+    [$._constructor_annotation_arguments, $.arguments],
+    [$._constructor_annotation, $.applied_constructor_type],
     // type_parameters  '=>'  '{'  '}'  •  '['  …
     [$.block, $.capture_set],
     // '{'  identifier  •  ':' starts the braced typed lambda, the block
@@ -874,7 +878,7 @@ module.exports = grammar({
       seq(
         field("name", $._identifier),
         field("type_parameters", optional($.type_parameters)),
-        optional(alias($._constructor_annotation, $.annotation)),
+        repeat(alias($._constructor_annotation, $.annotation)),
         optional($.access_modifier),
         field(
           "class_parameters",
@@ -1073,28 +1077,34 @@ module.exports = grammar({
         ),
       ),
 
-    // Only allows 0 or 1 argument lists as these annotations
-    // usually come from Java, where multiple argument lists are not allowed
     _constructor_annotation: $ =>
-      prec(
-        "annotation",
-        seq(
-          "@",
-          field("name", $._simple_type),
-          optional(
-            alias(
-              seq(
-                // token.immediate here carries an assumption that there are no spaces between
-                // an annotation name and its argument list, otherwise this list should be
-                // classified as a class constructor list
-                token.immediate("("),
-                optional($._exprs_in_parens),
-                ")",
-              ),
-              $.arguments,
-            ),
+      seq(
+        "@",
+        // Not _simple_type. The applied constructor type would take the
+        // parenthesis into the name, and the class parameters already compete
+        // for it.
+        field(
+          "name",
+          choice(
+            $.generic_type,
+            $.projected_type,
+            $.stable_type_identifier,
+            $._type_identifier,
           ),
         ),
+        field(
+          "arguments",
+          repeat(alias($._constructor_annotation_arguments, $.arguments)),
+        ),
+      ),
+
+    // The same parenthesis may open the class parameters. An empty list is an
+    // argument list, and anything the parameters can hold is theirs, which is
+    // how the reference parser reads it.
+    _constructor_annotation_arguments: $ =>
+      choice(
+        prec.dynamic(1, seq("(", ")")),
+        prec.dynamic(-1, seq("(", $._exprs_in_parens, ")")),
       ),
 
     val_definition: $ =>

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -189,6 +189,53 @@ val val = ???
 --------------------------------------------------------------------------------
 
 ================================================================================
+Constructor annotation before the class parameters
+================================================================================
+
+class Baz @deprecated(implicit c: C)
+class Bam @ann(obj)(obj, "h")(n: String)
+class Bar @publicInBinary(@publicInBinary private[Bar] val x: Int)
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_definition
+    (identifier)
+    (annotation
+      (type_identifier))
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier))))
+  (class_definition
+    (identifier)
+    (annotation
+      (type_identifier)
+      (arguments
+        (identifier))
+      (arguments
+        (identifier)
+        (string)))
+    (class_parameters
+      (class_parameter
+        (identifier)
+        (type_identifier))))
+  (class_definition
+    (identifier)
+    (annotation
+      (type_identifier))
+    (class_parameters
+      (class_parameter
+        (annotation
+          (type_identifier))
+        (modifiers
+          (access_modifier
+            (access_qualifier
+              (identifier))))
+        (identifier)
+        (type_identifier)))))
+
+================================================================================
 Package
 ================================================================================
 
@@ -821,7 +868,6 @@ class A @ann ()(x: Int, y: Int)
     (identifier)
     (annotation
       (type_identifier)
-      (arguments)
       (arguments))
     (class_parameters
       (class_parameter
@@ -834,7 +880,6 @@ class A @ann ()(x: Int, y: Int)
     (identifier)
     (annotation
       (type_identifier)
-      (arguments)
       (arguments))
     (class_parameters
       (class_parameter
@@ -846,8 +891,8 @@ class A @ann ()(x: Int, y: Int)
   (class_definition
     (identifier)
     (annotation
-      (type_identifier))
-    (class_parameters)
+      (type_identifier)
+      (arguments))
     (class_parameters
       (class_parameter
         (identifier)
@@ -897,10 +942,8 @@ class A @ann(1) (x: Int, y: Int)
     (identifier)
     (annotation
       (type_identifier)
-      (arguments)
       (arguments
-        (integer_literal))
-      (arguments))
+        (integer_literal)))
     (class_parameters
       (class_parameter
         (identifier)


### PR DESCRIPTION
`class Baz @deprecated(implicit c: C)` and
`class Bar @publicInBinary(@publicInBinary private[Bar] val x: Int)` ended in an error node, and `class Bam @ann(obj)(obj, "h")(n: String)` did too because only one argument list was allowed.

The parenthesis after a constructor annotation opens either an argument list or the class parameters. Whitespace used to decide, which is not what the reference parser does. It reads an empty list as an argument list and hands the parenthesis to the parameters as soon as they could hold what is inside, and the two weights say the same thing.

The name drops the applied constructor type, which was taking the parenthesis into the name and splitting an empty argument list into two nodes. That is why some files in the corpus report a different tree. Failures drop from 46 to 44 in dotty 3.8.4

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/i2426.scala#L5 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/run/publicInBinary/Lib_1.scala#L125