### PR TITLE
fix: read a self type and a chained body in a given

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1014,7 +1014,7 @@ module.exports = grammar({
           PREC.control,
           seq($._indent, optional($.self_type), $._block, $._outdent),
         ),
-        seq("{", optional($._block), "}"),
+        seq("{", optional($._braced_template_body1), "}"),
       ),
 
     _extension_template_body: $ =>
@@ -1331,9 +1331,9 @@ module.exports = grammar({
             choice(colonEol($), "with"),
             field("body", $.with_template_body),
           ),
-          // Several constructors and no body. The separator is `with` or a
-          // comma. A refinement is a constructor everywhere else, but a brace
-          // here is always the body, so the extras leave it out.
+          // Several constructors. The separator is `with` or a comma. A
+          // refinement is a constructor everywhere else, but a brace here is
+          // always the body, so the extras leave it out.
           seq(
             $._constructor_application,
             repeat1(
@@ -1342,6 +1342,7 @@ module.exports = grammar({
                 field("extra", $._constructor_application_extra),
               ),
             ),
+            optional(seq("with", field("body", $.with_template_body))),
           ),
         ),
       ),

--- a/test/corpus/definitions.txt
+++ b/test/corpus/definitions.txt
@@ -1918,6 +1918,111 @@ object A:
         body: (identifier)))))
 
 ================================================================================
+Self type in a braced given body
+================================================================================
+
+given a: Show[Int] with { self =>
+  def show(x: Int) = ""
+}
+
+given b[T]: Show[T] with { self: Show[T] =>
+  def show(x: T) = ""
+}
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (given_definition
+    (identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (with_template_body
+      (self_type
+        (identifier))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (string))))
+  (given_definition
+    (identifier)
+    (type_parameters
+      (identifier))
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (with_template_body
+      (self_type
+        (identifier)
+        (generic_type
+          (type_identifier)
+          (type_arguments
+            (type_identifier))))
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (string)))))
+
+================================================================================
+Given body after several constructors
+================================================================================
+
+given g: Show[Int] with Read[Int] with {
+  def show(x: Int) = ""
+}
+
+given h: Show[Int] with Read[Int] with
+  def show(x: Int) = ""
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (given_definition
+    (identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (with_template_body
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (string))))
+  (given_definition
+    (identifier)
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (generic_type
+      (type_identifier)
+      (type_arguments
+        (type_identifier)))
+    (with_template_body
+      (function_definition
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type_identifier)))
+        (string)))))
+
+================================================================================
 Class with using type-only parameters (Scala 3 syntax)
 ================================================================================
 


### PR DESCRIPTION
- Supersedes https://github.com/tree-sitter/tree-sitter-scala/pull/403

----

`given a: Show[Int] with { self => ... }` read `self` as a lambda parameter, and the typed spelling `{ self: Show[T] => ... }` ended in an error node. The braced branch of the with body was a bare block while the indented branch already took a self type. It now shares the rule the other braced template bodies use, so one state reads the self type in both places.

`given g: Show[Int] with Read[Int] with { ... }` read the brace as a refinement on a missing type, and the indented spelling ended in an error node. The alternative that takes more than one constructor had no body at all. It now ends with an optional body, which is the last clause of the production in the reference grammar.

Couldn't find any real example, so I compiled the codes with scalac 3.8.4 to confirm they are accepted.
<img width="623" height="584" alt="image" src="https://github.com/user-attachments/assets/19480263-3bd1-4e2f-81a7-2f25128f948f" />

The trees of all 52,236 files in my local corpus are unchanged.