### PR TITLE
fix: read a lone asterisk as a type operator

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1783,7 +1783,13 @@ module.exports = grammar({
         seq(
           // SimpleType1 admits a bare Refinement: `A & { type X = Int }`.
           field("left", choice($._infix_type_choice, $._structural_type)),
-          field("operator", wordOrOpName($)),
+          // A repeated parameter makes the shared `*` token valid after a type,
+          // and it then wins over the operator regex, so the infix reading has
+          // to admit it too (see _asterisk).
+          field(
+            "operator",
+            choice(wordOrOpName($), alias($._asterisk, $.operator_identifier)),
+          ),
           field("right", choice($._infix_type_choice, $._structural_type)),
         ),
       ),

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -1619,3 +1619,72 @@ def f[K](k: K): K ->> V = ???
       (operator_identifier)
       (type_identifier))
     (operator_identifier)))
+
+================================================================================
+An infix type whose operator is a lone asterisk
+================================================================================
+
+val t: (2 * 7 + 1) % 10 = 5
+
+def f(a: Int, b: Int)(using ev: (a.type * b.type) =:= (b.type * a.type)) = true
+
+def g(x: Int*) = x
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (val_definition
+    (identifier)
+    (infix_type
+      (tuple_type
+        (infix_type
+          (infix_type
+            (literal_type
+              (integer_literal))
+            (operator_identifier)
+            (literal_type
+              (integer_literal)))
+          (operator_identifier)
+          (literal_type
+            (integer_literal))))
+      (operator_identifier)
+      (literal_type
+        (integer_literal)))
+    (integer_literal))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (type_identifier))
+      (parameter
+        (identifier)
+        (type_identifier)))
+    (parameters
+      (parameter
+        (identifier)
+        (infix_type
+          (tuple_type
+            (infix_type
+              (singleton_type
+                (identifier))
+              (operator_identifier)
+              (singleton_type
+                (identifier))))
+          (operator_identifier)
+          (tuple_type
+            (infix_type
+              (singleton_type
+                (identifier))
+              (operator_identifier)
+              (singleton_type
+                (identifier)))))))
+    (boolean_literal))
+  (function_definition
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (repeated_parameter_type
+          (type_identifier))))
+    (identifier)))


### PR DESCRIPTION
`val t: (2 * 7 + 1) % 10 = 5` and `(a.type * b.type) =:= (b.type * a.type)`, which are _compile-time operations_, ended in an error node. A repeated parameter makes the shared `*` token valid after a type, and that string token beats the operator regex, so inside parentheses the `*` was always taken as the repeat marker.

The infix type now admits the same token as its operator, the way the infix expression already does. The two readings fork and the one that cannot go on dies, so a `*` before a closing paren stays a repeated parameter and a `*` with an operand after it is the operator. The reference parser splits the same way, by looking at the token that follows the `*`.

Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/singleton-ops-composition.scala#L6
Seen in https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/tests/pos/7512.scala#L8