### PR TITLE
fix: take `implicit` in front of a parenthesized lambda parameter list

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2092,8 +2092,11 @@ module.exports = grammar({
     method_value: $ =>
       prec.left(PREC.call, seq($._simple_expression, $.wildcard)),
 
+    // The parenthesized list rides along so that `implicit` is read in the
+    // state that already expects it. Scala 2 spelled a context function this
+    // way, and the reference parser still reads it.
     _single_lambda_param: $ =>
-      prec.right(seq(optional("implicit"), operandName($))),
+      prec.right(seq(optional("implicit"), choice(operandName($), $.bindings))),
 
     // Keeps a braced `{ x: T => ... }` a lambda instead of a fewer-braces colon
     // argument on `x`.
@@ -2112,7 +2115,7 @@ module.exports = grammar({
                 // No unparenthesized typed parameter here. It is only legal
                 // inside braces, and `OWrites: c => body` must stay a colon
                 // argument.
-                choice($.bindings, $.wildcard, $._single_lambda_param),
+                choice($.wildcard, $._single_lambda_param),
               ),
               anyArrow(),
               $._indentable_expression,
@@ -2141,10 +2144,7 @@ module.exports = grammar({
         "lambda",
         choice(
           seq(
-            field(
-              "parameters",
-              choice($.bindings, $.wildcard, $._single_lambda_param),
-            ),
+            field("parameters", choice($.wildcard, $._single_lambda_param)),
             anyArrow(),
             optional(
               choice(
@@ -2166,10 +2166,7 @@ module.exports = grammar({
       prec.right(
         "lambda",
         seq(
-          field(
-            "parameters",
-            choice($.bindings, $.wildcard, $._single_lambda_param),
-          ),
+          field("parameters", choice($.wildcard, $._single_lambda_param)),
           anyArrow(),
           optional($._block),
         ),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -5007,3 +5007,56 @@ object O {
               (identifier)
               (type_identifier)))
           (identifier))))))
+
+================================================================================
+Implicit lambda parameters (Scala 2)
+================================================================================
+
+object O {
+  val a = { implicit (x: Int) => x + x }
+  val b = implicit (x: Int, y: Int) => x + y
+  val c = { implicit x: Int => x + x }
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (object_definition
+    (identifier)
+    (template_body
+      (val_definition
+        (identifier)
+        (block
+          (lambda_expression
+            (bindings
+              (binding
+                (identifier)
+                (type_identifier)))
+            (infix_expression
+              (identifier)
+              (operator_identifier)
+              (identifier)))))
+      (val_definition
+        (identifier)
+        (lambda_expression
+          (bindings
+            (binding
+              (identifier)
+              (type_identifier))
+            (binding
+              (identifier)
+              (type_identifier)))
+          (infix_expression
+            (identifier)
+            (operator_identifier)
+            (identifier))))
+      (val_definition
+        (identifier)
+        (block
+          (lambda_expression
+            (identifier)
+            (type_identifier)
+            (infix_expression
+              (identifier)
+              (operator_identifier)
+              (identifier))))))))


### PR DESCRIPTION
`{ implicit (x: Int) => x + x }` ended in an error node. The keyword was only read in front of a single unparenthesized parameter.

The parenthesized list moves next to that parameter rather than staying its own branch, so the keyword is read in the state that already expects it. The other spelling costs the parse tables a second copy of the lambda head.

Scala 2 wrote a context function this way. The reference parser still reads it and reports a migration warning.

Failures drop from 44 to 42 in dotty 3.8.4, and from 907 to 901 in my local corpus of 52,236 files.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/t3672.scala#L2 
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/warn/i9266.scala#L5